### PR TITLE
Target command improvements and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ help: ## Display this help.
 ##@ Development
 
 .PHONY: test
-test: generate lint ## Run tests.
+test: lint ## Run tests.
 	go test ./... -coverprofile cover.out
 
 .PHONY: lint

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/onsi/ginkgo v1.15.0
 	github.com/onsi/gomega v1.10.5
 	github.com/spf13/cobra v1.2.1
+	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
 	golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect

--- a/internal/util/factory.go
+++ b/internal/util/factory.go
@@ -136,3 +136,13 @@ func callIPify(ctx context.Context, domain string) (*net.IP, error) {
 
 	return &netIP, nil
 }
+
+// WithFilesystemTargetProvider returns a copy of the factory with a fsTargetProvider
+func (f *FactoryImpl) WithFilesystemTargetProvider() Factory {
+	return &FactoryImpl{
+		GardenHomeDirectory: f.GardenHomeDirectory,
+		ConfigFile:          f.ConfigFile,
+		TargetFile:          f.TargetFile,
+		TargetProvider:      target.NewFilesystemTargetProvider(f.TargetFile),
+	}
+}

--- a/internal/util/factory.go
+++ b/internal/util/factory.go
@@ -53,9 +53,8 @@ type FactoryImpl struct {
 	// This is only used if the TargetProvider property is nil.
 	TargetFile string
 
-	// TargetProvider can be used to completely override the provider. In this
-	// case, TargetFile is not used by the factory.
-	TargetProvider target.TargetProvider
+	// TargetFlags can be used to completely override the provider.
+	TargetFlags target.TargetFlags
 }
 
 var _ Factory = &FactoryImpl{}
