### PR TITLE
Bug/targeting changes

### DIFF
--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -46,7 +46,7 @@ func NewCmdTarget(f util.Factory, o *TargetOptions) *cobra.Command {
 
 	ioStreams := util.NewIOStreams()
 
-	cmd.AddCommand(NewCmdDrop(f, NewDropOptions(ioStreams)))
+	cmd.AddCommand(NewCmdUnset(f, NewUnsetOptions(ioStreams)))
 
 	return cmd
 }
@@ -165,7 +165,7 @@ type TargetOptions struct {
 	TargetName string
 }
 
-// NewTargetOptions returns initialized DropOptions
+// NewTargetOptions returns initialized UnsetOptions
 func NewTargetOptions(ioStreams util.IOStreams) *TargetOptions {
 	return &TargetOptions{
 		Options: base.Options{

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -165,7 +165,7 @@ type TargetOptions struct {
 	TargetName string
 }
 
-// NewTargetOptions returns initialized UnsetOptions
+// NewTargetOptions returns initialized TargetOptions
 func NewTargetOptions(ioStreams util.IOStreams) *TargetOptions {
 	return &TargetOptions{
 		Options: base.Options{

--- a/pkg/cmd/target/unset.go
+++ b/pkg/cmd/target/unset.go
@@ -17,11 +17,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// NewCmdDrop returns a new (target) drop command.
-func NewCmdDrop(f util.Factory, o *DropOptions) *cobra.Command {
+// NewCmdUnset returns a new (target) unset command.
+func NewCmdUnset(f util.Factory, o *UnsetOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "drop",
-		Short: "Drop target, e.g. \"gardenctl target drop shoot\" to drop currently targeted shoot",
+		Use:   "unset",
+		Short: "Unset target, e.g. \"gardenctl target unset shoot\" to unset currently targeted shoot",
 		ValidArgs: []string{
 			string(TargetKindGarden),
 			string(TargetKindProject),
@@ -36,14 +36,14 @@ func NewCmdDrop(f util.Factory, o *DropOptions) *cobra.Command {
 				return err
 			}
 
-			return runCmdDrop(f, o)
+			return runCmdUnset(f, o)
 		},
 	}
 
 	return cmd
 }
 
-func runCmdDrop(f util.Factory, o *DropOptions) error {
+func runCmdUnset(f util.Factory, o *UnsetOptions) error {
 	manager, err := f.Manager()
 	if err != nil {
 		return err
@@ -53,13 +53,13 @@ func runCmdDrop(f util.Factory, o *DropOptions) error {
 
 	switch o.Kind {
 	case TargetKindGarden:
-		targetName, err = manager.DropTargetGarden()
+		targetName, err = manager.UnsetTargetGarden()
 	case TargetKindProject:
-		targetName, err = manager.DropTargetProject()
+		targetName, err = manager.UnsetTargetProject()
 	case TargetKindSeed:
-		targetName, err = manager.DropTargetSeed()
+		targetName, err = manager.UnsetTargetSeed()
 	case TargetKindShoot:
-		targetName, err = manager.DropTargetShoot()
+		targetName, err = manager.UnsetTargetShoot()
 	default:
 		err = errors.New("invalid kind")
 	}
@@ -68,22 +68,22 @@ func runCmdDrop(f util.Factory, o *DropOptions) error {
 		return err
 	}
 
-	fmt.Fprintf(o.IOStreams.Out, "Successfully dropped targeted %s %q\n", o.Kind, targetName)
+	fmt.Fprintf(o.IOStreams.Out, "Successfully unset targeted %s %q\n", o.Kind, targetName)
 
 	return nil
 }
 
-// DropOptions is a struct to support drop command
-type DropOptions struct {
+// UnsetOptions is a struct to support unset command
+type UnsetOptions struct {
 	base.Options
 
 	// Kind is the target kind, for example "garden" or "seed"
 	Kind TargetKind
 }
 
-// NewDropOptions returns initialized DropOptions
-func NewDropOptions(ioStreams util.IOStreams) *DropOptions {
-	return &DropOptions{
+// NewUnsetOptions returns initialized UnsetOptions
+func NewUnsetOptions(ioStreams util.IOStreams) *UnsetOptions {
+	return &UnsetOptions{
 		Options: base.Options{
 			IOStreams: ioStreams,
 		},
@@ -91,7 +91,7 @@ func NewDropOptions(ioStreams util.IOStreams) *DropOptions {
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *DropOptions) Complete(_ util.Factory, cmd *cobra.Command, args []string) error {
+func (o *UnsetOptions) Complete(_ util.Factory, cmd *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		o.Kind = TargetKind(strings.TrimSpace(args[0]))
 	}
@@ -100,7 +100,7 @@ func (o *DropOptions) Complete(_ util.Factory, cmd *cobra.Command, args []string
 }
 
 // Validate validates the provided options
-func (o *DropOptions) Validate() error {
+func (o *UnsetOptions) Validate() error {
 	if err := ValidateKind(o.Kind); err != nil {
 		return err
 	}

--- a/pkg/cmd/target/unset_test.go
+++ b/pkg/cmd/target/unset_test.go
@@ -31,13 +31,13 @@ func init() {
 var _ = Describe("Command", func() {
 	It("should reject bad options", func() {
 		streams, _, _, _ := util.NewTestIOStreams()
-		o := cmdtarget.NewDropOptions(streams)
-		cmd := cmdtarget.NewCmdDrop(&util.FactoryImpl{}, o)
+		o := cmdtarget.NewUnsetOptions(streams)
+		cmd := cmdtarget.NewCmdUnset(&util.FactoryImpl{}, o)
 
 		Expect(cmd.RunE(cmd, nil)).NotTo(Succeed())
 	})
 
-	It("should be able to drop a targeted garden", func() {
+	It("should be able to unset a targeted garden", func() {
 		streams, _, out, _ := util.NewTestIOStreams()
 
 		gardenName := "mygarden"
@@ -49,17 +49,17 @@ var _ = Describe("Command", func() {
 		}
 		targetProvider := internalfake.NewFakeTargetProvider(target.NewTarget(gardenName, "", "", ""))
 		factory := internalfake.NewFakeFactory(cfg, nil, nil, nil, targetProvider)
-		cmd := cmdtarget.NewCmdDrop(factory, cmdtarget.NewDropOptions(streams))
+		cmd := cmdtarget.NewCmdUnset(factory, cmdtarget.NewUnsetOptions(streams))
 
 		Expect(cmd.RunE(cmd, []string{"garden"})).To(Succeed())
-		Expect(out.String()).To(ContainSubstring("Successfully dropped targeted garden %q\n", gardenName))
+		Expect(out.String()).To(ContainSubstring("Successfully unset targeted garden %q\n", gardenName))
 
 		currentTarget, err := targetProvider.Read()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(currentTarget.GardenName()).To(BeEmpty())
 	})
 
-	It("should be able to drop a targeted project", func() {
+	It("should be able to unset a targeted project", func() {
 		streams, _, out, _ := util.NewTestIOStreams()
 
 		gardenName := "mygarden"
@@ -93,11 +93,11 @@ var _ = Describe("Command", func() {
 		clientProvider.WithClient(gardenKubeconfig, fakeGardenClient)
 
 		factory := internalfake.NewFakeFactory(cfg, nil, clientProvider, nil, targetProvider)
-		cmd := cmdtarget.NewCmdDrop(factory, cmdtarget.NewDropOptions(streams))
+		cmd := cmdtarget.NewCmdUnset(factory, cmdtarget.NewUnsetOptions(streams))
 
 		// run command
 		Expect(cmd.RunE(cmd, []string{"project"})).To(Succeed())
-		Expect(out.String()).To(ContainSubstring("Successfully dropped targeted project %q\n", projectName))
+		Expect(out.String()).To(ContainSubstring("Successfully unset targeted project %q\n", projectName))
 
 		currentTarget, err := targetProvider.Read()
 		Expect(err).NotTo(HaveOccurred())
@@ -105,7 +105,7 @@ var _ = Describe("Command", func() {
 		Expect(currentTarget.ProjectName()).To(BeEmpty())
 	})
 
-	It("should be able to drop targeted seed", func() {
+	It("should be able to unset targeted seed", func() {
 		streams, _, out, _ := util.NewTestIOStreams()
 
 		gardenName := "mygarden"
@@ -142,11 +142,11 @@ var _ = Describe("Command", func() {
 		clientProvider.WithClient(gardenKubeconfig, fakeGardenClient)
 
 		factory := internalfake.NewFakeFactory(cfg, nil, clientProvider, nil, targetProvider)
-		cmd := cmdtarget.NewCmdDrop(factory, cmdtarget.NewDropOptions(streams))
+		cmd := cmdtarget.NewCmdUnset(factory, cmdtarget.NewUnsetOptions(streams))
 
 		// run command
 		Expect(cmd.RunE(cmd, []string{"seed"})).To(Succeed())
-		Expect(out.String()).To(ContainSubstring("Successfully dropped targeted seed %q\n", seedName))
+		Expect(out.String()).To(ContainSubstring("Successfully unset targeted seed %q\n", seedName))
 
 		currentTarget, err := targetProvider.Read()
 		Expect(err).NotTo(HaveOccurred())
@@ -154,7 +154,7 @@ var _ = Describe("Command", func() {
 		Expect(currentTarget.SeedName()).To(BeEmpty())
 	})
 
-	It("should be able to drop targeted shoot", func() {
+	It("should be able to unset targeted shoot", func() {
 		streams, _, out, _ := util.NewTestIOStreams()
 
 		gardenName := "mygarden"
@@ -197,11 +197,11 @@ var _ = Describe("Command", func() {
 		clientProvider.WithClient(gardenKubeconfig, fakeGardenClient)
 
 		factory := internalfake.NewFakeFactory(cfg, nil, clientProvider, nil, targetProvider)
-		cmd := cmdtarget.NewCmdDrop(factory, cmdtarget.NewDropOptions(streams))
+		cmd := cmdtarget.NewCmdUnset(factory, cmdtarget.NewUnsetOptions(streams))
 
 		// run command
 		Expect(cmd.RunE(cmd, []string{"shoot"})).To(Succeed())
-		Expect(out.String()).To(ContainSubstring("Successfully dropped targeted shoot %q\n", shootName))
+		Expect(out.String()).To(ContainSubstring("Successfully unset targeted shoot %q\n", shootName))
 
 		currentTarget, err := targetProvider.Read()
 		Expect(err).NotTo(HaveOccurred())
@@ -212,10 +212,10 @@ var _ = Describe("Command", func() {
 	})
 })
 
-var _ = Describe("DropOptions", func() {
+var _ = Describe("UnsetOptions", func() {
 	It("should validate", func() {
 		streams, _, _, _ := util.NewTestIOStreams()
-		o := cmdtarget.NewDropOptions(streams)
+		o := cmdtarget.NewUnsetOptions(streams)
 		o.Kind = cmdtarget.TargetKindGarden
 
 		Expect(o.Validate()).To(Succeed())
@@ -223,7 +223,7 @@ var _ = Describe("DropOptions", func() {
 
 	It("should reject invalid kinds", func() {
 		streams, _, _, _ := util.NewTestIOStreams()
-		o := cmdtarget.NewDropOptions(streams)
+		o := cmdtarget.NewUnsetOptions(streams)
 		o.Kind = "not a kind"
 
 		err := o.Validate()

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -35,7 +35,7 @@ type Manager interface {
 	TargetFlags() TargetFlags
 
 	// TargetGarden sets the garden target configuration
-	// This implicitly drops project, seed and shoot target configuration
+	// This implicitly unsets project, seed and shoot target configuration
 	TargetGarden(name string) error
 	// TargetProject sets the project target configuration
 	// This implicitly unsets seed and shoot target configuration
@@ -46,17 +46,17 @@ type Manager interface {
 	// TargetShoot sets the shoot target configuration
 	// It will also configure appropriate project and seed values if not already set
 	TargetShoot(ctx context.Context, name string) error
-	// DropTargetGarden unsets the garden target configuration
+	// UnsetTargetGarden unsets the garden target configuration
 	// This implicitly unsets project, shoot and seed target configuration
-	DropTargetGarden() (string, error)
-	// DropTargetProject unsets the project target configuration
+	UnsetTargetGarden() (string, error)
+	// UnsetTargetProject unsets the project target configuration
 	// This implicitly unsets seed and shoot target configuration
-	DropTargetProject() (string, error)
-	// DropTargetSeed unsets the garden seed configuration
+	UnsetTargetProject() (string, error)
+	// UnsetTargetSeed unsets the garden seed configuration
 	// This implicitly unsets project and shoot target configuration
-	DropTargetSeed() (string, error)
-	// DropTargetShoot unsets the garden shoot configuration
-	DropTargetShoot() (string, error)
+	UnsetTargetSeed() (string, error)
+	// UnsetTargetShoot unsets the garden shoot configuration
+	UnsetTargetShoot() (string, error)
 
 	// GardenClient controller-runtime client for accessing the configured garden cluster
 	GardenClient(t Target) (client.Client, error)
@@ -126,7 +126,7 @@ func (m *managerImpl) TargetGarden(gardenName string) error {
 	return fmt.Errorf("garden %q is not defined in gardenctl configuration", gardenName)
 }
 
-func (m *managerImpl) DropTargetGarden() (string, error) {
+func (m *managerImpl) UnsetTargetGarden() (string, error) {
 	currentTarget, err := m.CurrentTarget()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current target: %v", err)
@@ -177,7 +177,7 @@ func (m *managerImpl) TargetProject(ctx context.Context, projectName string) err
 	})
 }
 
-func (m *managerImpl) DropTargetProject() (string, error) {
+func (m *managerImpl) UnsetTargetProject() (string, error) {
 	currentTarget, err := m.CurrentTarget()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current target: %v", err)
@@ -243,7 +243,7 @@ func (m *managerImpl) TargetSeed(ctx context.Context, seedName string) error {
 	})
 }
 
-func (m *managerImpl) DropTargetSeed() (string, error) {
+func (m *managerImpl) UnsetTargetSeed() (string, error) {
 	currentTarget, err := m.CurrentTarget()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current target: %v", err)
@@ -342,7 +342,7 @@ func (m *managerImpl) TargetShoot(ctx context.Context, shootName string) error {
 	})
 }
 
-func (m *managerImpl) DropTargetShoot() (string, error) {
+func (m *managerImpl) UnsetTargetShoot() (string, error) {
 	currentTarget, err := m.CurrentTarget()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current target: %v", err)

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -44,16 +44,16 @@ type Manager interface {
 	// This implicitly unsets project and shoot target configuration
 	TargetSeed(ctx context.Context, name string) error
 	// TargetShoot sets the shoot target configuration
+	// This implicitly unsets seed target configuration
 	// It will also configure appropriate project and seed values if not already set
 	TargetShoot(ctx context.Context, name string) error
 	// UnsetTargetGarden unsets the garden target configuration
 	// This implicitly unsets project, shoot and seed target configuration
 	UnsetTargetGarden() (string, error)
 	// UnsetTargetProject unsets the project target configuration
-	// This implicitly unsets seed and shoot target configuration
+	// This implicitly unsets shoot target configuration
 	UnsetTargetProject() (string, error)
 	// UnsetTargetSeed unsets the garden seed configuration
-	// This implicitly unsets project and shoot target configuration
 	UnsetTargetSeed() (string, error)
 	// UnsetTargetShoot unsets the garden shoot configuration
 	UnsetTargetShoot() (string, error)
@@ -187,7 +187,6 @@ func (m *managerImpl) UnsetTargetProject() (string, error) {
 	if targetedName != "" {
 		return targetedName, m.patchTarget(func(t *targetImpl) error {
 			t.Project = ""
-			t.Seed = ""
 			t.Shoot = ""
 
 			return nil
@@ -253,8 +252,6 @@ func (m *managerImpl) UnsetTargetSeed() (string, error) {
 	if targetedName != "" {
 		return targetedName, m.patchTarget(func(t *targetImpl) error {
 			t.Seed = ""
-			t.Project = ""
-			t.Shoot = ""
 
 			return nil
 		})
@@ -307,11 +304,11 @@ func (m *managerImpl) TargetShoot(ctx context.Context, shootName string) error {
 		} else if t.Seed != "" {
 			seed, err = m.resolveSeedName(ctx, gardenClient, t.Seed)
 			if err != nil {
-				return fmt.Errorf("failed to fetch kubeconfig for seed cluster: %w", err)
+				return fmt.Errorf("failed to resolve sed by name: %w", err)
 			}
 		}
 
-		project, seed, shoot, err := m.resolveShootName(ctx, gardenClient, project, seed, shootName)
+		project, shoot, err := m.resolveShootName(ctx, gardenClient, project, seed, shootName)
 		if err != nil {
 			return fmt.Errorf("failed to resolve shoot: %w", err)
 		}
@@ -334,9 +331,7 @@ func (m *managerImpl) TargetShoot(ctx context.Context, shootName string) error {
 			t.Project = project.Name
 		}
 
-		if seed != nil {
-			t.Seed = seed.Name
-		}
+		t.Seed = ""
 
 		return nil
 	})
@@ -364,17 +359,16 @@ func (m *managerImpl) UnsetTargetShoot() (string, error) {
 // on the given garden. Either project or seed can be supplied to help in
 // finding the Shoot. If no or multiple Shoots match the given criteria, an
 // error is returned.
-// If a project or a seed are given, they are returned directly (unless an
-// error is returned). If neither are given, the function will decide how
-// to best find the Shoot later by returning either a project or a seed,
-// never both.
+// If a project is given, it is returned directly (unless an
+// error is returned). If none are given, the function will
+// return matching project to clearly identify the shoot
 func (m *managerImpl) resolveShootName(
 	ctx context.Context,
 	gardenClient client.Client,
 	project *gardencorev1beta1.Project,
 	seed *gardencorev1beta1.Seed,
 	shootName string,
-) (*gardencorev1beta1.Project, *gardencorev1beta1.Seed, *gardencorev1beta1.Shoot, error) {
+) (*gardencorev1beta1.Project, *gardencorev1beta1.Shoot, error) {
 	shoot := &gardencorev1beta1.Shoot{}
 
 	// If a shoot is targeted via a project, we fetch it based on the project's namespace.
@@ -389,10 +383,10 @@ func (m *managerImpl) resolveShootName(
 		key := types.NamespacedName{Name: shootName, Namespace: *project.Spec.Namespace}
 
 		if err := gardenClient.Get(ctx, key, shoot); err != nil {
-			return nil, nil, nil, fmt.Errorf("failed to get shoot %v: %w", key, err)
+			return nil, nil, fmt.Errorf("failed to get shoot %v: %w", key, err)
 		}
 
-		return project, nil, shoot, nil
+		return project, shoot, nil
 	}
 
 	// list all shoots, filter by their name and possibly spec.seedName (if seed is set)
@@ -410,7 +404,7 @@ func (m *managerImpl) resolveShootName(
 	}
 
 	if err := gardenClient.List(ctx, &shootList, listOpts...); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to list shoot clusters: %w", err)
+		return nil, nil, fmt.Errorf("failed to list shoot clusters: %w", err)
 	}
 
 	// filter found shoots
@@ -431,26 +425,20 @@ func (m *managerImpl) resolveShootName(
 	}
 
 	if len(matchingShoots) == 0 {
-		return nil, nil, nil, fmt.Errorf("no shoot named %q exists", shootName)
+		return nil, nil, fmt.Errorf("no shoot named %q exists", shootName)
 	}
 
 	if len(matchingShoots) > 1 {
-		return nil, nil, nil, fmt.Errorf("there are multiple shoots named %q on this garden, please target a project or seed to make your choice unambiguous", shootName)
+		return nil, nil, fmt.Errorf("there are multiple shoots named %q on this garden, please target a project or seed to make your choice unambiguous", shootName)
 	}
 
 	shoot = matchingShoots[0]
-
-	// if the user specifically targeted via a seed, keep their choice
-	if seed != nil {
-		return nil, seed, shoot, nil
-	}
-
 	// given how fast we can resolve shoots by project and that shoots
 	// always have a project, but not always a seed (yet), we prefer
 	// for users later to use the project path in their target
 	projectList := &gardencorev1beta1.ProjectList{}
 	if err := gardenClient.List(ctx, projectList, client.MatchingFields{gardencore.ProjectNamespace: shoot.Namespace}); err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to fetch parent project for shoot: %v", err)
+		return nil, nil, fmt.Errorf("failed to fetch parent project for shoot: %v", err)
 	}
 
 	// see note above on why we have to filter again because ctrl-runtime doesn't support FieldSelectors in tests
@@ -464,16 +452,14 @@ func (m *managerImpl) resolveShootName(
 
 			seed, err = m.resolveSeedName(ctx, gardenClient, *shoot.Status.SeedName)
 			if err != nil {
-				return nil, nil, nil, fmt.Errorf("failed to fetch project or seed for shoot: %v", err)
+				return nil, nil, fmt.Errorf("failed to fetch project or seed for shoot: %v", err)
 			}
 		}
 	} else {
 		project = &projectList.Items[0]
 	}
 
-	// only project or seed will be non-nil at this point
-
-	return project, seed, shoot, nil
+	return project, shoot, nil
 }
 
 func filterProjectsByNamespace(items []gardencorev1beta1.Project, namespace string) []gardencorev1beta1.Project {
@@ -625,7 +611,7 @@ func (m *managerImpl) ensureShootKubeconfig(ctx context.Context, t Target) ([]by
 		}
 	}
 
-	_, _, shoot, err := m.resolveShootName(ctx, gardenClient, project, seed, t.ShootName())
+	_, shoot, err := m.resolveShootName(ctx, gardenClient, project, seed, t.ShootName())
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve shoot: %w", err)
 	}

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -445,19 +445,10 @@ func (m *managerImpl) resolveShootName(
 	projectList.Items = filterProjectsByNamespace(projectList.Items, shoot.Namespace)
 
 	if len(projectList.Items) == 0 {
-		// this should never happen, but to aid in inspecting broken
-		// installations, try to find the seed instead as a fallback
-		if shoot.Status.SeedName != nil && *shoot.Status.SeedName != "" {
-			var err error
-
-			seed, err = m.resolveSeedName(ctx, gardenClient, *shoot.Status.SeedName)
-			if err != nil {
-				return nil, nil, fmt.Errorf("failed to fetch project or seed for shoot: %v", err)
-			}
-		}
-	} else {
-		project = &projectList.Items[0]
+		return nil, nil, fmt.Errorf("failed to fetch parent project for shoot")
 	}
+
+	project = &projectList.Items[0]
 
 	return project, shoot, nil
 }

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -304,7 +304,7 @@ func (m *managerImpl) TargetShoot(ctx context.Context, shootName string) error {
 		} else if t.Seed != "" {
 			seed, err = m.resolveSeedName(ctx, gardenClient, t.Seed)
 			if err != nil {
-				return fmt.Errorf("failed to resolve sed by name: %w", err)
+				return fmt.Errorf("failed to resolve seed: %w", err)
 			}
 		}
 

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -400,7 +400,7 @@ var _ = Describe("Manager", func() {
 		Expect(newClient).NotTo(BeNil())
 	})
 
-	It("should be able to drop selected garden", func() {
+	It("should be able to unset selected garden", func() {
 		t := target.NewTarget(gardenName, "", "", "")
 		targetProvider := fake.NewFakeTargetProvider(t)
 
@@ -408,7 +408,7 @@ var _ = Describe("Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manager).NotTo(BeNil())
 
-		Expect(manager.DropTargetGarden()).Should(Equal(gardenName))
+		Expect(manager.UnsetTargetGarden()).Should(Equal(gardenName))
 		assertTargetProvider(targetProvider, target.NewTarget("", "", "", ""))
 	})
 
@@ -420,13 +420,13 @@ var _ = Describe("Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manager).NotTo(BeNil())
 
-		res, dropErr := manager.DropTargetGarden()
-		Expect(dropErr).To(HaveOccurred())
+		res, unsetErr := manager.UnsetTargetGarden()
+		Expect(unsetErr).To(HaveOccurred())
 		Expect(res).To(BeEmpty())
 		assertTargetProvider(targetProvider, t)
 	})
 
-	It("should unset deeper target levels when dropping garden", func() {
+	It("should unset deeper target levels when unsetping garden", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1AmbiguousShoot.Name)
 		targetProvider := fake.NewFakeTargetProvider(t)
 
@@ -434,14 +434,14 @@ var _ = Describe("Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manager).NotTo(BeNil())
 
-		// Drop Garden
-		Expect(manager.DropTargetGarden()).Should(Equal(gardenName))
+		// Unset Garden
+		Expect(manager.UnsetTargetGarden()).Should(Equal(gardenName))
 
-		// should also drop project, seed and shoot
+		// should also unset project, seed and shoot
 		assertTargetProvider(targetProvider, target.NewTarget("", "", "", ""))
 	})
 
-	It("should be able to drop selected project", func() {
+	It("should be able to unset selected project", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", "")
 		targetProvider := fake.NewFakeTargetProvider(t)
 
@@ -449,7 +449,7 @@ var _ = Describe("Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manager).NotTo(BeNil())
 
-		Expect(manager.DropTargetProject()).Should(Equal(prod1Project.Name))
+		Expect(manager.UnsetTargetProject()).Should(Equal(prod1Project.Name))
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, "", "", ""))
 	})
 
@@ -461,13 +461,13 @@ var _ = Describe("Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manager).NotTo(BeNil())
 
-		res, dropErr := manager.DropTargetProject()
-		Expect(dropErr).To(HaveOccurred())
+		res, unsetErr := manager.UnsetTargetProject()
+		Expect(unsetErr).To(HaveOccurred())
 		Expect(res).To(BeEmpty())
 		assertTargetProvider(targetProvider, t)
 	})
 
-	It("should unset deeper target levels when dropping project", func() {
+	It("should unset deeper target levels when unsetping project", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1AmbiguousShoot.Name)
 		targetProvider := fake.NewFakeTargetProvider(t)
 
@@ -475,14 +475,14 @@ var _ = Describe("Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manager).NotTo(BeNil())
 
-		// Drop Project
-		Expect(manager.DropTargetProject()).Should(Equal(prod1Project.Name))
+		// Unset Project
+		Expect(manager.UnsetTargetProject()).Should(Equal(prod1Project.Name))
 
-		// should also drop seed and shoot
+		// should also unset seed and shoot
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, "", "", ""))
 	})
 
-	It("should be able to drop selected shoot", func() {
+	It("should be able to unset selected shoot", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", prod1AmbiguousShoot.Name)
 		targetProvider := fake.NewFakeTargetProvider(t)
 
@@ -490,7 +490,7 @@ var _ = Describe("Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manager).NotTo(BeNil())
 
-		Expect(manager.DropTargetShoot()).Should(Equal(prod1AmbiguousShoot.Name))
+		Expect(manager.UnsetTargetShoot()).Should(Equal(prod1AmbiguousShoot.Name))
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", ""))
 	})
 
@@ -502,13 +502,13 @@ var _ = Describe("Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manager).NotTo(BeNil())
 
-		res, dropErr := manager.DropTargetShoot()
-		Expect(dropErr).To(HaveOccurred())
+		res, unsetErr := manager.UnsetTargetShoot()
+		Expect(unsetErr).To(HaveOccurred())
 		Expect(res).To(BeEmpty())
 		assertTargetProvider(targetProvider, t)
 	})
 
-	It("should be able to drop selected seed", func() {
+	It("should be able to unset selected seed", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1AmbiguousShoot.Name)
 		targetProvider := fake.NewFakeTargetProvider(t)
 
@@ -516,7 +516,7 @@ var _ = Describe("Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manager).NotTo(BeNil())
 
-		Expect(manager.DropTargetSeed()).Should(Equal(seed.Name))
+		Expect(manager.UnsetTargetSeed()).Should(Equal(seed.Name))
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, "", "", ""))
 	})
 
@@ -528,8 +528,8 @@ var _ = Describe("Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manager).NotTo(BeNil())
 
-		res, dropErr := manager.DropTargetSeed()
-		Expect(dropErr).To(HaveOccurred())
+		res, unsetErr := manager.UnsetTargetSeed()
+		Expect(unsetErr).To(HaveOccurred())
 		Expect(res).To(BeEmpty())
 		assertTargetProvider(targetProvider, t)
 	})

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -248,8 +248,8 @@ var _ = Describe("Manager", func() {
 		assertTargetProvider(targetProvider, t)
 	})
 
-	It("should be able to target valid seeds", func() {
-		t := target.NewTarget(gardenName, "", "", "")
+	It("should be able to target valid seeds and drop project and shoot target", func() {
+		t := target.NewTarget(gardenName, prod1Project.Name, "", prod1AmbiguousShoot.Name)
 		targetProvider := fake.NewFakeTargetProvider(t)
 
 		manager, err := target.NewManager(cfg, targetProvider, clientProvider, kubeconfigCache)

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -463,7 +463,7 @@ var _ = Describe("Manager", func() {
 		// Unset Project
 		Expect(manager.UnsetTargetProject()).Should(Equal(prod1Project.Name))
 
-		// should also unset seed and shoot
+		// should also unset shoot
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, "", "", ""))
 	})
 

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Manager", func() {
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1AmbiguousShoot.Name))
 	})
 
-	It("should be able to target valid shoots with a seed already targeted", func() {
+	It("should be able to target valid shoots with a seed already targeted. Should drop seed and set shoot project instead", func() {
 		t := target.NewTarget(gardenName, "", seed.Name, "")
 		targetProvider := fake.NewFakeTargetProvider(t)
 
@@ -293,7 +293,7 @@ var _ = Describe("Manager", func() {
 		Expect(manager).NotTo(BeNil())
 
 		Expect(manager.TargetShoot(context.TODO(), prod1GoldenShoot.Name)).To(Succeed())
-		assertTargetProvider(targetProvider, target.NewTarget(gardenName, "", seed.Name, prod1GoldenShoot.Name))
+		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name))
 	})
 
 	It("should be able to target valid shoots with another seed already targeted", func() {
@@ -320,21 +320,6 @@ var _ = Describe("Manager", func() {
 		Expect(manager.TargetShoot(context.TODO(), prod1GoldenShoot.Name)).To(Succeed())
 		// project should be inserted into the path, as it is prefered over a seed step
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name))
-	})
-
-	It("should be able to target valid shoots with only garden targeted with project missing", func() {
-		t := target.NewTarget(gardenName, "", "", "")
-		targetProvider := fake.NewFakeTargetProvider(t)
-
-		// artificially break the garden
-		Expect(gardenClient.Delete(context.TODO(), prod1Project)).To(Succeed())
-
-		manager, err := target.NewManager(cfg, targetProvider, clientProvider, kubeconfigCache)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(manager).NotTo(BeNil())
-
-		Expect(manager.TargetShoot(context.TODO(), prod1GoldenShoot.Name)).To(Succeed())
-		assertTargetProvider(targetProvider, target.NewTarget(gardenName, "", seed.Name, prod1GoldenShoot.Name))
 	})
 
 	It("should error when multiple shoots match", func() {
@@ -426,7 +411,7 @@ var _ = Describe("Manager", func() {
 		assertTargetProvider(targetProvider, t)
 	})
 
-	It("should unset deeper target levels when unsetping garden", func() {
+	It("should unset deeper target levels when unsetting garden", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1AmbiguousShoot.Name)
 		targetProvider := fake.NewFakeTargetProvider(t)
 
@@ -467,8 +452,8 @@ var _ = Describe("Manager", func() {
 		assertTargetProvider(targetProvider, t)
 	})
 
-	It("should unset deeper target levels when unsetping project", func() {
-		t := target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1AmbiguousShoot.Name)
+	It("should unset deeper target levels when unsetting project", func() {
+		t := target.NewTarget(gardenName, prod1Project.Name, "", prod1AmbiguousShoot.Name)
 		targetProvider := fake.NewFakeTargetProvider(t)
 
 		manager, err := target.NewManager(cfg, targetProvider, clientProvider, kubeconfigCache)
@@ -509,7 +494,7 @@ var _ = Describe("Manager", func() {
 	})
 
 	It("should be able to unset selected seed", func() {
-		t := target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1AmbiguousShoot.Name)
+		t := target.NewTarget(gardenName, "", seed.Name, "")
 		targetProvider := fake.NewFakeTargetProvider(t)
 
 		manager, err := target.NewManager(cfg, targetProvider, clientProvider, kubeconfigCache)


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we change how the targeting behaves if a seed is targeted.
If a `seed` is targeted and the user targets a `shoot`, the seed is discarded in favor for `project` and `shoot`.
Also, if the user targets a `seed`, `project` and `shoot` are discarded.
This ensures that `shoot` and `seed` are never targeted at the same time.

This PR also renames the `target drop` command to `target unset`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
