### PR TITLE
Use DynamicTargetProvider to complete options

### DIFF
--- a/pkg/cmd/target/command.go
+++ b/pkg/cmd/target/command.go
@@ -31,21 +31,13 @@ func NewCommand(f util.Factory, o *Options, targetProvider *target.DynamicTarget
 			return util.FilterStringsByPrefix(toComplete, suggestions), cobra.ShellCompDirectiveNoFileComp
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// we never want to load existing target information from disk for completing
-			// the arguments, so we temporarily remove the filename; this prevents users
-			// from simply running "gardenctl target" and have it print unexpected messages
-			targetFile := targetProvider.TargetFile
-
-			targetProvider.TargetFile = ""
-
-			if err := o.Complete(f, cmd, args); err != nil {
+			if err := o.Complete(f, cmd, args, targetProvider); err != nil {
 				return fmt.Errorf("failed to complete command options: %w", err)
 			}
+
 			if err := o.Validate(); err != nil {
 				return err
 			}
-
-			targetProvider.TargetFile = targetFile
 
 			return runCommand(f, o)
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the "cheat" that was introduced with https://github.com/gardener/gardenctl-v2/pull/21#issuecomment-869787373
The completion now takes the flags directly from the DTP to complete incomplete options

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
