### PR TITLE
Fix binary name in build script

### DIFF
--- a/hack/build-darwin-amd64.sh
+++ b/hack/build-darwin-amd64.sh
@@ -29,7 +29,7 @@ if [[ -z "${LD_FLAGS}" ]]; then
 fi
 ###############################################################################
 
-out_file="${BINARY_PATH}"/darwin-amd64/garden-login_darwin_amd64
+out_file="${BINARY_PATH}"/darwin-amd64/gardenctl_v2_darwin-amd64
 
 echo "building for darwin-amd64: ${out_file}"
 CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 GO111MODULE=on go build \


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix binary name in `hack/build-darwin-amd64.sh` build script

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
