### PR TITLE
Add klog flags like `v`

### DIFF
--- a/hack/get-build-ld-flags.sh
+++ b/hack/get-build-ld-flags.sh
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-PACKAGE_PATH="${1:-k8s.io/component-base}"
+PACKAGE_PATHS="${1:-"k8s.io/component-base k8s.io/client-go/pkg"}"
 VERSION_PATH="${2:-$(dirname $0)/../VERSION}"
 PROGRAM_NAME="${3:-gardenctl-v2}"
 VERSION_VERSIONFILE="$(cat "$VERSION_PATH")"
@@ -29,10 +29,13 @@ fi
 # version-to-build in our pipelines (see https://github.com/gardener/cc-utils/issues/431).
 TREE_STATE="$([ -z "$(git status --porcelain 2>/dev/null | grep -vf <(git ls-files --cached --deleted --ignored --exclude-from=.dockerignore) -e 'VERSION')" ] && echo clean || echo dirty)"
 
-echo "-X $PACKAGE_PATH/version.gitMajor=$MAJOR_VERSION
-      -X $PACKAGE_PATH/version.gitMinor=$MINOR_VERSION
-      -X $PACKAGE_PATH/version.gitVersion=$VERSION
-      -X $PACKAGE_PATH/version.gitTreeState=$TREE_STATE
-      -X $PACKAGE_PATH/version.gitCommit=$(git rev-parse --verify HEAD)
-      -X $PACKAGE_PATH/version.buildDate=$(date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/\([0-9][0-9]\)$/:\1/g')
-      -X $PACKAGE_PATH/version/verflag.programName=$PROGRAM_NAME"
+for PACKAGE_PATH in $PACKAGE_PATHS
+do
+  echo "-X $PACKAGE_PATH/version.gitMajor=$MAJOR_VERSION
+        -X $PACKAGE_PATH/version.gitMinor=$MINOR_VERSION
+        -X $PACKAGE_PATH/version.gitVersion=$VERSION
+        -X $PACKAGE_PATH/version.gitTreeState=$TREE_STATE
+        -X $PACKAGE_PATH/version.gitCommit=$(git rev-parse --verify HEAD)
+        -X $PACKAGE_PATH/version.buildDate=$(date '+%Y-%m-%dT%H:%M:%S%z' | sed 's/\([0-9][0-9]\)$/:\1/g')
+        -X $PACKAGE_PATH/version/verflag.programName=$PROGRAM_NAME"
+done

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -87,7 +87,7 @@ func NewGardenctlCommand(f *util.FactoryImpl, ioStreams util.IOStreams) *cobra.C
 	// Do not precalculate what $HOME is for the help text, because it prevents
 	// usage where the current user has no home directory (which might _just_ be
 	// the reason the user chose to specify an explicit config file).
-	flags.StringVar(&f.ConfigFile, "config", "", fmt.Sprintf("config file (default is $HOME/%s/%s.yaml)", gardenHomeFolder, configName))
+	flags.StringVar(&f.ConfigFile, "config", "", fmt.Sprintf("config file (default is %s)", filepath.Join("~", gardenHomeFolder, configName+".yaml")))
 
 	// allow to temporarily re-target a different cluster
 	f.TargetFlags.AddFlags(flags)
@@ -117,7 +117,7 @@ func initConfig(f *util.FactoryImpl) {
 
 		configPath := filepath.Join(home, gardenHomeFolder)
 
-		// Search config in $HOME/.garden or in path provided with the env variable GCTL_HOME with name ".garden-login" (without extension) or name from env variable GCTL_CONFIG_NAME.
+		// Search config in ~/.garden or in path provided with the env variable GCTL_HOME with name "gardenctl-v2" (without extension) or name from env variable GCTL_CONFIG_NAME.
 		envHomeDir, err := homedir.Expand(os.Getenv(envGardenHomeDir))
 		cobra.CheckErr(err)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add klog flags like `v` to set the number for the log level verbosity (default 0). This is needed for debugging purposes.

I also fixed the `User-Agent` header with this PR, which was previously `User-Agent: gardenctl/v0.0.0 (darwin/amd64) kubernetes/$Format` and is now `User-Agent: gardenctl/v0.1.0 (darwin/amd64) kubernetes/cb80eec`


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add klog flags like `v`
```