@@ -70,11 +69,7 @@ func (f *FactoryImpl) Manager() (target.Manager, error) {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
-	targetProvider := f.TargetProvider
-	if targetProvider == nil {
-		targetProvider = target.NewFilesystemTargetProvider(f.TargetFile)
-	}
-
+	targetProvider := target.NewTargetProvider(f.TargetFile, f.TargetFlags)
 	kubeconfigCache := target.NewFilesystemKubeconfigCache(filepath.Join(f.GardenHomeDirectory, "cache", "kubeconfigs"))
 	clientProvider := target.NewClientProvider()
 
@@ -137,12 +132,12 @@ func callIPify(ctx context.Context, domain string) (*net.IP, error) {
 	return &netIP, nil
 }
 
-// WithFilesystemTargetProvider returns a copy of the factory with a fsTargetProvider
-func (f *FactoryImpl) WithFilesystemTargetProvider() Factory {
+// WithoutTargetFlags returns a copy of the factory without target flags
+func (f *FactoryImpl) WithoutTargetFlags() Factory {
 	return &FactoryImpl{
 		GardenHomeDirectory: f.GardenHomeDirectory,
 		ConfigFile:          f.ConfigFile,
 		TargetFile:          f.TargetFile,
-		TargetProvider:      target.NewFilesystemTargetProvider(f.TargetFile),
+		TargetFlags:         nil,
 	}
 }

--- a/internal/util/factory.go
+++ b/internal/util/factory.go
@@ -50,10 +50,10 @@ type FactoryImpl struct {
 	ConfigFile string
 
 	// TargetFile is the filename where the currently active target is located.
-	// This is only used if the TargetProvider property is nil.
 	TargetFile string
 
-	// TargetFlags can be used to completely override the provider.
+	// TargetFlags can be used to completely override the target configuration
+	// stored on the filesystem via a CLI flags.
 	TargetFlags target.TargetFlags
 }
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"github.com/gardener/gardenctl-v2/pkg/cmd"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -12,8 +12,6 @@ import (
 	"os"
 	"path/filepath"
 
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	"github.com/gardener/gardenctl-v2/internal/util"
 	cmdssh "github.com/gardener/gardenctl-v2/pkg/cmd/ssh"
 	cmdtarget "github.com/gardener/gardenctl-v2/pkg/cmd/target"
@@ -23,6 +21,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
 )
 

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -62,7 +62,7 @@ func Execute() {
 	flags.StringVar(&factory.ConfigFile, "config", "", fmt.Sprintf("config file (default is $HOME/%s/%s.yaml)", gardenHomeFolder, configName))
 
 	// allow to temporarily re-target a different cluster
-	targetFlags.AddFlags(cmd)
+	targetFlags.AddFlags(flags)
 
 	cobra.OnInitialize(initConfig, func() {
 		registerFlagCompletions(cmd)

--- a/pkg/cmd/cmd_suite_test.go
+++ b/pkg/cmd/cmd_suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestCommand(t *testing.T) {
+func TestGardenctlCommand(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Root Command Test Suite")
+	RunSpecs(t, "Gardenctl Command Test Suite")
 }

--- a/pkg/cmd/cmd_whitebox_test.go
+++ b/pkg/cmd/cmd_whitebox_test.go
@@ -427,7 +427,7 @@ var _ = Describe("Gardenctl command", func() {
 			manager, err := factory.Manager()
 			Expect(err).NotTo(HaveOccurred())
 
-			// TODO comment via By or inline
+			// check target flags values
 			tf := manager.TargetFlags()
 			Expect(tf).To(BeIdenticalTo(factory.TargetFlags))
 			Expect(tf.GardenName()).To(BeEmpty())
@@ -435,7 +435,7 @@ var _ = Describe("Gardenctl command", func() {
 			Expect(tf.SeedName()).To(BeEmpty())
 			Expect(tf.ShootName()).To(Equal(shootName))
 
-			// TODO comment via By or inline
+			// check current target values
 			current, err := manager.CurrentTarget()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(current.GardenName()).To(Equal(gardenName))

--- a/pkg/cmd/cmd_whitebox_test.go
+++ b/pkg/cmd/cmd_whitebox_test.go
@@ -255,10 +255,7 @@ var _ = Describe("Completion", func() {
 			factory := &util.FactoryImpl{
 				ConfigFile: configFile,
 			}
-			manager, err := factory.Manager()
-			Expect(err).NotTo(HaveOccurred())
-
-			wrapped := completionWrapper(factory.Context(), manager, func(ctx context.Context, manager target.Manager) ([]string, error) {
+			wrapped := completionWrapper(factory, func(ctx context.Context, manager target.Manager) ([]string, error) {
 				return []string{"foo", "bar"}, nil
 			})
 

--- a/pkg/cmd/cmd_whitebox_test.go
+++ b/pkg/cmd/cmd_whitebox_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Completion", func() {
 		f.Close()
 
 		configFile = f.Name()
-		Expect(config.SaveToFile(configFile, cfg)).To(Succeed())
+		Expect(cfg.SaveToFile(configFile)).To(Succeed())
 
 		testProject1 = &gardencorev1beta1.Project{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/cmd/cmd_whitebox_test.go
+++ b/pkg/cmd/cmd_whitebox_test.go
@@ -255,8 +255,10 @@ var _ = Describe("Completion", func() {
 			factory := &util.FactoryImpl{
 				ConfigFile: configFile,
 			}
+			manager, err := factory.Manager()
+			Expect(err).NotTo(HaveOccurred())
 
-			wrapped := completionWrapper(factory, func(ctx context.Context, manager target.Manager) ([]string, error) {
+			wrapped := completionWrapper(factory.Context(), manager, func(ctx context.Context, manager target.Manager) ([]string, error) {
 				return []string{"foo", "bar"}, nil
 			})
 

--- a/pkg/cmd/cmd_whitebox_test.go
+++ b/pkg/cmd/cmd_whitebox_test.go
@@ -53,6 +53,7 @@ var _ = Describe("Completion", func() {
 		gardenClient         client.Client
 		shootClient          client.Client
 		factory              util.Factory
+		targetFlags          target.TargetFlags
 		configFile           string
 	)
 
@@ -198,6 +199,9 @@ var _ = Describe("Completion", func() {
 		// prepare command
 		factory = internalfake.NewFakeFactory(cfg, nil, clientProvider, nil, targetProvider)
 
+		// prepare CLI flags
+		targetFlags = target.NewTargetFlags("", "", "", "")
+
 		Expect(shootClient).NotTo(BeNil())
 		Expect(gardenClient).NotTo(BeNil())
 	})
@@ -211,7 +215,7 @@ var _ = Describe("Completion", func() {
 			manager, err := factory.Manager()
 			Expect(err).NotTo(HaveOccurred())
 
-			values, err := gardenFlagCompletionFunc(factory.Context(), manager)
+			values, err := gardenFlagCompletionFunc(factory.Context(), manager, targetFlags)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal([]string{"abc", gardenName}))
 		})
@@ -222,7 +226,7 @@ var _ = Describe("Completion", func() {
 			manager, err := factory.Manager()
 			Expect(err).NotTo(HaveOccurred())
 
-			values, err := projectFlagCompletionFunc(factory.Context(), manager)
+			values, err := projectFlagCompletionFunc(factory.Context(), manager, targetFlags)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal([]string{testProject1.Name, testProject2.Name}))
 		})
@@ -233,7 +237,7 @@ var _ = Describe("Completion", func() {
 			manager, err := factory.Manager()
 			Expect(err).NotTo(HaveOccurred())
 
-			values, err := seedFlagCompletionFunc(factory.Context(), manager)
+			values, err := seedFlagCompletionFunc(factory.Context(), manager, targetFlags)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal([]string{testSeed2.Name, testSeed1.Name}))
 		})
@@ -244,7 +248,7 @@ var _ = Describe("Completion", func() {
 			manager, err := factory.Manager()
 			Expect(err).NotTo(HaveOccurred())
 
-			values, err := shootFlagCompletionFunc(factory.Context(), manager)
+			values, err := shootFlagCompletionFunc(factory.Context(), manager, targetFlags)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal([]string{testShoot2.Name, testShoot1.Name}))
 		})
@@ -255,7 +259,7 @@ var _ = Describe("Completion", func() {
 			factory := &util.FactoryImpl{
 				ConfigFile: configFile,
 			}
-			wrapped := completionWrapper(factory, func(ctx context.Context, manager target.Manager) ([]string, error) {
+			wrapped := completionWrapper(factory, func(ctx context.Context, manager target.Manager, tf target.TargetFlags) ([]string, error) {
 				return []string{"foo", "bar"}, nil
 			})
 

--- a/pkg/cmd/cmd_whitebox_test.go
+++ b/pkg/cmd/cmd_whitebox_test.go
@@ -283,7 +283,7 @@ var _ = Describe("Gardenctl command", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			_, err = projectFlagCompletionFunc(factory.Context(), manager, targetFlags)
-			Expect(err).To(MatchError(MatchRegexp("^failed to read current target:")))
+			Expect(err).To(MatchError(HavePrefix("failed to read current target:")))
 		})
 	})
 
@@ -312,7 +312,7 @@ var _ = Describe("Gardenctl command", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			_, err = seedFlagCompletionFunc(factory.Context(), manager, targetFlags)
-			Expect(err).To(MatchError(MatchRegexp("^failed to read current target:")))
+			Expect(err).To(MatchError(HavePrefix("failed to read current target:")))
 		})
 	})
 
@@ -351,7 +351,7 @@ var _ = Describe("Gardenctl command", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			_, err = shootFlagCompletionFunc(factory.Context(), manager, targetFlags)
-			Expect(err).To(MatchError(MatchRegexp("^failed to read current target:")))
+			Expect(err).To(MatchError(HavePrefix("failed to read current target:")))
 		})
 	})
 
@@ -397,7 +397,7 @@ var _ = Describe("Gardenctl command", func() {
 			Expect(directory).To(Equal(cobra.ShellCompDirectiveNoFileComp))
 			Expect(returned).To(BeNil())
 			head := strings.Split(errOut.String(), "\n")[0]
-			Expect(head).To(MatchRegexp("^failed to load config:"))
+			Expect(head).To(HavePrefix("failed to load config:"))
 		})
 	})
 

--- a/pkg/cmd/ssh/ssh.go
+++ b/pkg/cmd/ssh/ssh.go
@@ -14,7 +14,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 	"io"
 	"io/ioutil"
 	"net"
@@ -27,6 +26,7 @@ import (
 	"time"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 	"github.com/gardener/gardenctl-v2/pkg/target"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"

--- a/pkg/cmd/target/drop.go
+++ b/pkg/cmd/target/drop.go
@@ -9,17 +9,17 @@ package target
 import (
 	"errors"
 	"fmt"
-	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 	"strings"
 
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+
 	"github.com/gardener/gardenctl-v2/internal/util"
-	"github.com/gardener/gardenctl-v2/pkg/target"
 
 	"github.com/spf13/cobra"
 )
 
 // NewCmdDrop returns a new (target) drop command.
-func NewCmdDrop(f util.Factory, o *DropOptions, targetProvider *target.DynamicTargetProvider) *cobra.Command {
+func NewCmdDrop(f util.Factory, o *DropOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "drop",
 		Short: "Drop target, e.g. \"gardenctl target drop shoot\" to drop currently targeted shoot",
@@ -30,7 +30,7 @@ func NewCmdDrop(f util.Factory, o *DropOptions, targetProvider *target.DynamicTa
 			string(TargetKindShoot),
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := o.Complete(f, cmd, args, targetProvider); err != nil {
+			if err := o.Complete(f, cmd, args); err != nil {
 				return fmt.Errorf("failed to complete command options: %w", err)
 			}
 			if err := o.Validate(); err != nil {
@@ -92,7 +92,7 @@ func NewDropOptions(ioStreams util.IOStreams) *DropOptions {
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *DropOptions) Complete(f util.Factory, cmd *cobra.Command, args []string, targetProvider *target.DynamicTargetProvider) error {
+func (o *DropOptions) Complete(_ util.Factory, cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		o.Kind = TargetKind(strings.TrimSpace(args[0]))
 	}

--- a/pkg/cmd/target/drop.go
+++ b/pkg/cmd/target/drop.go
@@ -11,9 +11,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
-
 	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 
 	"github.com/spf13/cobra"
 )

--- a/pkg/cmd/target/drop_test.go
+++ b/pkg/cmd/target/drop_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Command", func() {
 	It("should reject bad options", func() {
 		streams, _, _, _ := util.NewTestIOStreams()
 		o := cmdtarget.NewDropOptions(streams)
-		cmd := cmdtarget.NewCmdDrop(&util.FactoryImpl{}, o, &target.DynamicTargetProvider{})
+		cmd := cmdtarget.NewCmdDrop(&util.FactoryImpl{}, o)
 
 		Expect(cmd.RunE(cmd, nil)).NotTo(Succeed())
 	})
@@ -49,7 +49,7 @@ var _ = Describe("Command", func() {
 		}
 		targetProvider := internalfake.NewFakeTargetProvider(target.NewTarget(gardenName, "", "", ""))
 		factory := internalfake.NewFakeFactory(cfg, nil, nil, nil, targetProvider)
-		cmd := cmdtarget.NewCmdDrop(factory, cmdtarget.NewDropOptions(streams), &target.DynamicTargetProvider{})
+		cmd := cmdtarget.NewCmdDrop(factory, cmdtarget.NewDropOptions(streams))
 
 		Expect(cmd.RunE(cmd, []string{"garden"})).To(Succeed())
 		Expect(out.String()).To(ContainSubstring("Successfully dropped targeted garden %q\n", gardenName))
@@ -93,7 +93,7 @@ var _ = Describe("Command", func() {
 		clientProvider.WithClient(gardenKubeconfig, fakeGardenClient)
 
 		factory := internalfake.NewFakeFactory(cfg, nil, clientProvider, nil, targetProvider)
-		cmd := cmdtarget.NewCmdDrop(factory, cmdtarget.NewDropOptions(streams), &target.DynamicTargetProvider{})
+		cmd := cmdtarget.NewCmdDrop(factory, cmdtarget.NewDropOptions(streams))
 
 		// run command
 		Expect(cmd.RunE(cmd, []string{"project"})).To(Succeed())
@@ -142,7 +142,7 @@ var _ = Describe("Command", func() {
 		clientProvider.WithClient(gardenKubeconfig, fakeGardenClient)
 
 		factory := internalfake.NewFakeFactory(cfg, nil, clientProvider, nil, targetProvider)
-		cmd := cmdtarget.NewCmdDrop(factory, cmdtarget.NewDropOptions(streams), &target.DynamicTargetProvider{})
+		cmd := cmdtarget.NewCmdDrop(factory, cmdtarget.NewDropOptions(streams))
 
 		// run command
 		Expect(cmd.RunE(cmd, []string{"seed"})).To(Succeed())
@@ -197,7 +197,7 @@ var _ = Describe("Command", func() {
 		clientProvider.WithClient(gardenKubeconfig, fakeGardenClient)
 
 		factory := internalfake.NewFakeFactory(cfg, nil, clientProvider, nil, targetProvider)
-		cmd := cmdtarget.NewCmdDrop(factory, cmdtarget.NewDropOptions(streams), &target.DynamicTargetProvider{})
+		cmd := cmdtarget.NewCmdDrop(factory, cmdtarget.NewDropOptions(streams))
 
 		// run command
 		Expect(cmd.RunE(cmd, []string{"shoot"})).To(Succeed())

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -11,9 +11,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
-
 	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 
 	"github.com/spf13/cobra"
 )

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -12,6 +12,7 @@ import (
 	cmdtarget "github.com/gardener/gardenctl-v2/pkg/cmd/target"
 	"github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/target"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Command", func() {
 	It("should reject bad options", func() {
 		streams, _, _, _ := util.NewTestIOStreams()
 		o := cmdtarget.NewTargetOptions(streams)
-		cmd := cmdtarget.NewCmdTarget(&util.FactoryImpl{}, o, &target.DynamicTargetProvider{})
+		cmd := cmdtarget.NewCmdTarget(&util.FactoryImpl{}, o)
 
 		Expect(cmd.RunE(cmd, nil)).NotTo(Succeed())
 	})
@@ -48,7 +48,7 @@ var _ = Describe("Command", func() {
 		}
 		targetProvider := internalfake.NewFakeTargetProvider(target.NewTarget("", "", "", ""))
 		factory := internalfake.NewFakeFactory(cfg, nil, nil, nil, targetProvider)
-		cmd := cmdtarget.NewCmdTarget(factory, cmdtarget.NewTargetOptions(streams), &target.DynamicTargetProvider{})
+		cmd := cmdtarget.NewCmdTarget(factory, cmdtarget.NewTargetOptions(streams))
 
 		Expect(cmd.RunE(cmd, []string{"garden", gardenName})).To(Succeed())
 		Expect(out.String()).To(ContainSubstring("Successfully targeted garden %q\n", gardenName))
@@ -92,7 +92,7 @@ var _ = Describe("Command", func() {
 		clientProvider.WithClient(gardenKubeconfig, fakeGardenClient)
 
 		factory := internalfake.NewFakeFactory(cfg, nil, clientProvider, nil, targetProvider)
-		cmd := cmdtarget.NewCmdTarget(factory, cmdtarget.NewTargetOptions(streams), &target.DynamicTargetProvider{})
+		cmd := cmdtarget.NewCmdTarget(factory, cmdtarget.NewTargetOptions(streams))
 
 		// run command
 		Expect(cmd.RunE(cmd, []string{"project", projectName})).To(Succeed())
@@ -141,7 +141,7 @@ var _ = Describe("Command", func() {
 		clientProvider.WithClient(gardenKubeconfig, fakeGardenClient)
 
 		factory := internalfake.NewFakeFactory(cfg, nil, clientProvider, nil, targetProvider)
-		cmd := cmdtarget.NewCmdTarget(factory, cmdtarget.NewTargetOptions(streams), &target.DynamicTargetProvider{})
+		cmd := cmdtarget.NewCmdTarget(factory, cmdtarget.NewTargetOptions(streams))
 
 		// run command
 		Expect(cmd.RunE(cmd, []string{"seed", seedName})).To(Succeed())
@@ -196,7 +196,7 @@ var _ = Describe("Command", func() {
 		clientProvider.WithClient(gardenKubeconfig, fakeGardenClient)
 
 		factory := internalfake.NewFakeFactory(cfg, nil, clientProvider, nil, targetProvider)
-		cmd := cmdtarget.NewCmdTarget(factory, cmdtarget.NewTargetOptions(streams), &target.DynamicTargetProvider{})
+		cmd := cmdtarget.NewCmdTarget(factory, cmdtarget.NewTargetOptions(streams))
 
 		// run command
 		Expect(cmd.RunE(cmd, []string{"shoot", shootName})).To(Succeed())

--- a/pkg/cmd/target/target_whitebox_test.go
+++ b/pkg/cmd/target/target_whitebox_test.go
@@ -8,10 +8,12 @@ package target
 
 import (
 	"fmt"
+
 	internalfake "github.com/gardener/gardenctl-v2/internal/fake"
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/target"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	. "github.com/onsi/ginkgo"

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -9,9 +9,9 @@ package version
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,7 +56,7 @@ func LoadFromFile(filename string) (*Config, error) {
 	return config, nil
 }
 
-func SaveToFile(filename string, config *Config) error {
+func (config *Config) SaveToFile(filename string) error {
 	f, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -94,10 +94,8 @@ func (m *managerImpl) CurrentTarget() (Target, error) {
 func (m *managerImpl) TargetFlags() TargetFlags {
 	var tf TargetFlags
 
-	if m.targetProvider != nil {
-		if dtp, ok := m.targetProvider.(*dynamicTargetProvider); ok {
-			tf = dtp.targetFlags
-		}
+	if dtp, ok := m.targetProvider.(*dynamicTargetProvider); ok {
+		tf = dtp.targetFlags
 	}
 
 	if tf == nil {

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -31,6 +31,9 @@ type Manager interface {
 	// CurrentTarget contains the current target configuration
 	CurrentTarget() (Target, error)
 
+	// TargetFlags returns the global target flags
+	TargetFlags() TargetFlags
+
 	// TargetGarden sets the garden target configuration
 	// This implicitly drops project, seed and shoot target configuration
 	TargetGarden(name string) error
@@ -86,6 +89,22 @@ func NewManager(config *config.Config, targetProvider TargetProvider, clientProv
 
 func (m *managerImpl) CurrentTarget() (Target, error) {
 	return m.targetProvider.Read()
+}
+
+func (m *managerImpl) TargetFlags() TargetFlags {
+	var tf TargetFlags
+
+	if m.targetProvider != nil {
+		if dtp, ok := m.targetProvider.(*dynamicTargetProvider); ok {
+			tf = dtp.targetFlags
+		}
+	}
+
+	if tf == nil {
+		tf = NewTargetFlags("", "", "", "")
+	}
+
+	return tf
 }
 
 func (m *managerImpl) Configuration() *config.Config {

--- a/pkg/target/target_flags.go
+++ b/pkg/target/target_flags.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 // TargetFlags represents the target cobra flags.
@@ -24,7 +24,7 @@ type TargetFlags interface {
 	// ShootName returns the value that is tied to the corresponding cobra flag.
 	ShootName() string
 	// AddFlags binds target configuration flags to a given flagset
-	AddFlags(cmd *cobra.Command)
+	AddFlags(flags *pflag.FlagSet)
 	// ToTarget converts the flags to a target
 	ToTarget() Target
 	// IsTargetValid returns true if the set of given CLI flags is enough
@@ -69,8 +69,7 @@ func (tf *targetFlagsImpl) ShootName() string {
 	return tf.shootName
 }
 
-func (tf *targetFlagsImpl) AddFlags(cmd *cobra.Command) {
-	flags := cmd.PersistentFlags()
+func (tf *targetFlagsImpl) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&tf.gardenName, "garden", "", "target the given garden cluster")
 	flags.StringVar(&tf.projectName, "project", "", "target the given project")
 	flags.StringVar(&tf.seedName, "seed", "", "target the given seed cluster")

--- a/pkg/target/target_flags.go
+++ b/pkg/target/target_flags.go
@@ -1,0 +1,125 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package target
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// TargetFlags represents the target cobra flags.
+//nolint
+type TargetFlags interface {
+	// GardenName returns the value that is tied to the corresponding cobra flag.
+	GardenName() string
+	// ProjectName returns the value that is tied to the corresponding cobra flag.
+	ProjectName() string
+	// SeedName returns the value that is tied to the corresponding cobra flag.
+	SeedName() string
+	// ShootName returns the value that is tied to the corresponding cobra flag.
+	ShootName() string
+	// AddFlags binds target configuration flags to a given flagset
+	AddFlags(cmd *cobra.Command)
+	// ToTarget converts the flags to a target
+	ToTarget() Target
+	// IsTargetValid returns true if the set of given CLI flags is enough
+	// to create a meaningful target. For example, if only the SeedName is
+	// given, false is returned because for targeting a seed, the GardenName
+	// must also be given. If ShootName and GardenName are set, false is
+	// returned because either project or seed have to be given as well.
+	IsTargetValid() bool
+	// OverrideTarget overrides the given target with the values of the target flags
+	OverrideTarget(current Target) (Target, error)
+}
+
+func NewTargetFlags(garden, project, seed, shoot string) TargetFlags {
+	return &targetFlagsImpl{
+		gardenName:  garden,
+		projectName: project,
+		seedName:    seed,
+		shootName:   shoot,
+	}
+}
+
+type targetFlagsImpl struct {
+	gardenName  string
+	projectName string
+	seedName    string
+	shootName   string
+}
+
+func (tf *targetFlagsImpl) GardenName() string {
+	return tf.gardenName
+}
+
+func (tf *targetFlagsImpl) ProjectName() string {
+	return tf.projectName
+}
+
+func (tf *targetFlagsImpl) SeedName() string {
+	return tf.seedName
+}
+
+func (tf *targetFlagsImpl) ShootName() string {
+	return tf.shootName
+}
+
+func (tf *targetFlagsImpl) AddFlags(cmd *cobra.Command) {
+	flags := cmd.PersistentFlags()
+	flags.StringVar(&tf.gardenName, "garden", "", "target the given garden cluster")
+	flags.StringVar(&tf.projectName, "project", "", "target the given project")
+	flags.StringVar(&tf.seedName, "seed", "", "target the given seed cluster")
+	flags.StringVar(&tf.shootName, "shoot", "", "target the given shoot cluster")
+}
+
+func (tf *targetFlagsImpl) ToTarget() Target {
+	return NewTarget(tf.gardenName, tf.projectName, tf.seedName, tf.shootName)
+}
+
+func (tf *targetFlagsImpl) isEmpty() bool {
+	return tf.gardenName == "" && tf.projectName == "" && tf.seedName == "" && tf.shootName == ""
+}
+
+func (tf *targetFlagsImpl) OverrideTarget(current Target) (Target, error) {
+	if !tf.isEmpty() {
+		if tf.gardenName != "" {
+			current = current.WithGardenName(tf.gardenName).WithProjectName("").WithSeedName("").WithShootName("")
+		}
+
+		if tf.projectName != "" && tf.seedName != "" {
+			return nil, errors.New("cannot specify --project and --seed at the same time")
+		}
+
+		if tf.projectName != "" {
+			current = current.WithProjectName(tf.projectName).WithSeedName("").WithShootName("")
+		}
+
+		if tf.seedName != "" {
+			current = current.WithSeedName(tf.seedName).WithProjectName("").WithShootName("")
+		}
+
+		if tf.shootName != "" {
+			current = current.WithShootName(tf.shootName)
+		}
+
+		if err := current.Validate(); err != nil {
+			return nil, fmt.Errorf("invalid target flags: %w", err)
+		}
+	}
+
+	return current, nil
+}
+
+func (tf *targetFlagsImpl) IsTargetValid() bool {
+	// garden name is always required for a complete set of flags
+	if tf.gardenName == "" {
+		return false
+	}
+
+	return tf.ToTarget().Validate() == nil
+}

--- a/pkg/target/target_flags.go
+++ b/pkg/target/target_flags.go
@@ -27,14 +27,14 @@ type TargetFlags interface {
 	AddFlags(flags *pflag.FlagSet)
 	// ToTarget converts the flags to a target
 	ToTarget() Target
-	// IsTargetValid returns true if the set of given CLI flags is enough
+	// isTargetValid returns true if the set of given CLI flags is enough
 	// to create a meaningful target. For example, if only the SeedName is
 	// given, false is returned because for targeting a seed, the GardenName
 	// must also be given. If ShootName and GardenName are set, false is
 	// returned because either project or seed have to be given as well.
-	IsTargetValid() bool
-	// OverrideTarget overrides the given target with the values of the target flags
-	OverrideTarget(current Target) (Target, error)
+	isTargetValid() bool
+	// overrideTarget overrides the given target with the values of the target flags
+	overrideTarget(current Target) (Target, error)
 }
 
 func NewTargetFlags(garden, project, seed, shoot string) TargetFlags {
@@ -84,7 +84,7 @@ func (tf *targetFlagsImpl) isEmpty() bool {
 	return tf.gardenName == "" && tf.projectName == "" && tf.seedName == "" && tf.shootName == ""
 }
 
-func (tf *targetFlagsImpl) OverrideTarget(current Target) (Target, error) {
+func (tf *targetFlagsImpl) overrideTarget(current Target) (Target, error) {
 	if !tf.isEmpty() {
 		if tf.gardenName != "" {
 			current = current.WithGardenName(tf.gardenName).WithProjectName("").WithSeedName("").WithShootName("")
@@ -114,7 +114,7 @@ func (tf *targetFlagsImpl) OverrideTarget(current Target) (Target, error) {
 	return current, nil
 }
 
-func (tf *targetFlagsImpl) IsTargetValid() bool {
+func (tf *targetFlagsImpl) isTargetValid() bool {
 	// garden name is always required for a complete set of flags
 	if tf.gardenName == "" {
 		return false

--- a/pkg/target/target_flags_test.go
+++ b/pkg/target/target_flags_test.go
@@ -46,4 +46,31 @@ var _ = Describe("Target Flags", func() {
 		})
 		Expect(names).To(Equal([]string{"garden", "project", "seed", "shoot"}))
 	})
+
+	It("should validate target flags", func() {
+		Expect(target.NewTargetFlags("", "project", "", "shoot").IsTargetValid()).To(BeFalse())
+		Expect(target.NewTargetFlags("garden", "", "", "shoot").IsTargetValid()).To(BeFalse())
+		Expect(target.NewTargetFlags("garden", "project", "seed", "shoot").IsTargetValid()).To(BeFalse())
+		Expect(target.NewTargetFlags("garden", "", "", "").IsTargetValid()).To(BeTrue())
+		Expect(target.NewTargetFlags("garden", "project", "", "").IsTargetValid()).To(BeTrue())
+		Expect(target.NewTargetFlags("garden", "", "seed", "").IsTargetValid()).To(BeTrue())
+		Expect(target.NewTargetFlags("garden", "project", "", "shoot").IsTargetValid()).To(BeTrue())
+		Expect(target.NewTargetFlags("garden", "", "seed", "shoot").IsTargetValid()).To(BeTrue())
+	})
+
+	It("should override a target with target flags", func() {
+		tf := target.NewTargetFlags("garden", "project", "", "shoot")
+		t, err := tf.OverrideTarget(target.NewTarget("a", "b", "c", "d"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(t.GardenName()).To(Equal("garden"))
+		Expect(t.ProjectName()).To(Equal("project"))
+		Expect(t.SeedName()).To(BeEmpty())
+		Expect(t.ShootName()).To(Equal("shoot"))
+	})
+
+	It("should fail to override a target", func() {
+		tf := target.NewTargetFlags("", "", "", "shoot")
+		_, err := tf.OverrideTarget(target.NewTarget("", "b", "c", "d"))
+		Expect(err).To(HaveOccurred())
+	})
 })

--- a/pkg/target/target_flags_test.go
+++ b/pkg/target/target_flags_test.go
@@ -8,10 +8,10 @@ package target_test
 
 import (
 	"github.com/gardener/gardenctl-v2/pkg/target"
-	"github.com/spf13/pflag"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/pflag"
 )
 
 var _ = Describe("Target Flags", func() {

--- a/pkg/target/target_flags_test.go
+++ b/pkg/target/target_flags_test.go
@@ -1,0 +1,49 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package target_test
+
+import (
+	"github.com/gardener/gardenctl-v2/pkg/target"
+	"github.com/spf13/pflag"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Target Flags", func() {
+	It("should return an empty set of target flags", func() {
+		tf := target.NewTargetFlags("", "", "", "")
+		Expect(tf).NotTo(BeNil())
+		Expect(tf.GardenName()).To(BeEmpty())
+		Expect(tf.ProjectName()).To(BeEmpty())
+		Expect(tf.SeedName()).To(BeEmpty())
+		Expect(tf.ShootName()).To(BeEmpty())
+		Expect(tf.IsTargetValid()).To(BeFalse())
+	})
+
+	It("should return valid set of target flags", func() {
+		tf := target.NewTargetFlags("garden", "project", "", "shoot")
+		Expect(tf).NotTo(BeNil())
+		Expect(tf.GardenName()).To(Equal("garden"))
+		Expect(tf.ProjectName()).To(Equal("project"))
+		Expect(tf.SeedName()).To(BeEmpty())
+		Expect(tf.ShootName()).To(Equal("shoot"))
+		Expect(tf.IsTargetValid()).To(BeTrue())
+	})
+
+	It("should add target flags to a cobra FlagSet", func() {
+		flags := &pflag.FlagSet{}
+		tf := target.NewTargetFlags("", "", "", "")
+		Expect(flags.HasFlags()).To(BeFalse())
+		tf.AddFlags(flags)
+		var names []string
+		flags.VisitAll(func(flag *pflag.Flag) {
+			names = append(names, flag.Name)
+		})
+		Expect(names).To(Equal([]string{"garden", "project", "seed", "shoot"}))
+	})
+})

--- a/pkg/target/target_provider.go
+++ b/pkg/target/target_provider.go
@@ -6,21 +6,32 @@ SPDX-License-Identifier: Apache-2.0
 package target
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
 	"gopkg.in/yaml.v3"
 )
 
-// TargetProvider can read and write targets.
+// TargetReader can read targets.
 //nolint
-type TargetProvider interface {
+type TargetReader interface {
 	// Read returns the current target. If no target exists yet, a default
 	// (empty) target is returned.
 	Read() (Target, error)
+}
+
+// TargetWriter can write targets.
+//nolint
+type TargetWriter interface {
 	// Write takes a target and saves it permanently.
 	Write(t Target) error
+}
+
+// TargetProvider can read and write targets.
+//nolint
+type TargetProvider interface {
+	TargetReader
+	TargetWriter
 }
 
 type fsTargetProvider struct {
@@ -83,6 +94,32 @@ func (p *fsTargetProvider) Write(t Target) error {
 	return nil
 }
 
+// NewDynamicTargetProvider returns a wrapper that combines the basic
+// file-based TargetProvider with CLI flags, to allow the user
+// to change the target for individual gardenctl commands
+// on-the-fly without changing the file on disk every time.
+//
+// If no CLI flags are given, this functions identical to the
+// regular TargetProvider from NewFilesystemTargetProvider().
+//
+// Otherwise, the flags are used to augment the existing target.
+func NewDynamicTargetProvider(targetFile string, targetFlags TargetFlags) TargetProvider {
+	var delegate TargetProvider
+
+	if targetFile != "" {
+		delegate = NewFilesystemTargetProvider(targetFile)
+	}
+
+	if targetFlags == nil {
+		return delegate
+	}
+
+	return &dynamicTargetProvider{
+		delegate:    delegate,
+		targetFlags: targetFlags,
+	}
+}
+
 // DynamicTargetProvider is a wrapper that combines the basic
 // file-based TargetProvider with CLI flags, to allow the user
 // to change the target for individual gardenctl commands
@@ -92,58 +129,30 @@ func (p *fsTargetProvider) Write(t Target) error {
 // regular TargetProvider from NewFilesystemTargetProvider().
 //
 // Otherwise, the flags are used to augment the existing target.
-type DynamicTargetProvider struct {
-	// TargetFile is the file where the target is read from / written to
-	// when no CLI flags override the targeting. If this is empty, no file
-	// will be loaded as a fallback.
-	TargetFile string
-
-	// GardenNameFlag is the value that should be tied to a cobra flag.
-	GardenNameFlag string
-	// ProjectNameFlag is the value that should be tied to a cobra flag.
-	ProjectNameFlag string
-	// SeedNameFlag is the value that should be tied to a cobra flag.
-	SeedNameFlag string
-	// ShootNameFlag is the value that should be tied to a cobra flag.
-	ShootNameFlag string
+type dynamicTargetProvider struct {
+	delegate    TargetProvider
+	targetFlags TargetFlags
 }
 
-// hasCLIFlags returns true if _any_ of the *Flag properties are not empty.
-func (p *DynamicTargetProvider) hasCLIFlags() bool {
-	return p.GardenNameFlag != "" || p.ProjectNameFlag != "" || p.SeedNameFlag != "" || p.ShootNameFlag != ""
-}
-
-// hasCompleteCLIFlags returns true if the set of given CLI flags is enough
-// to create a meaningful target. For example, if only the SeedNameFlag is
-// given, false is returned because for targeting a seed, the GardenNameFlag
-// must also be given. If ShootNameFlag and GardenNameFlag are set, false is
-// returned because either project or seed have to be given as well.
-func (p *DynamicTargetProvider) hasCompleteCLIFlags() bool {
-	// garden name is always required for a complete set of flags
-	if p.GardenNameFlag == "" {
-		return false
-	}
-
-	return NewTarget(p.GardenNameFlag, p.ProjectNameFlag, p.SeedNameFlag, p.ShootNameFlag).Validate() == nil
-}
+var _ TargetProvider = &dynamicTargetProvider{}
 
 // Read returns the current target from the TargetFile if no CLI
 // flags were given, and tries to construct a meaningful target
 // otherwise.
-func (p *DynamicTargetProvider) Read() (Target, error) {
+func (p *dynamicTargetProvider) Read() (Target, error) {
 	// user gave everything we needed
-	if p.hasCompleteCLIFlags() {
-		return NewTarget(p.GardenNameFlag, p.ProjectNameFlag, p.SeedNameFlag, p.ShootNameFlag), nil
+	if p.targetFlags != nil && p.targetFlags.IsTargetValid() {
+		return p.targetFlags.ToTarget(), nil
 	}
 
 	// user didn't specify anything at all or _some_ flags; in both
 	// cases we need to read the current target from disk
 	current := NewTarget("", "", "", "")
 
-	if p.TargetFile != "" {
+	if p.delegate != nil {
 		var err error
 
-		current, err = NewFilesystemTargetProvider(p.TargetFile).Read()
+		current, err = p.delegate.Read()
 		if err != nil {
 			return nil, err
 		}
@@ -151,40 +160,18 @@ func (p *DynamicTargetProvider) Read() (Target, error) {
 
 	// user gave _some_ flags; we use those to override the current target
 	// (e.g. to quickly change a shoot while keeping garden/project names)
-	if p.hasCLIFlags() {
+	if p.targetFlags != nil {
 		// note that "deeper" levels of targets are reset, as to allow the
 		// user to "move up", e.g. when they have targeted a shoot, just
 		// specifying "--garden mygarden" should target the garden, not the same
 		// shoot on the garden mygarden.
-		if p.GardenNameFlag != "" {
-			current = current.WithGardenName(p.GardenNameFlag).WithProjectName("").WithSeedName("").WithShootName("")
-		}
-
-		if p.ProjectNameFlag != "" && p.SeedNameFlag != "" {
-			return nil, errors.New("cannot specify --project and --seed at the same time")
-		}
-
-		if p.ProjectNameFlag != "" {
-			current = current.WithProjectName(p.ProjectNameFlag).WithSeedName("").WithShootName("")
-		}
-
-		if p.SeedNameFlag != "" {
-			current = current.WithSeedName(p.SeedNameFlag).WithProjectName("").WithShootName("")
-		}
-
-		if p.ShootNameFlag != "" {
-			current = current.WithShootName(p.ShootNameFlag)
-		}
-
-		if err := current.Validate(); err != nil {
-			return nil, fmt.Errorf("invalid target flags: %w", err)
-		}
+		return p.targetFlags.OverrideTarget(current)
 	}
 
 	return current, nil
 }
 
 // Write takes a target and saves it permanently.
-func (p *DynamicTargetProvider) Write(t Target) error {
-	return NewFilesystemTargetProvider(p.TargetFile).Write(t)
+func (p *dynamicTargetProvider) Write(t Target) error {
+	return p.delegate.Write(t)
 }

--- a/pkg/target/target_provider.go
+++ b/pkg/target/target_provider.go
@@ -105,7 +105,7 @@ func NewTargetProvider(targetFile string, targetFlags TargetFlags) TargetProvide
 }
 
 // dynamicTargetProvider is a wrapper that combines the basic
-// file-based TargetProvider with CLI flags, to allow the user
+// filesystem based TargetProvider with CLI flags, to allow the user
 // to change the target for individual gardenctl commands
 // on-the-fly without changing the file on disk every time.
 //
@@ -114,7 +114,9 @@ func NewTargetProvider(targetFile string, targetFlags TargetFlags) TargetProvide
 //
 // Otherwise, the flags are used to augment the existing target.
 type dynamicTargetProvider struct {
-	delegate    TargetProvider
+	// delegate must be valid a filesystem based TargetProvider (required)
+	delegate *fsTargetProvider
+	// targetFlags refers to the global target CLI flags (required)
 	targetFlags TargetFlags
 }
 

--- a/pkg/target/target_provider.go
+++ b/pkg/target/target_provider.go
@@ -141,7 +141,7 @@ var _ TargetProvider = &dynamicTargetProvider{}
 // otherwise.
 func (p *dynamicTargetProvider) Read() (Target, error) {
 	// user gave everything we needed
-	if p.targetFlags != nil && p.targetFlags.IsTargetValid() {
+	if p.targetFlags != nil && p.targetFlags.isTargetValid() {
 		return p.targetFlags.ToTarget(), nil
 	}
 
@@ -165,7 +165,7 @@ func (p *dynamicTargetProvider) Read() (Target, error) {
 		// user to "move up", e.g. when they have targeted a shoot, just
 		// specifying "--garden mygarden" should target the garden, not the same
 		// shoot on the garden mygarden.
-		return p.targetFlags.OverrideTarget(current)
+		return p.targetFlags.overrideTarget(current)
 	}
 
 	return current, nil

--- a/pkg/target/target_provider_test.go
+++ b/pkg/target/target_provider_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Target Provider", func() {
 		tmpFile, err = ioutil.TempFile("", "gardenertarget*")
 		Expect(err).NotTo(HaveOccurred())
 
-		provider = target.NewFilesystemTargetProvider(tmpFile.Name())
+		provider = target.NewTargetProvider(tmpFile.Name(), nil)
 	})
 
 	AfterEach(func() {
@@ -91,7 +91,7 @@ var _ = Describe("Dynamic Target Provider", func() {
 		tmpFile, err = ioutil.TempFile("", "gardenertarget*")
 		Expect(err).NotTo(HaveOccurred())
 
-		provider = target.NewFilesystemTargetProvider(tmpFile.Name())
+		provider = target.NewTargetProvider(tmpFile.Name(), nil)
 	})
 
 	AfterEach(func() {
@@ -107,7 +107,7 @@ var _ = Describe("Dynamic Target Provider", func() {
 		Expect(provider.Write(dummy)).To(Succeed())
 
 		tf := target.NewTargetFlags("", "", "", "")
-		dtp := target.NewDynamicTargetProvider(tmpFile.Name(), tf)
+		dtp := target.NewTargetProvider(tmpFile.Name(), tf)
 
 		readBack, err := dtp.Read()
 		Expect(err).NotTo(HaveOccurred())
@@ -121,7 +121,7 @@ var _ = Describe("Dynamic Target Provider", func() {
 			dummy := target.NewTarget("mygarden", "myproject", "", "myshoot")
 			Expect(provider.Write(dummy)).To(Succeed())
 
-			dtp := target.NewDynamicTargetProvider(tmpFile.Name(), tf)
+			dtp := target.NewTargetProvider(tmpFile.Name(), tf)
 
 			readBack, err := dtp.Read()
 			Expect(err).NotTo(HaveOccurred())
@@ -139,7 +139,7 @@ var _ = Describe("Dynamic Target Provider", func() {
 			dummy := target.NewTarget("mygarden", "myproject", "", "myshoot")
 			Expect(provider.Write(dummy)).To(Succeed())
 
-			dtp := target.NewDynamicTargetProvider(tmpFile.Name(), tf)
+			dtp := target.NewTargetProvider(tmpFile.Name(), tf)
 
 			readBack, err := dtp.Read()
 			Expect(err).NotTo(HaveOccurred())
@@ -188,7 +188,7 @@ var _ = Describe("Dynamic Target Provider", func() {
 			dummy := target.NewTarget("mygarden", "myproject", "", "myshoot")
 			Expect(provider.Write(dummy)).To(Succeed())
 
-			dtp := target.NewDynamicTargetProvider(tmpFile.Name(), tf)
+			dtp := target.NewTargetProvider(tmpFile.Name(), tf)
 
 			readBack, err := dtp.Read()
 			Expect(readBack).To(BeNil())
@@ -202,7 +202,7 @@ var _ = Describe("Dynamic Target Provider", func() {
 		dummy := target.NewTarget("mygarden", "myproject", "", "myshoot")
 
 		tf := target.NewTargetFlags("", "", "", "")
-		dtp := target.NewDynamicTargetProvider(tmpFile.Name(), tf)
+		dtp := target.NewTargetProvider(tmpFile.Name(), tf)
 		Expect(dtp.Write(dummy)).To(Succeed())
 
 		readBack, err := provider.Read()

--- a/pkg/target/target_provider_test.go
+++ b/pkg/target/target_provider_test.go
@@ -106,9 +106,8 @@ var _ = Describe("Dynamic Target Provider", func() {
 		dummy := target.NewTarget("mygarden", "myproject", "", "myshoot")
 		Expect(provider.Write(dummy)).To(Succeed())
 
-		dtp := target.DynamicTargetProvider{
-			TargetFile: tmpFile.Name(),
-		}
+		tf := target.NewTargetFlags("", "", "", "")
+		dtp := target.NewDynamicTargetProvider(tmpFile.Name(), tf)
 
 		readBack, err := dtp.Read()
 		Expect(err).NotTo(HaveOccurred())
@@ -117,33 +116,30 @@ var _ = Describe("Dynamic Target Provider", func() {
 
 	DescribeTable(
 		"should return a new target for complete flags",
-		func(dtp target.DynamicTargetProvider) {
+		func(tf target.TargetFlags) {
 			// prepare target that should never be read
 			dummy := target.NewTarget("mygarden", "myproject", "", "myshoot")
 			Expect(provider.Write(dummy)).To(Succeed())
 
-			dtp.TargetFile = tmpFile.Name()
+			dtp := target.NewDynamicTargetProvider(tmpFile.Name(), tf)
 
 			readBack, err := dtp.Read()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(readBack.GardenName()).To(Equal(dtp.GardenNameFlag))
-			Expect(readBack.ProjectName()).To(Equal(dtp.ProjectNameFlag))
-			Expect(readBack.SeedName()).To(Equal(dtp.SeedNameFlag))
-			Expect(readBack.ShootName()).To(Equal(dtp.ShootNameFlag))
+			expectEqualTargets(readBack, tf.ToTarget())
 		},
-		Entry("just garden", target.DynamicTargetProvider{GardenNameFlag: "newgarden"}),
-		Entry("garden->project", target.DynamicTargetProvider{GardenNameFlag: "newgarden", ProjectNameFlag: "newproject"}),
-		Entry("garden->seed", target.DynamicTargetProvider{GardenNameFlag: "newgarden", SeedNameFlag: "newseed"}),
-		Entry("garden->project->shoot", target.DynamicTargetProvider{GardenNameFlag: "newgarden", ProjectNameFlag: "newproject", ShootNameFlag: "newshoot"}),
+		Entry("just garden", target.NewTargetFlags("newgarden", "", "", "")),
+		Entry("garden->project", target.NewTargetFlags("newgarden", "newproject", "", "")),
+		Entry("garden->seed", target.NewTargetFlags("newgarden", "", "newseed", "")),
+		Entry("garden->project->shoot", target.NewTargetFlags("newgarden", "newproject", "", "newshoot")),
 	)
 
 	DescribeTable(
 		"should augment existing target with CLI flags",
-		func(dtp target.DynamicTargetProvider, expected target.Target) {
+		func(tf target.TargetFlags, expected target.Target) {
 			dummy := target.NewTarget("mygarden", "myproject", "", "myshoot")
 			Expect(provider.Write(dummy)).To(Succeed())
 
-			dtp.TargetFile = tmpFile.Name()
+			dtp := target.NewDynamicTargetProvider(tmpFile.Name(), tf)
 
 			readBack, err := dtp.Read()
 			Expect(err).NotTo(HaveOccurred())
@@ -151,61 +147,62 @@ var _ = Describe("Dynamic Target Provider", func() {
 		},
 		Entry(
 			"target garden cluster",
-			target.DynamicTargetProvider{GardenNameFlag: "newgarden"},
+			target.NewTargetFlags("newgarden", "", "", ""),
 			target.NewTarget("newgarden", "", "", ""),
 		),
 		Entry(
 			"target project",
-			target.DynamicTargetProvider{ProjectNameFlag: "newproject"},
+			target.NewTargetFlags("", "newproject", "", ""),
 			target.NewTarget("mygarden", "newproject", "", ""),
 		),
 		Entry(
 			"target seed",
-			target.DynamicTargetProvider{SeedNameFlag: "newseed"},
+			target.NewTargetFlags("", "", "newseed", ""),
 			target.NewTarget("mygarden", "", "newseed", ""),
 		),
 		Entry(
 			"target shoot",
-			target.DynamicTargetProvider{ShootNameFlag: "newshoot"},
+			target.NewTargetFlags("", "", "", "newshoot"),
 			target.NewTarget("mygarden", "myproject", "", "newshoot"),
 		),
 		Entry(
 			"target shoot in a different project",
-			target.DynamicTargetProvider{ProjectNameFlag: "newproject", ShootNameFlag: "newshoot"},
+			target.NewTargetFlags("", "newproject", "", "newshoot"),
 			target.NewTarget("mygarden", "newproject", "", "newshoot"),
 		),
 		Entry(
 			"target shoot in a seed",
-			target.DynamicTargetProvider{SeedNameFlag: "newseed", ShootNameFlag: "newshoot"},
+			target.NewTargetFlags("", "", "newseed", "newshoot"),
 			target.NewTarget("mygarden", "", "newseed", "newshoot"),
 		),
 		Entry(
 			"complete re-target",
-			target.DynamicTargetProvider{GardenNameFlag: "newgarden", SeedNameFlag: "newseed", ShootNameFlag: "newshoot"},
+			target.NewTargetFlags("newgarden", "", "newseed", "newshoot"),
 			target.NewTarget("newgarden", "", "newseed", "newshoot"),
 		),
 	)
 
 	DescribeTable(
 		"should not allow syntactically wrong targets",
-		func(dtp target.DynamicTargetProvider) {
+		func(tf target.TargetFlags) {
 			dummy := target.NewTarget("mygarden", "myproject", "", "myshoot")
 			Expect(provider.Write(dummy)).To(Succeed())
 
-			dtp.TargetFile = tmpFile.Name()
+			dtp := target.NewDynamicTargetProvider(tmpFile.Name(), tf)
 
 			readBack, err := dtp.Read()
 			Expect(readBack).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		},
-		Entry("seed and project", target.DynamicTargetProvider{ProjectNameFlag: "newproject", SeedNameFlag: "newseed"}),
+		Entry("seed and project", target.NewTargetFlags("", "newproject", "newseed", "")),
 	)
 
 	It("should write changes as expected", func() {
 		// prepare target
 		dummy := target.NewTarget("mygarden", "myproject", "", "myshoot")
 
-		dtp := target.DynamicTargetProvider{TargetFile: tmpFile.Name()}
+		tf := target.NewTargetFlags("", "", "", "")
+		dtp := target.NewDynamicTargetProvider(tmpFile.Name(), tf)
 		Expect(dtp.Write(dummy)).To(Succeed())
 
 		readBack, err := provider.Read()


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR tries to improve some problems and imperfections at the target command.
* A separate structure for the target flags is introduced and made accessible via the manager.
* All information is now passed to the subcommand via the factory.
* The DynamicTargetProvider now wraps the FilesystemTargetProvider.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
