### PR TITLE
Config command proposal

### DIFF
--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -109,7 +109,7 @@ func (g *clientImpl) GetProjectByNamespace(ctx context.Context, namespace string
 
 	projectList, err := g.ListProjects(ctx, fieldSelector, limit)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch project by namespace: %v", err)
+		return nil, fmt.Errorf("failed to fetch project by namespace: %w", err)
 	}
 
 	if len(projectList.Items) == 0 {

--- a/internal/util/target.go
+++ b/internal/util/target.go
@@ -107,8 +107,13 @@ func ProjectNamesForTarget(ctx context.Context, manager target.Manager, t target
 
 // GardenNames returns all names of configured Gardens
 func GardenNames(manager target.Manager) ([]string, error) {
+	config := manager.Configuration()
+	if config == nil {
+		return nil, errors.New("could not get configuration")
+	}
+
 	names := sets.NewString()
-	for _, garden := range manager.Configuration().Gardens {
+	for _, garden := range config.Gardens {
 		names.Insert(garden.Name)
 	}
 

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
+	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
 	cmdenv "github.com/gardener/gardenctl-v2/pkg/cmd/env"
 	cmdssh "github.com/gardener/gardenctl-v2/pkg/cmd/ssh"
 	cmdtarget "github.com/gardener/gardenctl-v2/pkg/cmd/target"
@@ -107,6 +108,7 @@ func NewGardenctlCommand(f *util.FactoryImpl, ioStreams util.IOStreams) *cobra.C
 	cmd.AddCommand(cmdssh.NewCmdSSH(f, cmdssh.NewSSHOptions(ioStreams)))
 	cmd.AddCommand(cmdtarget.NewCmdTarget(f, cmdtarget.NewTargetOptions(ioStreams)))
 	cmd.AddCommand(cmdversion.NewCmdVersion(f, cmdversion.NewVersionOptions(ioStreams)))
+	cmd.AddCommand(cmdconfig.NewCmdConfig(f, ioStreams))
 	cmd.AddCommand(cmdenv.NewCmdProviderEnv(f, ioStreams))
 	cmd.AddCommand(cmdenv.NewCmdKubectlEnv(f, ioStreams))
 

--- a/pkg/cmd/cmd_suite_test.go
+++ b/pkg/cmd/cmd_suite_test.go
@@ -51,6 +51,7 @@ var _ = BeforeSuite(func() {
 	Expect(os.MkdirAll(sessionDir, os.ModePerm))
 	targetFile = filepath.Join(sessionDir, cmd.TargetFilename)
 	cfg = &config.Config{
+		Filename: configFile,
 		Gardens: []config.Garden{{
 			Name:       "foo",
 			Kubeconfig: "/not/a/real/garden-foo/kubeconfig",
@@ -59,7 +60,7 @@ var _ = BeforeSuite(func() {
 			Kubeconfig: "/not/a/real/garden-bar/kubeconfig",
 		}},
 	}
-	Expect(cfg.SaveToFile(configFile)).To(Succeed())
+	Expect(cfg.Save()).To(Succeed())
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -172,8 +172,12 @@ var _ = Describe("Gardenctl command", func() {
 			clientProvider := targetmocks.NewMockClientProvider(ctrl)
 
 			// ensure the clientprovider provides the proper clients to the manager
-			clientProvider.EXPECT().FromFile(cfg.Gardens[0].Kubeconfig).Return(gardenClient1, nil).AnyTimes()
-			clientProvider.EXPECT().FromFile(cfg.Gardens[1].Kubeconfig).Return(gardenClient2, nil).AnyTimes()
+			clientConfig1, err := cfg.ClientConfig(gardenName1)
+			Expect(err).ToNot(HaveOccurred())
+			clientProvider.EXPECT().FromClientConfig(gomock.Eq(clientConfig1)).Return(gardenClient1, nil).AnyTimes()
+			clientConfig2, err := cfg.ClientConfig(gardenName2)
+			Expect(err).ToNot(HaveOccurred())
+			clientProvider.EXPECT().FromClientConfig(gomock.Eq(clientConfig2)).Return(gardenClient2, nil).AnyTimes()
 
 			currentTarget := target.NewTarget(gardenName1, testProject1.Name, "", testShoot1.Name)
 			targetProvider := fake.NewFakeTargetProvider(currentTarget)

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
-	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
@@ -62,82 +61,4 @@ func getConfiguration(f util.Factory) (*config.Config, error) {
 	}
 
 	return config, nil
-}
-
-// NewCmdConfigView returns a new (config) view command.
-func NewCmdConfigView(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
-	use := "view"
-	o := &options{
-		Options: base.Options{
-			IOStreams: ioStreams,
-		},
-		Command: use,
-	}
-	cmd := &cobra.Command{
-		Use:   use,
-		Short: "Print the gardenctl configuration",
-		RunE:  base.WrapRunE(o, f),
-	}
-
-	o.AddFlags(cmd.Flags())
-
-	return cmd
-}
-
-// NewCmdConfigSetGarden returns a new (config) set-garden command.
-func NewCmdConfigSetGarden(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
-	use := "set-garden"
-	o := &options{
-		Options: base.Options{
-			IOStreams: ioStreams,
-		},
-		Command: use,
-	}
-	cmd := &cobra.Command{
-		Use:   use,
-		Short: "modify or add Garden to gardenctl configuration",
-		Long:  "Modify or add Garden to gardenctl configuration. E.g. \"gardenctl config set-garden my-garden --kubeconfig ~/.kube/kubeconfig.yaml\" to configure or add a garden with identity 'my-garden'",
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			suggestions, err := validGardenArgsFunction(f, args)
-			if err != nil {
-				fmt.Fprintln(o.IOStreams.ErrOut, err.Error())
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			}
-
-			return util.FilterStringsByPrefix(toComplete, suggestions), cobra.ShellCompDirectiveNoFileComp
-		},
-		RunE: base.WrapRunE(o, f),
-	}
-
-	o.AddFlags(cmd.Flags())
-
-	return cmd
-}
-
-// NewCmdConfigDeleteGarden returns a new (config) delete-garden command.
-func NewCmdConfigDeleteGarden(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
-	use := "delete-garden"
-	o := &options{
-		Options: base.Options{
-			IOStreams: ioStreams,
-		},
-		Command: use,
-	}
-	cmd := &cobra.Command{
-		Use:   use,
-		Short: "delete Garden from gardenctl configuration",
-		Long:  "Delete Garden from gardenctl configuration. E.g. \"gardenctl config delete-garden my-garden\" to delete my-garden",
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			suggestions, err := validGardenArgsFunction(f, args)
-			if err != nil {
-				fmt.Fprintln(o.IOStreams.ErrOut, err.Error())
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			}
-
-			return util.FilterStringsByPrefix(toComplete, suggestions), cobra.ShellCompDirectiveNoFileComp
-		},
-		RunE: base.WrapRunE(o, f),
-	}
-
-	return cmd
 }

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -1,0 +1,133 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCmdConfig returns a new config command.
+func NewCmdConfig(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "modify gardenctl configuration file using subcommands",
+		Long: `Modify gardenctl files using subcommands like "gardenctl config set-garden my-garden"
+
+The loading order follows these rules:
+1. If the --config flag is set, then only that file is loaded.
+2. If $GCTL_HOME environment variable is set, then it is used as primary search path for the config file. The secondary search path of the home directory is ${HOME}/.garden/.
+3. If $GCTL_CONFIG_NAME environment variable is set, then it is used as config filename. Otherwise, the config filename will default to gardenctl-v2. The config name must not include the file extension`,
+	}
+
+	cmd.AddCommand(NewCmdConfigView(f, ioStreams))
+	cmd.AddCommand(NewCmdConfigSetGarden(f, ioStreams))
+	cmd.AddCommand(NewCmdConfigDeleteGarden(f, ioStreams))
+
+	return cmd
+}
+
+func validGardenArgsFunction(f util.Factory, args []string) ([]string, error) {
+	if len(args) > 0 {
+		return nil, nil
+	}
+
+	manager, err := f.Manager()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get target manager: %w", err)
+	}
+
+	config := manager.Configuration()
+	if config == nil {
+		return nil, errors.New("failed to get configuration")
+	}
+
+	return config.GardenNames(), nil
+}
+
+// NewCmdConfigView returns a new (config) view command.
+func NewCmdConfigView(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	use := "view"
+	o := &options{
+		Options: base.Options{
+			IOStreams: ioStreams,
+		},
+		Command: use,
+	}
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: "Print the gardenctl configuration",
+		RunE:  base.WrapRunE(o, f),
+	}
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// NewCmdConfigSetGarden returns a new (config) set-garden command.
+func NewCmdConfigSetGarden(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	use := "set-garden"
+	o := &options{
+		Options: base.Options{
+			IOStreams: ioStreams,
+		},
+		Command: use,
+	}
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: "modify or add Garden to gardenctl configuration",
+		Long:  "Modify or add Garden to gardenctl configuration. E.g. \"gardenctl config set-garden my-garden --kubeconfig ~/.kube/kubeconfig.yaml\" to configure or add a garden with identity 'my-garden'",
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			suggestions, err := validGardenArgsFunction(f, args)
+			if err != nil {
+				fmt.Fprintln(o.IOStreams.ErrOut, err.Error())
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			return util.FilterStringsByPrefix(toComplete, suggestions), cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: base.WrapRunE(o, f),
+	}
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// NewCmdConfigDeleteGarden returns a new (config) delete-garden command.
+func NewCmdConfigDeleteGarden(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	use := "delete-garden"
+	o := &options{
+		Options: base.Options{
+			IOStreams: ioStreams,
+		},
+		Command: use,
+	}
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: "delete Garden from gardenctl configuration",
+		Long:  "Delete Garden from gardenctl configuration. E.g. \"gardenctl config delete-garden my-garden\" to delete my-garden",
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			suggestions, err := validGardenArgsFunction(f, args)
+			if err != nil {
+				fmt.Fprintln(o.IOStreams.ErrOut, err.Error())
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			return util.FilterStringsByPrefix(toComplete, suggestions), cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: base.WrapRunE(o, f),
+	}
+
+	return cmd
+}

--- a/pkg/cmd/config/config.go
+++ b/pkg/cmd/config/config.go
@@ -1,5 +1,6 @@
 /*
 SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
 SPDX-License-Identifier: Apache-2.0
 */
 
@@ -9,11 +10,11 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/spf13/cobra"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
-
-	"github.com/spf13/cobra"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
 // NewCmdConfig returns a new config command.
@@ -41,6 +42,15 @@ func validGardenArgsFunction(f util.Factory, args []string) ([]string, error) {
 		return nil, nil
 	}
 
+	config, err := getConfiguration(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return config.GardenNames(), nil
+}
+
+func getConfiguration(f util.Factory) (*config.Config, error) {
 	manager, err := f.Manager()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get target manager: %w", err)
@@ -51,7 +61,7 @@ func validGardenArgsFunction(f util.Factory, args []string) ([]string, error) {
 		return nil, errors.New("failed to get configuration")
 	}
 
-	return config.GardenNames(), nil
+	return config, nil
 }
 
 // NewCmdConfigView returns a new (config) view command.

--- a/pkg/cmd/config/config_suite_test.go
+++ b/pkg/cmd/config/config_suite_test.go
@@ -111,12 +111,5 @@ func assertGarden(cfg *config.Config, garden *config.Garden) {
 func assertConfigHasBeenSaved(cfg *config.Config) {
 	c, err := config.LoadFromFile(cfg.Filename)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-	for i, g := range cfg.Gardens {
-		if len(g.Patterns) == 0 {
-			cfg.Gardens[i].Patterns = nil
-		}
-	}
-
 	ExpectWithOffset(1, c).To(BeEquivalentTo(cfg))
 }

--- a/pkg/cmd/config/config_suite_test.go
+++ b/pkg/cmd/config/config_suite_test.go
@@ -1,5 +1,6 @@
 /*
 SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
 SPDX-License-Identifier: Apache-2.0
 */
 

--- a/pkg/cmd/config/config_suite_test.go
+++ b/pkg/cmd/config/config_suite_test.go
@@ -89,7 +89,7 @@ var _ = AfterEach(func() {
 })
 
 func assertAllFlagNames(flags *pflag.FlagSet, expNames ...string) {
-	actNames := []string{}
+	var actNames []string
 
 	flags.VisitAll(func(flag *pflag.Flag) {
 		actNames = append(actNames, flag.Name)

--- a/pkg/cmd/config/config_suite_test.go
+++ b/pkg/cmd/config/config_suite_test.go
@@ -37,6 +37,7 @@ var (
 	manager       *targetmocks.MockManager
 	streams       util.IOStreams
 	out           *util.SafeBytesBuffer
+	errOut        *util.SafeBytesBuffer
 	patterns      []string
 )
 
@@ -76,7 +77,7 @@ var _ = BeforeEach(func() {
 			}},
 	}
 
-	streams, _, out, _ = util.NewTestIOStreams()
+	streams, _, out, errOut = util.NewTestIOStreams()
 	ctrl = gomock.NewController(GinkgoT())
 	factory = utilmocks.NewMockFactory(ctrl)
 	manager = targetmocks.NewMockManager(ctrl)

--- a/pkg/cmd/config/config_suite_test.go
+++ b/pkg/cmd/config/config_suite_test.go
@@ -1,0 +1,32 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config_test
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var gardenHomeDir string
+
+func TestCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Command Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	gardenHomeDir, err = os.MkdirTemp("", "gctlv2-*")
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	Expect(os.RemoveAll(gardenHomeDir)).To(Succeed())
+})

--- a/pkg/cmd/config/config_test.go
+++ b/pkg/cmd/config/config_test.go
@@ -1,0 +1,124 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config_test
+
+import (
+	"path/filepath"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+	utilmocks "github.com/gardener/gardenctl-v2/internal/util/mocks"
+	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
+	"github.com/gardener/gardenctl-v2/pkg/config"
+	targetmocks "github.com/gardener/gardenctl-v2/pkg/target/mocks"
+)
+
+var _ = Describe("Config Commands", func() {
+	const (
+		gardenIdentity1 = "fooGarden"
+		gardenIdentity2 = "barGarden"
+		gardenIdentity3 = "bazGarden"
+		gardenContext1  = "my-context"
+		kubeconfig      = "not/a/file"
+	)
+
+	var (
+		cfg      *config.Config
+		ctrl     *gomock.Controller
+		factory  *utilmocks.MockFactory
+		manager  *targetmocks.MockManager
+		streams  util.IOStreams
+		out      *util.SafeBytesBuffer
+		patterns []string
+	)
+
+	BeforeEach(func() {
+		patterns = []string{
+			"^shoot--(?P<project>.+)--(?P<shoot>.+)$",
+			"^namespace:(?P<namespace>[^/]+)$",
+		}
+		cfg = &config.Config{
+			Filename: filepath.Join(gardenHomeDir, "gardenctl-testconfig.yaml"),
+			Gardens: []config.Garden{
+				{
+					Name:       gardenIdentity1,
+					Kubeconfig: kubeconfig,
+					Context:    gardenContext1,
+				},
+				{
+					Name:       gardenIdentity2,
+					Kubeconfig: kubeconfig,
+					Patterns:   patterns,
+				}},
+		}
+
+		streams, _, out, _ = util.NewTestIOStreams()
+		ctrl = gomock.NewController(GinkgoT())
+		factory = utilmocks.NewMockFactory(ctrl)
+		manager = targetmocks.NewMockManager(ctrl)
+		manager.EXPECT().Configuration().Return(cfg)
+		factory.EXPECT().Manager().Return(manager, nil)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("should print configuration", func() {
+		cmd := cmdconfig.NewCmdConfigView(factory, streams)
+		Expect(cmd.RunE(cmd, nil)).To(Succeed())
+
+		Expect(out.String()).To(ContainSubstring("gardens"))
+		Expect(out.String()).To(ContainSubstring(gardenIdentity1))
+		Expect(out.String()).To(ContainSubstring(gardenIdentity2))
+		Expect(out.String()).To(ContainSubstring("matchPatterns"))
+		Expect(out.String()).To(ContainSubstring(patterns[1]))
+	})
+
+	It("should delete garden from configuration", func() {
+		_, err := cfg.Garden(gardenIdentity1)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(cfg.Gardens)).To(Equal(2))
+
+		cmd := cmdconfig.NewCmdConfigDeleteGarden(factory, streams)
+		Expect(cmd.RunE(cmd, []string{gardenIdentity1})).To(Succeed())
+
+		_, err = cfg.Garden(gardenIdentity1)
+		Expect(err).To(HaveOccurred())
+		Expect(len(cfg.Gardens)).To(Equal(1))
+	})
+
+	It("should add new garden to configuration", func() {
+		Expect(len(cfg.Gardens)).To(Equal(2))
+
+		cmd := cmdconfig.NewCmdConfigSetGarden(factory, streams)
+		Expect(cmd.RunE(cmd, []string{gardenIdentity3})).To(Succeed())
+
+		_, err := cfg.Garden(gardenIdentity3)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(cfg.Gardens)).To(Equal(3))
+	})
+
+	It("should modify an existing garden configuration", func() {
+		Expect(len(cfg.Gardens)).To(Equal(2))
+
+		cmd := cmdconfig.NewCmdConfigSetGarden(factory, streams)
+		pathToKubeconfig := "path/to/kubeconfig"
+		Expect(cmd.Flags().Set("kubeconfig", pathToKubeconfig)).To(Succeed())
+		Expect(cmd.RunE(cmd, []string{gardenIdentity1})).To(Succeed())
+
+		g, err := cfg.Garden(gardenIdentity1)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(cfg.Gardens)).To(Equal(2))
+		Expect(g.Name).To(Equal(gardenIdentity1))
+		Expect(g.Kubeconfig).To(Equal(pathToKubeconfig))
+		// Check that existing value does not get overwritten
+		Expect(g.Context).To(Equal(gardenContext1))
+	})
+})

--- a/pkg/cmd/config/config_test.go
+++ b/pkg/cmd/config/config_test.go
@@ -1,0 +1,158 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
+	"github.com/gardener/gardenctl-v2/pkg/config"
+)
+
+var _ = Describe("Config Command", func() {
+	Describe("Instance", func() {
+		var cmd *cobra.Command
+
+		BeforeEach(func() {
+			cmd = cmdconfig.NewCmdConfig(factory, streams)
+		})
+
+		It("should have 3 subcommands", func() {
+			Expect(cmd.Use).To(Equal("config"))
+			subCommands := []string{}
+			for _, c := range cmd.Commands() {
+				subCommands = append(subCommands, c.Name())
+			}
+			Expect(subCommands).To(Equal([]string{"delete-garden", "set-garden", "view"}))
+		})
+
+		Describe("Execute Subcommands", func() {
+			BeforeEach(func() {
+				factory.EXPECT().Manager().Return(manager, nil)
+				manager.EXPECT().Configuration().Return(cfg)
+			})
+
+			It("should successfully run subcommand view", func() {
+				cmd.SetArgs([]string{
+					"view",
+				})
+				Expect(cmd.Execute()).To(Succeed())
+
+				c := &config.Config{Filename: cfg.Filename}
+				Expect(yaml.Unmarshal([]byte(out.String()), c)).To(Succeed())
+				Expect(c).To(BeEquivalentTo(cfg))
+			})
+
+			It("should successfully run subcommand set-garden", func() {
+				garden := &config.Garden{
+					Name:       gardenIdentity3,
+					Kubeconfig: "/path/to/kubeconfig",
+					Context:    "default",
+				}
+				cmd.SetArgs([]string{
+					"set-garden",
+					gardenIdentity3,
+					"--kubeconfig=" + garden.Kubeconfig,
+					"--context=" + garden.Context,
+				})
+				Expect(cmd.Execute()).To(Succeed())
+
+				Expect(cfg.GardenNames()).To(Equal([]string{
+					gardenIdentity1,
+					gardenIdentity2,
+					gardenIdentity3,
+				}))
+				g, err := cfg.Garden(gardenIdentity3)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(g).To(BeEquivalentTo(garden))
+				c, err := config.LoadFromFile(cfg.Filename)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(c).To(BeEquivalentTo(cfg))
+			})
+
+			It("should successfully run subcommand delete-garden", func() {
+				cmd.SetArgs([]string{
+					"delete-garden",
+					gardenIdentity2,
+				})
+				Expect(cmd.Execute()).To(Succeed())
+
+				Expect(cfg.GardenNames()).To(Equal([]string{
+					gardenIdentity1,
+				}))
+				c, err := config.LoadFromFile(cfg.Filename)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(c).To(BeEquivalentTo(cfg))
+			})
+		})
+	})
+
+	Describe("Helper Functions", func() {
+		Describe("Completing the configured gardens", func() {
+			var validGardenArgsFunction cmdconfig.CobraValidArgsFunction
+
+			BeforeEach(func() {
+				validGardenArgsFunction = cmdconfig.ValidGardenArgsFunctionWrapper(factory, streams)
+			})
+
+			Context("when args are empty and no error occurs", func() {
+				BeforeEach(func() {
+					factory.EXPECT().Manager().Return(manager, nil)
+					manager.EXPECT().Configuration().Return(cfg)
+				})
+
+				It(`should return one garden for ""`, func() {
+					values, directive := validGardenArgsFunction(nil, nil, "")
+					Expect(values).To(Equal([]string{gardenIdentity1, gardenIdentity2}))
+					Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+				})
+
+				It(`should return one garden for "foo"`, func() {
+					values, directive := validGardenArgsFunction(nil, nil, "foo")
+					Expect(values).To(Equal([]string{gardenIdentity1}))
+					Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+				})
+			})
+
+			Context("when args are empty and config does not exist", func() {
+				It("should return nothing", func() {
+					factory.EXPECT().Manager().Return(manager, nil)
+					manager.EXPECT().Configuration().Return(nil)
+
+					values, directive := validGardenArgsFunction(nil, []string{}, "")
+					Expect(values).To(BeNil())
+					Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+					Expect(errOut.String()).To(Equal("failed to get configuration\n"))
+				})
+			})
+
+			Context("when args are empty and an error occurs", func() {
+				It("should return nothing", func() {
+					factory.EXPECT().Manager().Return(nil, errors.New("error"))
+
+					values, directive := validGardenArgsFunction(nil, []string{}, "")
+					Expect(values).To(BeNil())
+					Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+					Expect(errOut.String()).To(MatchRegexp("^failed to get target manager:"))
+				})
+			})
+
+			Context("when args are not empty", func() {
+				It("should return nothing", func() {
+					values, directive := validGardenArgsFunction(nil, []string{gardenIdentity1}, "")
+					Expect(values).To(BeNil())
+					Expect(directive).To(Equal(cobra.ShellCompDirectiveNoFileComp))
+				})
+			})
+		})
+	})
+})

--- a/pkg/cmd/config/delete_garden.go
+++ b/pkg/cmd/config/delete_garden.go
@@ -79,12 +79,14 @@ func (o *deleteGardenOptions) Validate() error {
 
 // Run executes the command
 func (o *deleteGardenOptions) Run(_ util.Factory) error {
-	err := o.Configuration.DeleteGarden(o.Name)
-	if err != nil {
-		return err
+	i, ok := o.Configuration.IndexOfGarden(o.Name)
+	if !ok {
+		return fmt.Errorf("garden %q is not defined in gardenctl configuration", o.Name)
 	}
 
-	err = o.Configuration.Save()
+	o.Configuration.Gardens = append(o.Configuration.Gardens[:i], o.Configuration.Gardens[i+1:]...)
+
+	err := o.Configuration.Save()
 	if err != nil {
 		return fmt.Errorf("failed to delete garden from configuration: %w", err)
 	}

--- a/pkg/cmd/config/delete_garden.go
+++ b/pkg/cmd/config/delete_garden.go
@@ -26,19 +26,11 @@ func NewCmdConfigDeleteGarden(f util.Factory, ioStreams util.IOStreams) *cobra.C
 		},
 	}
 	cmd := &cobra.Command{
-		Use:   "delete-garden",
-		Short: "delete Garden from gardenctl configuration",
-		Long:  "Delete Garden from gardenctl configuration. E.g. \"gardenctl config delete-garden my-garden\" to delete my-garden",
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			suggestions, err := validGardenArgsFunction(f, args)
-			if err != nil {
-				fmt.Fprintln(o.IOStreams.ErrOut, err.Error())
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			}
-
-			return util.FilterStringsByPrefix(toComplete, suggestions), cobra.ShellCompDirectiveNoFileComp
-		},
-		RunE: base.WrapRunE(o, f),
+		Use:               "delete-garden",
+		Short:             "delete Garden from gardenctl configuration",
+		Long:              "Delete Garden from gardenctl configuration. E.g. \"gardenctl config delete-garden my-garden\" to delete my-garden",
+		ValidArgsFunction: validGardenArgsFunctionWrapper(f, ioStreams),
+		RunE:              base.WrapRunE(o, f),
 	}
 
 	return cmd

--- a/pkg/cmd/config/delete_garden.go
+++ b/pkg/cmd/config/delete_garden.go
@@ -54,14 +54,9 @@ type deleteGardenOptions struct {
 
 // Complete adapts from the command line args to the data required.
 func (o *deleteGardenOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
-	manager, err := f.Manager()
+	config, err := getConfiguration(f)
 	if err != nil {
-		return fmt.Errorf("failed to get target manager: %w", err)
-	}
-
-	config := manager.Configuration()
-	if config == nil {
-		return errors.New("failed to get configuration")
+		return err
 	}
 
 	o.Configuration = config

--- a/pkg/cmd/config/delete_garden.go
+++ b/pkg/cmd/config/delete_garden.go
@@ -1,0 +1,100 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/config"
+)
+
+// NewCmdConfigDeleteGarden returns a new (config) delete-garden command.
+func NewCmdConfigDeleteGarden(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	o := &deleteGardenOptions{
+		Options: base.Options{
+			IOStreams: ioStreams,
+		},
+	}
+	cmd := &cobra.Command{
+		Use:   "delete-garden",
+		Short: "delete Garden from gardenctl configuration",
+		Long:  "Delete Garden from gardenctl configuration. E.g. \"gardenctl config delete-garden my-garden\" to delete my-garden",
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			suggestions, err := validGardenArgsFunction(f, args)
+			if err != nil {
+				fmt.Fprintln(o.IOStreams.ErrOut, err.Error())
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			return util.FilterStringsByPrefix(toComplete, suggestions), cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: base.WrapRunE(o, f),
+	}
+
+	return cmd
+}
+
+type deleteGardenOptions struct {
+	base.Options
+	// Configuration is the gardenctl configuration
+	Configuration *config.Config
+	// Name is a unique name of this Garden that can be used to target this Garden
+	Name string
+}
+
+// Complete adapts from the command line args to the data required.
+func (o *deleteGardenOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+	manager, err := f.Manager()
+	if err != nil {
+		return fmt.Errorf("failed to get target manager: %w", err)
+	}
+
+	config := manager.Configuration()
+	if config == nil {
+		return errors.New("failed to get configuration")
+	}
+
+	o.Configuration = config
+
+	if len(args) > 0 {
+		o.Name = strings.TrimSpace(args[0])
+	}
+
+	return nil
+}
+
+// Validate validates the provided options
+func (o *deleteGardenOptions) Validate() error {
+	if o.Name == "" {
+		return errors.New("garden identity is required")
+	}
+
+	return nil
+}
+
+// Run executes the command
+func (o *deleteGardenOptions) Run(_ util.Factory) error {
+	err := o.Configuration.DeleteGarden(o.Name)
+	if err != nil {
+		return err
+	}
+
+	err = o.Configuration.Save()
+	if err != nil {
+		return fmt.Errorf("failed to delete garden from configuration: %w", err)
+	}
+
+	fmt.Fprintf(o.IOStreams.Out, "Successfully deleted garden %q\n", o.Name)
+
+	return nil
+}

--- a/pkg/cmd/config/delete_garden_test.go
+++ b/pkg/cmd/config/delete_garden_test.go
@@ -18,38 +18,6 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
-var _ = Describe("Config Command - DeleteGarden", func() {
-	BeforeEach(func() {
-		manager.EXPECT().Configuration().Return(cfg)
-		factory.EXPECT().Manager().Return(manager, nil)
-	})
-
-	It("should delete garden from configuration", func() {
-		_, err := cfg.Garden(gardenIdentity1)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(cfg.Gardens)).To(Equal(2))
-
-		cmd := cmdconfig.NewCmdConfigDeleteGarden(factory, streams)
-		Expect(cmd.RunE(cmd, []string{gardenIdentity1})).To(Succeed())
-
-		_, err = cfg.Garden(gardenIdentity1)
-		Expect(err).To(HaveOccurred())
-		Expect(len(cfg.Gardens)).To(Equal(1))
-	})
-})
-
-var _ = Describe("Config Command - DeleteGarden Options", func() {
-	DescribeTable("Validating options",
-		func(name string, matcher types.GomegaMatcher) {
-			o := cmdconfig.NewDeleteGardenOptions()
-			o.Name = name
-			Expect(o.Validate()).To(matcher)
-		},
-		Entry("when garden is foo", "foo", Succeed()),
-		Entry("when garden empty", "", Not(Succeed())),
-	)
-})
-
 var _ = Describe("Config Subcommand DeleteGarden", func() {
 	Describe("Instance", func() {
 		var cmd *cobra.Command

--- a/pkg/cmd/config/delete_garden_test.go
+++ b/pkg/cmd/config/delete_garden_test.go
@@ -75,10 +75,10 @@ var _ = Describe("Config Subcommand DeleteGarden", func() {
 		Describe("Run", func() {
 			BeforeEach(func() {
 				options.Configuration = cfg
-				options.Name = gardenIdentity1
 			})
 
 			It("should delete garden from configuration", func() {
+				options.Name = gardenIdentity1
 				Expect(options.Run(nil)).To(Succeed())
 
 				assertGardenNames(cfg, gardenIdentity2)
@@ -92,6 +92,7 @@ var _ = Describe("Config Subcommand DeleteGarden", func() {
 			})
 
 			It("should fail when the filename is invalid", func() {
+				options.Name = gardenIdentity1
 				options.Configuration.Filename = string([]byte{0})
 				Expect(options.Run(nil)).To(MatchError(MatchRegexp("^failed to delete garden")))
 			})

--- a/pkg/cmd/config/delete_garden_test.go
+++ b/pkg/cmd/config/delete_garden_test.go
@@ -11,8 +11,11 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
+	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
 var _ = Describe("Config Command - DeleteGarden", func() {
@@ -45,4 +48,93 @@ var _ = Describe("Config Command - DeleteGarden Options", func() {
 		Entry("when garden is foo", "foo", Succeed()),
 		Entry("when garden empty", "", Not(Succeed())),
 	)
+})
+
+var _ = Describe("Config Subcommand DeleteGarden", func() {
+	Describe("Instance", func() {
+		var cmd *cobra.Command
+
+		BeforeEach(func() {
+			cmd = cmdconfig.NewCmdConfigDeleteGarden(factory, streams)
+		})
+
+		It("should have Use, ValidArgsFunction and no Flags", func() {
+			Expect(cmd.Use).To(Equal("delete-garden"))
+			Expect(cmd.ValidArgsFunction).NotTo(BeNil())
+			Expect(cmd.ValidArgs).To(BeNil())
+			hasFlags := false
+			cmd.Flags().VisitAll(func(flag *pflag.Flag) { hasFlags = true })
+			Expect(hasFlags).To(BeFalse())
+		})
+	})
+
+	Describe("Options", func() {
+		var options *cmdconfig.DeleteGardenOptions
+
+		BeforeEach(func() {
+			options = cmdconfig.NewDeleteGardenOptions()
+			options.IOStreams = streams
+		})
+
+		Describe("Complete", func() {
+			Context("when getting configuration fails", func() {
+				It("should fail", func() {
+					factory.EXPECT().Manager().Return(manager, nil)
+					manager.EXPECT().Configuration().Return(nil)
+					Expect(options.Complete(factory, nil, nil)).To(MatchError("failed to get configuration"))
+				})
+			})
+
+			Context("when getting configuration succeeds", func() {
+				It("should succeed", func() {
+					factory.EXPECT().Manager().Return(manager, nil)
+					manager.EXPECT().Configuration().Return(cfg)
+					Expect(options.Complete(factory, nil, []string{" garden "})).To(Succeed())
+					Expect(options.Configuration).To(BeIdenticalTo(cfg))
+					Expect(options.Name).To(Equal("garden"))
+				})
+			})
+		})
+
+		Describe("Validate", func() {
+			DescribeTable("Validating Name Argument",
+				func(name string, matcher types.GomegaMatcher) {
+					o := cmdconfig.NewDeleteGardenOptions()
+					o.Name = name
+					Expect(o.Validate()).To(matcher)
+				},
+				Entry("when garden is foo", "foo", Succeed()),
+				Entry("when garden empty", "", MatchError("garden identity is required")),
+			)
+		})
+
+		Describe("Run", func() {
+			BeforeEach(func() {
+				options.Configuration = cfg
+				options.Name = gardenIdentity1
+			})
+
+			It("should delete garden from configuration", func() {
+				Expect(options.Run(nil)).To(Succeed())
+
+				Expect(cfg.GardenNames()).To(Equal([]string{
+					gardenIdentity2,
+				}))
+				c, err := config.LoadFromFile(cfg.Filename)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(c).To(BeEquivalentTo(cfg))
+				Expect(out.String()).To(MatchRegexp("^Successfully deleted garden"))
+			})
+
+			It("should fail when the garden does not exist", func() {
+				options.Name = gardenIdentity3
+				Expect(options.Run(nil)).To(MatchError(MatchRegexp(`^garden ".*" is not defined`)))
+			})
+
+			It("should fail when the filename is invalid", func() {
+				options.Configuration.Filename = string([]byte{0})
+				Expect(options.Run(nil)).To(MatchError(MatchRegexp("^failed to delete garden")))
+			})
+		})
+	})
 })

--- a/pkg/cmd/config/delete_garden_test.go
+++ b/pkg/cmd/config/delete_garden_test.go
@@ -15,31 +15,30 @@ import (
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
 )
 
-var _ = Describe("Config Command - View Options", func() {
-	Describe("Validating options", func() {
-		It("should succeed", func() {
-			o := cmdconfig.NewOptions("view")
-			Expect(o.Validate()).To(Succeed())
-		})
+var _ = Describe("Config Command - DeleteGarden", func() {
+	BeforeEach(func() {
+		manager.EXPECT().Configuration().Return(cfg)
+		factory.EXPECT().Manager().Return(manager, nil)
 	})
-})
 
-var _ = Describe("Config Command - SetGarden Options", func() {
-	DescribeTable("Validating options",
-		func(name string, matcher types.GomegaMatcher) {
-			o := cmdconfig.NewOptions("set-garden")
-			o.Name = name
-			Expect(o.Validate()).To(matcher)
-		},
-		Entry("when garden is foo", "foo", Succeed()),
-		Entry("when garden empty", "", Not(Succeed())),
-	)
+	It("should delete garden from configuration", func() {
+		_, err := cfg.Garden(gardenIdentity1)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(cfg.Gardens)).To(Equal(2))
+
+		cmd := cmdconfig.NewCmdConfigDeleteGarden(factory, streams)
+		Expect(cmd.RunE(cmd, []string{gardenIdentity1})).To(Succeed())
+
+		_, err = cfg.Garden(gardenIdentity1)
+		Expect(err).To(HaveOccurred())
+		Expect(len(cfg.Gardens)).To(Equal(1))
+	})
 })
 
 var _ = Describe("Config Command - DeleteGarden Options", func() {
 	DescribeTable("Validating options",
 		func(name string, matcher types.GomegaMatcher) {
-			o := cmdconfig.NewOptions("delete-garden")
+			o := cmdconfig.NewDeleteGardenOptions()
 			o.Name = name
 			Expect(o.Validate()).To(matcher)
 		},

--- a/pkg/cmd/config/delete_garden_test.go
+++ b/pkg/cmd/config/delete_garden_test.go
@@ -12,10 +12,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
-	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
 var _ = Describe("Config Subcommand DeleteGarden", func() {
@@ -30,9 +28,7 @@ var _ = Describe("Config Subcommand DeleteGarden", func() {
 			Expect(cmd.Use).To(Equal("delete-garden"))
 			Expect(cmd.ValidArgsFunction).NotTo(BeNil())
 			Expect(cmd.ValidArgs).To(BeNil())
-			hasFlags := false
-			cmd.Flags().VisitAll(func(flag *pflag.Flag) { hasFlags = true })
-			Expect(hasFlags).To(BeFalse())
+			assertAllFlagNames(cmd.Flags())
 		})
 	})
 
@@ -85,12 +81,8 @@ var _ = Describe("Config Subcommand DeleteGarden", func() {
 			It("should delete garden from configuration", func() {
 				Expect(options.Run(nil)).To(Succeed())
 
-				Expect(cfg.GardenNames()).To(Equal([]string{
-					gardenIdentity2,
-				}))
-				c, err := config.LoadFromFile(cfg.Filename)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(c).To(BeEquivalentTo(cfg))
+				assertGardenNames(cfg, gardenIdentity2)
+				assertConfigHasBeenSaved(cfg)
 				Expect(out.String()).To(MatchRegexp("^Successfully deleted garden"))
 			})
 

--- a/pkg/cmd/config/export_test.go
+++ b/pkg/cmd/config/export_test.go
@@ -10,15 +10,38 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 )
 
-type TestOptions struct {
-	options
+type ViewOptions struct {
+	viewOptions
 }
 
-func NewOptions(cmd string) *TestOptions {
-	return &TestOptions{
-		options: options{
+func NewViewOptions() *ViewOptions {
+	return &ViewOptions{
+		viewOptions: viewOptions{
 			Options: base.Options{},
-			Command: cmd,
+		},
+	}
+}
+
+type SetGardenOptions struct {
+	setGardenOptions
+}
+
+func NewSetGardenOptions() *SetGardenOptions {
+	return &SetGardenOptions{
+		setGardenOptions: setGardenOptions{
+			Options: base.Options{},
+		},
+	}
+}
+
+type DeleteGardenOptions struct {
+	deleteGardenOptions
+}
+
+func NewDeleteGardenOptions() *DeleteGardenOptions {
+	return &DeleteGardenOptions{
+		deleteGardenOptions: deleteGardenOptions{
+			Options: base.Options{},
 		},
 	}
 }

--- a/pkg/cmd/config/export_test.go
+++ b/pkg/cmd/config/export_test.go
@@ -10,6 +10,10 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 )
 
+var ValidGardenArgsFunctionWrapper = validGardenArgsFunctionWrapper
+
+type CobraValidArgsFunction cobraValidArgsFunction
+
 type ViewOptions struct {
 	viewOptions
 }

--- a/pkg/cmd/config/export_test.go
+++ b/pkg/cmd/config/export_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 )
 
-var ValidGardenArgsFunctionWrapper = validGardenArgsFunctionWrapper
+var (
+	ValidGardenArgsFunctionWrapper = validGardenArgsFunctionWrapper
+	ValidatePatterns               = validatePatterns
+)
 
 type CobraValidArgsFunction cobraValidArgsFunction
 

--- a/pkg/cmd/config/export_test.go
+++ b/pkg/cmd/config/export_test.go
@@ -1,0 +1,35 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+)
+
+type TestOptions struct {
+	options
+	out *util.SafeBytesBuffer
+}
+
+func NewOptions(cmd string) *TestOptions {
+	streams, _, out, _ := util.NewTestIOStreams()
+
+	return &TestOptions{
+		options: options{
+			Options: base.Options{
+				IOStreams: streams,
+			},
+			Command: cmd,
+		},
+		out: out,
+	}
+}
+
+func (o *TestOptions) String() string {
+	return o.out.String()
+}

--- a/pkg/cmd/config/export_test.go
+++ b/pkg/cmd/config/export_test.go
@@ -7,29 +7,18 @@ SPDX-License-Identifier: Apache-2.0
 package config
 
 import (
-	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 )
 
 type TestOptions struct {
 	options
-	out *util.SafeBytesBuffer
 }
 
 func NewOptions(cmd string) *TestOptions {
-	streams, _, out, _ := util.NewTestIOStreams()
-
 	return &TestOptions{
 		options: options{
-			Options: base.Options{
-				IOStreams: streams,
-			},
+			Options: base.Options{},
 			Command: cmd,
 		},
-		out: out,
 	}
-}
-
-func (o *TestOptions) String() string {
-	return o.out.String()
 }

--- a/pkg/cmd/config/options.go
+++ b/pkg/cmd/config/options.go
@@ -1,5 +1,6 @@
 /*
 SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
 SPDX-License-Identifier: Apache-2.0
 */
 
@@ -42,14 +43,9 @@ type options struct {
 
 // Complete adapts from the command line args to the data required.
 func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
-	manager, err := f.Manager()
+	config, err := getConfiguration(f)
 	if err != nil {
-		return fmt.Errorf("failed to get target manager: %w", err)
-	}
-
-	config := manager.Configuration()
-	if config == nil {
-		return errors.New("failed to get configuration")
+		return err
 	}
 
 	o.Configuration = config

--- a/pkg/cmd/config/options.go
+++ b/pkg/cmd/config/options.go
@@ -1,0 +1,169 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/component-base/cli/flag"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/config"
+)
+
+// Options is a struct to support all config subcommands
+type options struct {
+	base.Options
+	// Configuration is the gardenctl configuration
+	Configuration *config.Config
+	// Command is the name of the config command
+	Command string
+	// Name is a unique name of this Garden that can be used to target this Garden
+	Name string
+	// KubeconfigFlag is the path to the kubeconfig file of the Garden cluster
+	KubeconfigFlag flag.StringFlag
+	// ContextFlag Overrides the current-context of the garden cluster kubeconfig
+	// +optional
+	ContextFlag flag.StringFlag
+	// Patterns is a list of regex patterns that can be defined to use custom input formats for targeting
+	// Use named capturing groups to match target values.
+	// Supported capturing groups: project, namespace, shoot
+	// +optional
+	Patterns []string
+}
+
+// Complete adapts from the command line args to the data required.
+func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+	manager, err := f.Manager()
+	if err != nil {
+		return fmt.Errorf("failed to get target manager: %w", err)
+	}
+
+	config := manager.Configuration()
+	if config == nil {
+		return errors.New("failed to get configuration")
+	}
+
+	o.Configuration = config
+
+	switch o.Command {
+	case "set-garden", "delete-garden":
+		if len(args) > 0 {
+			o.Name = strings.TrimSpace(args[0])
+		}
+	case "view":
+		if o.Output == "" {
+			o.Output = "yaml"
+		}
+	}
+
+	return nil
+}
+
+// Validate validates the provided options
+func (o *options) Validate() error {
+	switch o.Command {
+	case "set-garden", "delete-garden":
+		if o.Name == "" {
+			return errors.New("garden identity is required")
+		}
+	case "view":
+		return o.Options.Validate()
+	}
+
+	return nil
+}
+
+// AddFlags adds flags to adjust the output to a cobra command
+func (o *options) AddFlags(flags *pflag.FlagSet) {
+	switch o.Command {
+	case "set-garden":
+		flags.Var(&o.KubeconfigFlag, "kubeconfig", "path to kubeconfig file for this Garden cluster")
+		flags.Var(&o.ContextFlag, "context", "override the current-context of the garden cluster kubeconfig")
+		flags.StringArrayVar(&o.Patterns, "pattern", nil, `define regex match patterns for this garden for custom input formats for targeting.
+Use named capturing groups to match target values.
+Supported capturing groups: project, namespace, shoot.
+Note that if you set this flag it will overwrite the pattern list in the config file.
+You may specify any number of extra patterns.
+Example: ^((?Pmy-garden[^/]+)/)?shoot--(?P<project>.+)--(?P<shoot>.+)$`)
+	case "delete-garden":
+		// no flags
+	case "view":
+		o.Options.AddFlags(flags)
+	}
+}
+
+// Run executes the command
+func (o *options) Run(_ util.Factory) error {
+	switch o.Command {
+	case "set-garden":
+		return o.runSetGarden()
+	case "delete-garden":
+		return o.runDeleteGarden()
+	case "view":
+		return o.runView()
+	}
+
+	return nil
+}
+
+func (o *options) runSetGarden() error {
+	garden, err := o.Configuration.Garden(o.Name)
+	if err == nil {
+		if o.KubeconfigFlag.Provided() {
+			garden.Kubeconfig = o.KubeconfigFlag.Value()
+		}
+
+		if o.ContextFlag.Provided() {
+			garden.Context = o.ContextFlag.Value()
+		}
+
+		if o.Patterns != nil {
+			firstPattern := o.Patterns[0]
+			if len(firstPattern) > 0 {
+				garden.Patterns = o.Patterns
+			} else {
+				garden.Patterns = []string{}
+			}
+		}
+	} else {
+		o.Configuration.Gardens = append(o.Configuration.Gardens, config.Garden{
+			Name:       o.Name,
+			Kubeconfig: o.KubeconfigFlag.Value(),
+			Context:    o.ContextFlag.Value(),
+			Patterns:   o.Patterns,
+		})
+	}
+
+	err = o.Configuration.Save()
+	if err != nil {
+		return fmt.Errorf("failed to configure garden: %w", err)
+	}
+
+	fmt.Fprintf(o.IOStreams.Out, "Successfully configured garden %q\n", o.Name)
+
+	return nil
+}
+
+func (o *options) runDeleteGarden() error {
+	err := o.Configuration.DeleteGarden(o.Name)
+	if err != nil {
+		return fmt.Errorf("failed to delete garden from configuration: %w", err)
+	}
+
+	fmt.Fprintf(o.IOStreams.Out, "Successfully deleted garden %q\n", o.Name)
+
+	return nil
+}
+
+func (o *options) runView() error {
+	return o.PrintObject(o.Configuration)
+}

--- a/pkg/cmd/config/options.go
+++ b/pkg/cmd/config/options.go
@@ -156,6 +156,11 @@ func (o *options) runSetGarden() error {
 func (o *options) runDeleteGarden() error {
 	err := o.Configuration.DeleteGarden(o.Name)
 	if err != nil {
+		return err
+	}
+
+	err = o.Configuration.Save()
+	if err != nil {
 		return fmt.Errorf("failed to delete garden from configuration: %w", err)
 	}
 

--- a/pkg/cmd/config/options_test.go
+++ b/pkg/cmd/config/options_test.go
@@ -1,0 +1,32 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+
+	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
+)
+
+var _ = Describe("Config Commands - Options", func() {
+	DescribeTable("Validation of config subcommand",
+		func(cmd string, name string, matcher types.GomegaMatcher) {
+			o := cmdconfig.NewOptions(cmd)
+			o.Name = name
+			Expect(o.Validate()).To(matcher)
+		},
+		Entry("for command view and garden foo", "view", "foo", Succeed()),
+		Entry("for command view and no garden", "view", "", Succeed()),
+		Entry("for command set-garden and garden foo", "set-garden", "foo", Succeed()),
+		Entry("for command set-garden and no garden", "set-garden", "", Not(Succeed())),
+		Entry("for command delete-garden and garden foo", "delete-garden", "foo", Succeed()),
+		Entry("for command delete-garden and no garden", "delete-garden", "", Not(Succeed())),
+	)
+})

--- a/pkg/cmd/config/options_test.go
+++ b/pkg/cmd/config/options_test.go
@@ -15,18 +15,35 @@ import (
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
 )
 
-var _ = Describe("Config Commands - Options", func() {
-	DescribeTable("Validation of config subcommand",
-		func(cmd string, name string, matcher types.GomegaMatcher) {
-			o := cmdconfig.NewOptions(cmd)
+var _ = Describe("Config Command - View Options", func() {
+	Describe("Validating options", func() {
+		It("should succeed", func() {
+			o := cmdconfig.NewOptions("view")
+			Expect(o.Validate()).To(Succeed())
+		})
+	})
+})
+
+var _ = Describe("Config Command - SetGarden Options", func() {
+	DescribeTable("Validating options",
+		func(name string, matcher types.GomegaMatcher) {
+			o := cmdconfig.NewOptions("set-garden")
 			o.Name = name
 			Expect(o.Validate()).To(matcher)
 		},
-		Entry("for command view and garden foo", "view", "foo", Succeed()),
-		Entry("for command view and no garden", "view", "", Succeed()),
-		Entry("for command set-garden and garden foo", "set-garden", "foo", Succeed()),
-		Entry("for command set-garden and no garden", "set-garden", "", Not(Succeed())),
-		Entry("for command delete-garden and garden foo", "delete-garden", "foo", Succeed()),
-		Entry("for command delete-garden and no garden", "delete-garden", "", Not(Succeed())),
+		Entry("when garden is foo", "foo", Succeed()),
+		Entry("when garden empty", "", Not(Succeed())),
+	)
+})
+
+var _ = Describe("Config Command - DeleteGarden Options", func() {
+	DescribeTable("Validating options",
+		func(name string, matcher types.GomegaMatcher) {
+			o := cmdconfig.NewOptions("delete-garden")
+			o.Name = name
+			Expect(o.Validate()).To(matcher)
+		},
+		Entry("when garden is foo", "foo", Succeed()),
+		Entry("when garden empty", "", Not(Succeed())),
 	)
 })

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -20,13 +20,38 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
-// Options is a struct to support all config subcommands
-type options struct {
+// NewCmdConfigSetGarden returns a new (config) set-garden command.
+func NewCmdConfigSetGarden(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	o := &setGardenOptions{
+		Options: base.Options{
+			IOStreams: ioStreams,
+		},
+	}
+	cmd := &cobra.Command{
+		Use:   "set-garden",
+		Short: "modify or add Garden to gardenctl configuration",
+		Long:  "Modify or add Garden to gardenctl configuration. E.g. \"gardenctl config set-garden my-garden --kubeconfig ~/.kube/kubeconfig.yaml\" to configure or add a garden with identity 'my-garden'",
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			suggestions, err := validGardenArgsFunction(f, args)
+			if err != nil {
+				fmt.Fprintln(o.IOStreams.ErrOut, err.Error())
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+
+			return util.FilterStringsByPrefix(toComplete, suggestions), cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: base.WrapRunE(o, f),
+	}
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+type setGardenOptions struct {
 	base.Options
 	// Configuration is the gardenctl configuration
 	Configuration *config.Config
-	// Command is the name of the config command
-	Command string
 	// Name is a unique name of this Garden that can be used to target this Garden
 	Name string
 	// KubeconfigFlag is the path to the kubeconfig file of the Garden cluster
@@ -42,76 +67,49 @@ type options struct {
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
-	config, err := getConfiguration(f)
+func (o *setGardenOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+	manager, err := f.Manager()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get target manager: %w", err)
+	}
+
+	config := manager.Configuration()
+	if config == nil {
+		return errors.New("failed to get configuration")
 	}
 
 	o.Configuration = config
 
-	switch o.Command {
-	case "set-garden", "delete-garden":
-		if len(args) > 0 {
-			o.Name = strings.TrimSpace(args[0])
-		}
-	case "view":
-		if o.Output == "" {
-			o.Output = "yaml"
-		}
+	if len(args) > 0 {
+		o.Name = strings.TrimSpace(args[0])
 	}
 
 	return nil
 }
 
 // Validate validates the provided options
-func (o *options) Validate() error {
-	switch o.Command {
-	case "set-garden", "delete-garden":
-		if o.Name == "" {
-			return errors.New("garden identity is required")
-		}
-	case "view":
-		return o.Options.Validate()
+func (o *setGardenOptions) Validate() error {
+	if o.Name == "" {
+		return errors.New("garden identity is required")
 	}
 
 	return nil
 }
 
 // AddFlags adds flags to adjust the output to a cobra command
-func (o *options) AddFlags(flags *pflag.FlagSet) {
-	switch o.Command {
-	case "set-garden":
-		flags.Var(&o.KubeconfigFlag, "kubeconfig", "path to kubeconfig file for this Garden cluster")
-		flags.Var(&o.ContextFlag, "context", "override the current-context of the garden cluster kubeconfig")
-		flags.StringArrayVar(&o.Patterns, "pattern", nil, `define regex match patterns for this garden for custom input formats for targeting.
+func (o *setGardenOptions) AddFlags(flags *pflag.FlagSet) {
+	flags.Var(&o.KubeconfigFlag, "kubeconfig", "path to kubeconfig file for this Garden cluster")
+	flags.Var(&o.ContextFlag, "context", "override the current-context of the garden cluster kubeconfig")
+	flags.StringArrayVar(&o.Patterns, "pattern", nil, `define regex match patterns for this garden for custom input formats for targeting.
 Use named capturing groups to match target values.
 Supported capturing groups: project, namespace, shoot.
 Note that if you set this flag it will overwrite the pattern list in the config file.
 You may specify any number of extra patterns.
 Example: ^((?Pmy-garden[^/]+)/)?shoot--(?P<project>.+)--(?P<shoot>.+)$`)
-	case "delete-garden":
-		// no flags
-	case "view":
-		o.Options.AddFlags(flags)
-	}
 }
 
 // Run executes the command
-func (o *options) Run(_ util.Factory) error {
-	switch o.Command {
-	case "set-garden":
-		return o.runSetGarden()
-	case "delete-garden":
-		return o.runDeleteGarden()
-	case "view":
-		return o.runView()
-	}
-
-	return nil
-}
-
-func (o *options) runSetGarden() error {
+func (o *setGardenOptions) Run(_ util.Factory) error {
 	garden, err := o.Configuration.Garden(o.Name)
 	if err == nil {
 		if o.KubeconfigFlag.Provided() {
@@ -147,24 +145,4 @@ func (o *options) runSetGarden() error {
 	fmt.Fprintf(o.IOStreams.Out, "Successfully configured garden %q\n", o.Name)
 
 	return nil
-}
-
-func (o *options) runDeleteGarden() error {
-	err := o.Configuration.DeleteGarden(o.Name)
-	if err != nil {
-		return err
-	}
-
-	err = o.Configuration.Save()
-	if err != nil {
-		return fmt.Errorf("failed to delete garden from configuration: %w", err)
-	}
-
-	fmt.Fprintf(o.IOStreams.Out, "Successfully deleted garden %q\n", o.Name)
-
-	return nil
-}
-
-func (o *options) runView() error {
-	return o.PrintObject(o.Configuration)
 }

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -68,14 +68,9 @@ type setGardenOptions struct {
 
 // Complete adapts from the command line args to the data required.
 func (o *setGardenOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
-	manager, err := f.Manager()
+	config, err := getConfiguration(f)
 	if err != nil {
-		return fmt.Errorf("failed to get target manager: %w", err)
-	}
-
-	config := manager.Configuration()
-	if config == nil {
-		return errors.New("failed to get configuration")
+		return err
 	}
 
 	o.Configuration = config

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -28,19 +28,11 @@ func NewCmdConfigSetGarden(f util.Factory, ioStreams util.IOStreams) *cobra.Comm
 		},
 	}
 	cmd := &cobra.Command{
-		Use:   "set-garden",
-		Short: "modify or add Garden to gardenctl configuration",
-		Long:  "Modify or add Garden to gardenctl configuration. E.g. \"gardenctl config set-garden my-garden --kubeconfig ~/.kube/kubeconfig.yaml\" to configure or add a garden with identity 'my-garden'",
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			suggestions, err := validGardenArgsFunction(f, args)
-			if err != nil {
-				fmt.Fprintln(o.IOStreams.ErrOut, err.Error())
-				return nil, cobra.ShellCompDirectiveNoFileComp
-			}
-
-			return util.FilterStringsByPrefix(toComplete, suggestions), cobra.ShellCompDirectiveNoFileComp
-		},
-		RunE: base.WrapRunE(o, f),
+		Use:               "set-garden",
+		Short:             "modify or add Garden to gardenctl configuration",
+		Long:              "Modify or add Garden to gardenctl configuration. E.g. \"gardenctl config set-garden my-garden --kubeconfig ~/.kube/kubeconfig.yaml\" to configure or add a garden with identity 'my-garden'",
+		ValidArgsFunction: validGardenArgsFunctionWrapper(f, ioStreams),
+		RunE:              base.WrapRunE(o, f),
 	}
 
 	o.AddFlags(cmd.Flags())

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -97,7 +97,7 @@ Use named capturing groups to match target values.
 Supported capturing groups: project, namespace, shoot.
 Note that if you set this flag it will overwrite the pattern list in the config file.
 You may specify any number of extra patterns.
-Example: ^((?Pmy-garden[^/]+)/)?shoot--(?P<project>.+)--(?P<shoot>.+)$`)
+Example: ^(?:my-garden/)?shoot--(?P<project>.+)--(?P<shoot>.+)$`)
 }
 
 // Run executes the command

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -117,7 +117,7 @@ func (o *setGardenOptions) Run(_ util.Factory) error {
 			if len(firstPattern) > 0 {
 				garden.Patterns = o.Patterns
 			} else {
-				garden.Patterns = []string{}
+				garden.Patterns = nil
 			}
 		}
 	} else {

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
 	"github.com/gardener/gardenctl-v2/pkg/config"
@@ -137,36 +136,3 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 		})
 	})
 })
-
-func assertAllFlagNames(flags *pflag.FlagSet, expNames ...string) {
-	actNames := []string{}
-
-	flags.VisitAll(func(flag *pflag.Flag) {
-		actNames = append(actNames, flag.Name)
-	})
-
-	ExpectWithOffset(1, actNames).To(Equal(expNames))
-}
-
-func assertGardenNames(cfg *config.Config, names ...string) {
-	ExpectWithOffset(1, cfg.GardenNames()).To(Equal(names))
-}
-
-func assertGarden(cfg *config.Config, garden *config.Garden) {
-	g, err := cfg.Garden(garden.Name)
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-	ExpectWithOffset(1, g).To(BeEquivalentTo(garden))
-}
-
-func assertConfigHasBeenSaved(cfg *config.Config) {
-	c, err := config.LoadFromFile(cfg.Filename)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-	for i, g := range cfg.Gardens {
-		if len(g.Patterns) == 0 {
-			cfg.Gardens[i].Patterns = nil
-		}
-	}
-
-	ExpectWithOffset(1, c).To(BeEquivalentTo(cfg))
-}

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -11,8 +11,11 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
+	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
 var _ = Describe("Config Command - SetGarden", func() {
@@ -61,3 +64,156 @@ var _ = Describe("Config Command - SetGarden Options", func() {
 		Entry("when garden empty", "", Not(Succeed())),
 	)
 })
+
+var _ = Describe("Config Subcommand SetGarden", func() {
+	Describe("Instance", func() {
+		var cmd *cobra.Command
+
+		BeforeEach(func() {
+			cmd = cmdconfig.NewCmdConfigSetGarden(factory, streams)
+		})
+
+		It("should have Use, ValidArgsFunction and Flags", func() {
+			Expect(cmd.Use).To(Equal("set-garden"))
+			Expect(cmd.ValidArgsFunction).NotTo(BeNil())
+			Expect(cmd.ValidArgs).To(BeNil())
+			assertAllFlagNames(cmd.Flags(), "context", "kubeconfig", "pattern")
+		})
+	})
+
+	Describe("Options", func() {
+		var options *cmdconfig.SetGardenOptions
+
+		BeforeEach(func() {
+			options = cmdconfig.NewSetGardenOptions()
+			options.IOStreams = streams
+		})
+
+		Describe("Complete", func() {
+			Context("when getting configuration fails", func() {
+				It("should fail", func() {
+					factory.EXPECT().Manager().Return(manager, nil)
+					manager.EXPECT().Configuration().Return(nil)
+					Expect(options.Complete(factory, nil, nil)).To(MatchError("failed to get configuration"))
+				})
+			})
+
+			Context("when getting configuration succeeds", func() {
+				It("should succeed", func() {
+					factory.EXPECT().Manager().Return(manager, nil)
+					manager.EXPECT().Configuration().Return(cfg)
+					Expect(options.Complete(factory, nil, []string{" garden "})).To(Succeed())
+					Expect(options.Configuration).To(BeIdenticalTo(cfg))
+					Expect(options.Name).To(Equal("garden"))
+				})
+			})
+		})
+
+		Describe("Validate", func() {
+			DescribeTable("Validating Name Argument",
+				func(name string, matcher types.GomegaMatcher) {
+					o := cmdconfig.NewSetGardenOptions()
+					o.Name = name
+					Expect(o.Validate()).To(matcher)
+				},
+				Entry("when garden is foo", "foo", Succeed()),
+				Entry("when garden empty", "", MatchError("garden identity is required")),
+			)
+		})
+
+		Describe("Run", func() {
+			const pathToKubeconfig = "/path/to/kubeconfig"
+			const testContext = "test-context"
+			const testPattern = "test-pattern"
+
+			BeforeEach(func() {
+				options.Configuration = cfg
+			})
+
+			It("should add new garden to configuration", func() {
+				options.Name = gardenIdentity3
+				Expect(options.KubeconfigFlag.Set(pathToKubeconfig)).To(Succeed())
+				Expect(options.Run(nil)).To(Succeed())
+
+				assertGardenNames(cfg, gardenIdentity1, gardenIdentity2, gardenIdentity3)
+				assertGarden(cfg, &config.Garden{
+					Name:       gardenIdentity3,
+					Kubeconfig: pathToKubeconfig,
+				})
+				assertConfigHasBeenSaved(cfg)
+				Expect(out.String()).To(MatchRegexp("^Successfully configured garden"))
+			})
+
+			It("should modify an existing garden configuration", func() {
+				options.Name = gardenIdentity1
+				Expect(options.ContextFlag.Set(testContext)).To(Succeed())
+				options.Patterns = []string{testPattern}
+				Expect(options.Run(nil)).To(Succeed())
+
+				assertGardenNames(cfg, gardenIdentity1, gardenIdentity2)
+				assertGarden(cfg, &config.Garden{
+					Name:       gardenIdentity1,
+					Kubeconfig: kubeconfig,
+					Context:    testContext,
+					Patterns:   []string{testPattern},
+				})
+				assertConfigHasBeenSaved(cfg)
+				Expect(out.String()).To(MatchRegexp("^Successfully configured garden"))
+			})
+
+			It("should remove all patterns from an existing configuration", func() {
+				options.Name = gardenIdentity2
+				Expect(options.KubeconfigFlag.Set(pathToKubeconfig)).To(Succeed())
+				options.Patterns = []string{""}
+				Expect(options.Run(nil)).To(Succeed())
+
+				assertGardenNames(cfg, gardenIdentity1, gardenIdentity2)
+				assertGarden(cfg, &config.Garden{
+					Name:       gardenIdentity2,
+					Kubeconfig: pathToKubeconfig,
+					Patterns:   []string{},
+				})
+				assertConfigHasBeenSaved(cfg)
+				Expect(out.String()).To(MatchRegexp("^Successfully configured garden"))
+			})
+
+			It("should fail when the filename is invalid", func() {
+				options.Configuration.Filename = string([]byte{0})
+				Expect(options.Run(nil)).To(MatchError(MatchRegexp("^failed to configure garden")))
+			})
+		})
+	})
+})
+
+func assertAllFlagNames(flags *pflag.FlagSet, expNames ...string) {
+	actNames := []string{}
+
+	flags.VisitAll(func(flag *pflag.Flag) {
+		actNames = append(actNames, flag.Name)
+	})
+
+	ExpectWithOffset(1, actNames).To(Equal(expNames))
+}
+
+func assertGardenNames(cfg *config.Config, names ...string) {
+	ExpectWithOffset(1, cfg.GardenNames()).To(Equal(names))
+}
+
+func assertGarden(cfg *config.Config, garden *config.Garden) {
+	g, err := cfg.Garden(garden.Name)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, g).To(BeEquivalentTo(garden))
+}
+
+func assertConfigHasBeenSaved(cfg *config.Config) {
+	c, err := config.LoadFromFile(cfg.Filename)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	for i, g := range cfg.Gardens {
+		if len(g.Patterns) == 0 {
+			cfg.Gardens[i].Patterns = nil
+		}
+	}
+
+	ExpectWithOffset(1, c).To(BeEquivalentTo(cfg))
+}

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -138,7 +138,6 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 				assertGarden(cfg, &config.Garden{
 					Name:       gardenIdentity2,
 					Kubeconfig: pathToKubeconfig,
-					Patterns:   []string{},
 				})
 				assertConfigHasBeenSaved(cfg)
 				Expect(out.String()).To(MatchRegexp("^Successfully configured garden"))

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -71,6 +71,21 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 				Entry("when garden is foo", "foo", Succeed()),
 				Entry("when garden empty", "", MatchError("garden identity is required")),
 			)
+
+			DescribeTable("Validating Pattern Flag",
+				func(patterns []string, matcher types.GomegaMatcher) {
+					o := cmdconfig.NewSetGardenOptions()
+					o.Name = "foo"
+					o.Patterns = patterns
+					Expect(o.Validate()).To(matcher)
+				},
+				Entry("when patterns is nil", nil, Succeed()),
+				Entry("when 1st pattern is empty", []string{""}, Succeed()),
+				Entry("when 1st pattern is empty and 2nd pattern is not empty", []string{"", "foo"}, MatchError("pattern[0] must not be empty")),
+				Entry("when all patterns are valid", []string{"^shoot--(?P<project>.+)--(?P<shoot>.+)$`"}, Succeed()),
+				Entry("when a pattern is not a valid regular expression", []string{"("}, MatchError(MatchRegexp(`^pattern\[0\] is not a valid regular expression`))),
+				Entry("when a pattern has an invalid subexpression name", []string{"^shoot--(?P<cluster>.+)$`"}, MatchError("pattern[0] contains an invalid subexpression \"cluster\"")),
+			)
 		})
 
 		Describe("Run", func() {

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -8,48 +8,12 @@ package config_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
 )
-
-var _ = Describe("Config Command - View", func() {
-	BeforeEach(func() {
-		manager.EXPECT().Configuration().Return(cfg)
-		factory.EXPECT().Manager().Return(manager, nil)
-	})
-
-	It("should print configuration", func() {
-		cmd := cmdconfig.NewCmdConfigView(factory, streams)
-		Expect(cmd.RunE(cmd, nil)).To(Succeed())
-
-		Expect(out.String()).To(ContainSubstring("gardens"))
-		Expect(out.String()).To(ContainSubstring(gardenIdentity1))
-		Expect(out.String()).To(ContainSubstring(gardenIdentity2))
-		Expect(out.String()).To(ContainSubstring("matchPatterns"))
-		Expect(out.String()).To(ContainSubstring(patterns[1]))
-	})
-})
-
-var _ = Describe("Config Command - DeleteGarden", func() {
-	BeforeEach(func() {
-		manager.EXPECT().Configuration().Return(cfg)
-		factory.EXPECT().Manager().Return(manager, nil)
-	})
-
-	It("should delete garden from configuration", func() {
-		_, err := cfg.Garden(gardenIdentity1)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(cfg.Gardens)).To(Equal(2))
-
-		cmd := cmdconfig.NewCmdConfigDeleteGarden(factory, streams)
-		Expect(cmd.RunE(cmd, []string{gardenIdentity1})).To(Succeed())
-
-		_, err = cfg.Garden(gardenIdentity1)
-		Expect(err).To(HaveOccurred())
-		Expect(len(cfg.Gardens)).To(Equal(1))
-	})
-})
 
 var _ = Describe("Config Command - SetGarden", func() {
 	BeforeEach(func() {
@@ -84,4 +48,16 @@ var _ = Describe("Config Command - SetGarden", func() {
 		// Check that existing value does not get overwritten
 		Expect(g.Context).To(Equal(gardenContext1))
 	})
+})
+
+var _ = Describe("Config Command - SetGarden Options", func() {
+	DescribeTable("Validating options",
+		func(name string, matcher types.GomegaMatcher) {
+			o := cmdconfig.NewSetGardenOptions()
+			o.Name = name
+			Expect(o.Validate()).To(matcher)
+		},
+		Entry("when garden is foo", "foo", Succeed()),
+		Entry("when garden empty", "", Not(Succeed())),
+	)
 })

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -18,53 +18,6 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
-var _ = Describe("Config Command - SetGarden", func() {
-	BeforeEach(func() {
-		manager.EXPECT().Configuration().Return(cfg)
-		factory.EXPECT().Manager().Return(manager, nil)
-	})
-
-	It("should add new garden to configuration", func() {
-		Expect(len(cfg.Gardens)).To(Equal(2))
-
-		cmd := cmdconfig.NewCmdConfigSetGarden(factory, streams)
-		Expect(cmd.RunE(cmd, []string{gardenIdentity3})).To(Succeed())
-
-		_, err := cfg.Garden(gardenIdentity3)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(cfg.Gardens)).To(Equal(3))
-	})
-
-	It("should modify an existing garden configuration", func() {
-		Expect(len(cfg.Gardens)).To(Equal(2))
-
-		cmd := cmdconfig.NewCmdConfigSetGarden(factory, streams)
-		pathToKubeconfig := "path/to/kubeconfig"
-		Expect(cmd.Flags().Set("kubeconfig", pathToKubeconfig)).To(Succeed())
-		Expect(cmd.RunE(cmd, []string{gardenIdentity1})).To(Succeed())
-
-		g, err := cfg.Garden(gardenIdentity1)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(cfg.Gardens)).To(Equal(2))
-		Expect(g.Name).To(Equal(gardenIdentity1))
-		Expect(g.Kubeconfig).To(Equal(pathToKubeconfig))
-		// Check that existing value does not get overwritten
-		Expect(g.Context).To(Equal(gardenContext1))
-	})
-})
-
-var _ = Describe("Config Command - SetGarden Options", func() {
-	DescribeTable("Validating options",
-		func(name string, matcher types.GomegaMatcher) {
-			o := cmdconfig.NewSetGardenOptions()
-			o.Name = name
-			Expect(o.Validate()).To(matcher)
-		},
-		Entry("when garden is foo", "foo", Succeed()),
-		Entry("when garden empty", "", Not(Succeed())),
-	)
-})
-
 var _ = Describe("Config Subcommand SetGarden", func() {
 	Describe("Instance", func() {
 		var cmd *cobra.Command

--- a/pkg/cmd/config/view.go
+++ b/pkg/cmd/config/view.go
@@ -1,0 +1,68 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/config"
+)
+
+// NewCmdConfigView returns a new (config) view command.
+func NewCmdConfigView(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	o := &viewOptions{
+		Options: base.Options{
+			IOStreams: ioStreams,
+		},
+	}
+	cmd := &cobra.Command{
+		Use:   "view",
+		Short: "Print the gardenctl configuration",
+		RunE:  base.WrapRunE(o, f),
+	}
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+type viewOptions struct {
+	base.Options
+	// Configuration is the gardenctl configuration
+	Configuration *config.Config
+}
+
+// Complete adapts from the command line args to the data required.
+func (o *viewOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+	manager, err := f.Manager()
+	if err != nil {
+		return fmt.Errorf("failed to get target manager: %w", err)
+	}
+
+	config := manager.Configuration()
+	if config == nil {
+		return errors.New("failed to get configuration")
+	}
+
+	o.Configuration = config
+
+	if o.Output == "" {
+		o.Output = "yaml"
+	}
+
+	return nil
+}
+
+// Run executes the command
+func (o *viewOptions) Run(_ util.Factory) error {
+	return o.PrintObject(o.Configuration)
+}

--- a/pkg/cmd/config/view.go
+++ b/pkg/cmd/config/view.go
@@ -7,9 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package config
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
@@ -43,14 +40,9 @@ type viewOptions struct {
 
 // Complete adapts from the command line args to the data required.
 func (o *viewOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
-	manager, err := f.Manager()
+	config, err := getConfiguration(f)
 	if err != nil {
-		return fmt.Errorf("failed to get target manager: %w", err)
-	}
-
-	config := manager.Configuration()
-	if config == nil {
-		return errors.New("failed to get configuration")
+		return err
 	}
 
 	o.Configuration = config

--- a/pkg/cmd/config/view_test.go
+++ b/pkg/cmd/config/view_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Config Subcommand View", func() {
 
 		It("should have Use and Flags", func() {
 			Expect(cmd.Use).To(Equal("view"))
-			Expect(cmd.Flag("output")).NotTo(BeNil())
+			assertAllFlagNames(cmd.Flags(), "output")
 		})
 	})
 

--- a/pkg/cmd/config/view_test.go
+++ b/pkg/cmd/config/view_test.go
@@ -20,33 +20,6 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
-var _ = Describe("Config Command - View", func() {
-	BeforeEach(func() {
-		manager.EXPECT().Configuration().Return(cfg)
-		factory.EXPECT().Manager().Return(manager, nil)
-	})
-
-	It("should print configuration", func() {
-		cmd := cmdconfig.NewCmdConfigView(factory, streams)
-		Expect(cmd.RunE(cmd, nil)).To(Succeed())
-
-		Expect(out.String()).To(ContainSubstring("gardens"))
-		Expect(out.String()).To(ContainSubstring(gardenIdentity1))
-		Expect(out.String()).To(ContainSubstring(gardenIdentity2))
-		Expect(out.String()).To(ContainSubstring("matchPatterns"))
-		Expect(out.String()).To(ContainSubstring(patterns[1]))
-	})
-})
-
-var _ = Describe("Config Command - View Options", func() {
-	Describe("Validating options", func() {
-		It("should succeed", func() {
-			o := cmdconfig.NewViewOptions()
-			Expect(o.Validate()).To(Succeed())
-		})
-	})
-})
-
 var _ = Describe("Config Subcommand View", func() {
 	Describe("Instance", func() {
 		var cmd *cobra.Command
@@ -55,7 +28,7 @@ var _ = Describe("Config Subcommand View", func() {
 			cmd = cmdconfig.NewCmdConfigView(factory, streams)
 		})
 
-		It("should have ", func() {
+		It("should have Use and Flags", func() {
 			Expect(cmd.Use).To(Equal("view"))
 			Expect(cmd.Flag("output")).NotTo(BeNil())
 		})

--- a/pkg/cmd/config/view_test.go
+++ b/pkg/cmd/config/view_test.go
@@ -1,0 +1,41 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package config_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
+)
+
+var _ = Describe("Config Command - View", func() {
+	BeforeEach(func() {
+		manager.EXPECT().Configuration().Return(cfg)
+		factory.EXPECT().Manager().Return(manager, nil)
+	})
+
+	It("should print configuration", func() {
+		cmd := cmdconfig.NewCmdConfigView(factory, streams)
+		Expect(cmd.RunE(cmd, nil)).To(Succeed())
+
+		Expect(out.String()).To(ContainSubstring("gardens"))
+		Expect(out.String()).To(ContainSubstring(gardenIdentity1))
+		Expect(out.String()).To(ContainSubstring(gardenIdentity2))
+		Expect(out.String()).To(ContainSubstring("matchPatterns"))
+		Expect(out.String()).To(ContainSubstring(patterns[1]))
+	})
+})
+
+var _ = Describe("Config Command - View Options", func() {
+	Describe("Validating options", func() {
+		It("should succeed", func() {
+			o := cmdconfig.NewViewOptions()
+			Expect(o.Validate()).To(Succeed())
+		})
+	})
+})

--- a/pkg/cmd/config/view_test.go
+++ b/pkg/cmd/config/view_test.go
@@ -7,10 +7,17 @@ SPDX-License-Identifier: Apache-2.0
 package config_test
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
+	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
 var _ = Describe("Config Command - View", func() {
@@ -36,6 +43,83 @@ var _ = Describe("Config Command - View Options", func() {
 		It("should succeed", func() {
 			o := cmdconfig.NewViewOptions()
 			Expect(o.Validate()).To(Succeed())
+		})
+	})
+})
+
+var _ = Describe("Config Subcommand View", func() {
+	Describe("Instance", func() {
+		var cmd *cobra.Command
+
+		BeforeEach(func() {
+			cmd = cmdconfig.NewCmdConfigView(factory, streams)
+		})
+
+		It("should have ", func() {
+			Expect(cmd.Use).To(Equal("view"))
+			Expect(cmd.Flag("output")).NotTo(BeNil())
+		})
+	})
+
+	Describe("Options", func() {
+		var options *cmdconfig.ViewOptions
+
+		BeforeEach(func() {
+			options = cmdconfig.NewViewOptions()
+			options.IOStreams = streams
+		})
+
+		Describe("Complete", func() {
+			Context("when getting configuration fails", func() {
+				It("should fail", func() {
+					factory.EXPECT().Manager().Return(manager, nil)
+					manager.EXPECT().Configuration().Return(nil)
+					Expect(options.Complete(factory, nil, nil)).To(MatchError("failed to get configuration"))
+				})
+			})
+
+			Context("when getting configuration succeeds", func() {
+				It("should succeed", func() {
+					factory.EXPECT().Manager().Return(manager, nil)
+					manager.EXPECT().Configuration().Return(cfg)
+					Expect(options.Complete(factory, nil, nil)).To(Succeed())
+					Expect(options.Configuration).To(BeIdenticalTo(cfg))
+					Expect(options.Output).To(Equal("yaml"))
+				})
+			})
+		})
+
+		Describe("Validate", func() {
+			DescribeTable("Output Flag",
+				func(output string, matcher types.GomegaMatcher) {
+					options.Output = output
+					Expect(options.Validate()).To(matcher)
+				},
+				Entry("when output is yaml", "yaml", Succeed()),
+				Entry("when output is json", "json", Succeed()),
+				Entry("when output is empty", "", Succeed()),
+				Entry("when output is invalid", "invalid", Not(Succeed())),
+			)
+		})
+
+		Describe("Run", func() {
+			It("should print configuration in json format", func() {
+				options.Configuration = cfg
+				options.Output = "json"
+				Expect(options.Run(nil)).To(Succeed())
+
+				c := &config.Config{Filename: cfg.Filename}
+				Expect(json.Unmarshal([]byte(out.String()), c)).To(Succeed())
+				Expect(c).To(BeEquivalentTo(cfg))
+			})
+		})
+
+		Describe("AddFlags", func() {
+			It("should add the output flag", func() {
+				flags := &pflag.FlagSet{}
+				options.AddFlags(flags)
+				Expect(flags.Lookup("output")).NotTo(BeNil())
+			})
 		})
 	})
 })

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -224,7 +224,9 @@ var _ = Describe("SSH Command", func() {
 		ctrl = gomock.NewController(GinkgoT())
 
 		clientProvider = targetmocks.NewMockClientProvider(ctrl)
-		clientProvider.EXPECT().FromFile(gardenKubeconfigFile).Return(gardenClient, nil).AnyTimes()
+		clientConfig, err := cfg.ClientConfig(gardenName)
+		Expect(err).ToNot(HaveOccurred())
+		clientProvider.EXPECT().FromClientConfig(gomock.Eq(clientConfig)).Return(gardenClient, nil).AnyTimes()
 
 		currentTarget = target.NewTarget(gardenName, testProject.Name, "", testShoot.Name)
 		targetProvider := internalfake.NewFakeTargetProvider(currentTarget)

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -95,7 +95,9 @@ var _ = Describe("Target Command", func() {
 	})
 
 	JustBeforeEach(func() {
-		clientProvider.EXPECT().FromFile(gardenKubeconfig).Return(gardenClient, nil).AnyTimes()
+		clientConfig, err := cfg.ClientConfig(gardenName)
+		Expect(err).ToNot(HaveOccurred())
+		clientProvider.EXPECT().FromClientConfig(gomock.Eq(clientConfig)).Return(gardenClient, nil).AnyTimes()
 	})
 
 	AfterEach(func() {

--- a/pkg/cmd/target/unset_test.go
+++ b/pkg/cmd/target/unset_test.go
@@ -89,7 +89,9 @@ var _ = Describe("Target Unset Command", func() {
 
 		clientProvider = targetmocks.NewMockClientProvider(ctrl)
 		gardenClient = internalfake.NewClientWithObjects(project, seed, shoot)
-		clientProvider.EXPECT().FromFile(gardenKubeconfig).Return(gardenClient, nil).AnyTimes()
+		clientConfig, err := cfg.ClientConfig(gardenName)
+		Expect(err).ToNot(HaveOccurred())
+		clientProvider.EXPECT().FromClientConfig(gomock.Eq(clientConfig)).Return(gardenClient, nil).AnyTimes()
 
 		factory = internalfake.NewFakeFactory(cfg, nil, clientProvider, targetProvider)
 		ctx = context.Background()

--- a/pkg/cmd/target/view.go
+++ b/pkg/cmd/target/view.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 )
 
-// NewCmdView returns a new version command.
+// NewCmdView returns a new target view command.
 func NewCmdView(f util.Factory, o *ViewOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "view",
@@ -52,7 +52,7 @@ func runViewCommand(f util.Factory, opt *ViewOptions) error {
 	return opt.PrintObject(currentTarget)
 }
 
-// ViewOptions is a struct to support version command
+// ViewOptions is a struct to support view command
 type ViewOptions struct {
 	base.Options
 }

--- a/pkg/cmd/target/view_test.go
+++ b/pkg/cmd/target/view_test.go
@@ -56,7 +56,6 @@ var _ = Describe("Target View Options", func() {
 	It("should validate", func() {
 		streams, _, _, _ := util.NewTestIOStreams()
 		o := cmdtarget.NewViewOptions(streams)
-		err := o.Validate()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(o.Validate()).ToNot(HaveOccurred())
 	})
 })

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -73,7 +73,6 @@ var _ = Describe("Version Command", func() {
 	})
 
 	It("should validate the options", func() {
-		err := o.Validate()
-		Expect(err).ToNot(HaveOccurred())
+		Expect(o.Validate()).ToNot(HaveOccurred())
 	})
 })

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -174,7 +174,7 @@ const (
 
 // MatchPattern matches a string against patterns defined in gardenctl config
 // If matched, the function creates and returns a PatternMatch from the provided target string
-func (config *Config) MatchPattern(value string, name string) (*PatternMatch, error) {
+func (config *Config) MatchPattern(value string, gardenName string) (*PatternMatch, error) {
 	var patternMatch *PatternMatch
 
 	for _, g := range config.Gardens {
@@ -186,7 +186,7 @@ func (config *Config) MatchPattern(value string, name string) (*PatternMatch, er
 		if match != nil {
 			match.Garden = g.Name
 
-			if name == "" || g.Name == name {
+			if gardenName == "" || g.Name == gardenName {
 				// Directly return match of selected garden
 				return match, nil
 			}
@@ -204,6 +204,7 @@ func (config *Config) MatchPattern(value string, name string) (*PatternMatch, er
 }
 
 // matchPattern matches pattern with provided list of patterns
+// If none of the provided patterns matches the given value no error is returned
 func matchPattern(patterns []string, value string) (*PatternMatch, error) {
 	for _, p := range patterns {
 		r, err := regexp.Compile(p)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,12 +32,12 @@ type Garden struct {
 	Kubeconfig string `yaml:"kubeconfig"`
 	// Context overrides the current-context of the garden cluster kubeconfig
 	// +optional
-	Context string `yaml:"context"`
+	Context string `yaml:"context,omitempty"`
 	// Patterns is a list of regex patterns that can be defined to use custom input formats for targeting
 	// Use named capturing groups to match target values.
 	// Supported capturing groups: project, namespace, shoot
 	// +optional
-	Patterns []string `yaml:"matchPatterns"`
+	Patterns []string `yaml:"matchPatterns,omitempty"`
 }
 
 // LoadFromFile parses a gardenctl config file and returns a Config struct

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -138,18 +138,6 @@ func (config *Config) ClientConfig(name string) (clientcmd.ClientConfig, error) 
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, overrides), nil
 }
 
-// DeleteGarden deletes a Garden from the configuration
-func (config *Config) DeleteGarden(name string) error {
-	i, ok := config.IndexOfGarden(name)
-	if !ok {
-		return fmt.Errorf("garden %q is not defined in gardenctl configuration", name)
-	}
-
-	config.Gardens = append(config.Gardens[:i], config.Gardens[i+1:]...)
-
-	return nil
-}
-
 // PatternMatch holds (target) values extracted from a provided string
 type PatternMatch struct {
 	// Garden is the matched Garden

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,7 +89,9 @@ func (config *Config) Save() error {
 	return nil
 }
 
-func (config *Config) indexOfGarden(name string) (int, bool) {
+// IndexOfGarden returns the index of the Garden with the given name in the configured Gardens slice
+// If no Garden with this name is found it returns -1
+func (config *Config) IndexOfGarden(name string) (int, bool) {
 	for i, g := range config.Gardens {
 		if g.Name == name {
 			return i, true
@@ -111,7 +113,7 @@ func (config *Config) GardenNames() []string {
 
 // Garden returns a Garden cluster from the list of configured Gardens
 func (config *Config) Garden(name string) (*Garden, error) {
-	i, ok := config.indexOfGarden(name)
+	i, ok := config.IndexOfGarden(name)
 	if !ok {
 		return nil, fmt.Errorf("garden %q is not defined in gardenctl configuration", name)
 	}
@@ -138,7 +140,7 @@ func (config *Config) ClientConfig(name string) (clientcmd.ClientConfig, error) 
 
 // DeleteGarden deletes a Garden from the configuration
 func (config *Config) DeleteGarden(name string) error {
-	i, ok := config.indexOfGarden(name)
+	i, ok := config.IndexOfGarden(name)
 	if !ok {
 		return fmt.Errorf("garden %q is not defined in gardenctl configuration", name)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,65 +17,58 @@ import (
 
 var _ = Describe("Config", func() {
 	var (
-		gardenName1  = "testgarden"
-		gardenAlias1 = []string{"test.garden"}
-		gardenName2  = "foogarden"
-		gardenAlias2 = []string{"foo", "bar"}
-		project      = "fooproject"
-		shoot        = "fooshoot"
-		namespace    = "foonamespace"
-		cfg          *config.Config
+		clusterIdentity1 = "testgarden"
+		clusterIdentity2 = "foogarden"
+		project          = "fooproject"
+		shoot            = "fooshoot"
+		namespace        = "foonamespace"
+		cfg              *config.Config
 	)
 
 	BeforeEach(func() {
 		cfg = &config.Config{
-			Gardens: []config.Garden{{
-				Name:    gardenName1,
-				Aliases: gardenAlias1,
-			},
+			Gardens: []config.Garden{
 				{
-					Name:    gardenName2,
-					Aliases: gardenAlias2,
+					Name: clusterIdentity1,
+					Patterns: []string{
+						fmt.Sprintf("^(%s/)?shoot--(?P<project>.+)--(?P<shoot>.+)$", clusterIdentity1),
+						"^namespace:(?P<namespace>[^/]+)$",
+					},
+				},
+				{
+					Name: clusterIdentity2,
+					Patterns: []string{
+						fmt.Sprintf("^(%s)?shoot--(?P<project>.+)--(?P<shoot>.+)$", clusterIdentity2),
+						"^namespace:(?P<namespace>[^/]+)$",
+					},
 				}},
-			MatchPatterns: []string{
-				"^((?P<garden>[^/]+)/)?shoot--(?P<project>.+)--(?P<shoot>.+)$",
-				"^namespace:(?P<namespace>[^/]+)$",
-			},
 		}
 	})
 
-	It("should find garden by name", func() {
-		gardenName, err := cfg.GardenName(gardenName1)
+	It("should find garden by identity", func() {
+		garden, err := cfg.Garden(clusterIdentity1)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(gardenName).Should(Equal(gardenName1))
-
-	})
-
-	It("should find garden by alias", func() {
-		gardenName, err := cfg.GardenName(gardenAlias1[0])
-		Expect(err).NotTo(HaveOccurred())
-		Expect(gardenName).Should(Equal(gardenName1))
-
-		gardenName, err = cfg.GardenName(gardenAlias2[1])
-		Expect(err).NotTo(HaveOccurred())
-		Expect(gardenName).Should(Equal(gardenName2))
+		Expect(garden.Name).Should(Equal(clusterIdentity1))
 
 	})
 
 	It("should throw an error if garden not found", func() {
-		_, err := cfg.GardenName("foobar")
+		_, err := cfg.Garden("foobar")
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("should return a PatternMatch for a given value", func() {
-		tm, err := cfg.MatchPattern(fmt.Sprintf("%s/shoot--%s--%s", gardenAlias2[1], project, shoot))
+		tm, err := cfg.MatchPattern(fmt.Sprintf("%s/shoot--%s--%s", clusterIdentity1, project, shoot), clusterIdentity1)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(tm.Garden).Should(Equal(gardenAlias2[1]))
+		Expect(tm.Garden).Should(Equal(clusterIdentity1))
 		Expect(tm.Project).Should(Equal(project))
 		Expect(tm.Shoot).Should(Equal(shoot))
+	})
 
-		tm, err = cfg.MatchPattern(fmt.Sprintf("namespace:%s", namespace))
+	It("should prefer PatternMatch for current garden", func() {
+		tm, err := cfg.MatchPattern(fmt.Sprintf("namespace:%s", namespace), clusterIdentity1)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(tm.Garden).Should(Equal(clusterIdentity1))
 		Expect(tm.Namespace).Should(Equal(namespace))
 	})
 })

--- a/pkg/config/export_test.go
+++ b/pkg/config/export_test.go
@@ -1,0 +1,1 @@
+package config

--- a/pkg/target/client_provider.go
+++ b/pkg/target/client_provider.go
@@ -17,11 +17,6 @@ import (
 // ClientProvider is able to take a kubeconfig either directly or
 // from a file and return a controller-runtime client for it.
 type ClientProvider interface {
-	// FromFile reads a kubeconfig (marshalled as YAML) from a file
-	// and returns a Kubernetes client.
-	FromFile(kubeconfigFile string) (client.Client, error)
-	// FromBytes reads YAML directly and returns a Kubernetes client.
-	FromBytes(kubeconfig []byte) (client.Client, error)
 	// FromClientConfig returns a Kubernetes client for the given client config.
 	FromClientConfig(config clientcmd.ClientConfig) (client.Client, error)
 }
@@ -33,27 +28,6 @@ var _ ClientProvider = &clientProvider{}
 // NewClientProvider returns a new ClientProvider.
 func NewClientProvider() ClientProvider {
 	return &clientProvider{}
-}
-
-// FromFile reads a kubeconfig (marshalled as YAML) from a file
-// and returns a Kubernetes client.
-func (p *clientProvider) FromFile(kubeconfigFile string) (client.Client, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load kubeconfig from %q: %w", kubeconfigFile, err)
-	}
-
-	return client.New(config, client.Options{})
-}
-
-// FromBytes reads YAML directly and returns a Kubernetes client.
-func (p *clientProvider) FromBytes(kubeconfig []byte) (client.Client, error) {
-	config, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
-	}
-
-	return client.New(config, client.Options{})
 }
 
 // FromClientConfig returns a Kubernetes client for the given client config.

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -146,7 +146,7 @@ func (m *managerImpl) Configuration() *config.Config {
 func (m *managerImpl) TargetGarden(ctx context.Context, identity string) error {
 	tb, err := NewTargetBuilder(m.config, m.clientProvider)
 	if err != nil {
-		return fmt.Errorf("failed to target garden: %w", err)
+		return fmt.Errorf("failed to create new target builder: %w", err)
 	}
 
 	currentTarget, err := m.CurrentTarget()
@@ -158,7 +158,7 @@ func (m *managerImpl) TargetGarden(ctx context.Context, identity string) error {
 
 	target, err := tb.SetGarden(identity).Build()
 	if err != nil {
-		return fmt.Errorf("failed to target garden: %w", err)
+		return fmt.Errorf("failed to build target: %w", err)
 	}
 
 	return m.updateTarget(target)
@@ -180,6 +180,7 @@ func (m *managerImpl) UnsetTargetGarden() (string, error) {
 		t.Project = ""
 		t.Seed = ""
 		t.Shoot = ""
+		t.ControlPlaneFlag = false
 
 		return nil
 	})
@@ -188,7 +189,7 @@ func (m *managerImpl) UnsetTargetGarden() (string, error) {
 func (m *managerImpl) TargetProject(ctx context.Context, projectName string) error {
 	tb, err := NewTargetBuilder(m.config, m.clientProvider)
 	if err != nil {
-		return fmt.Errorf("failed to target project: %w", err)
+		return fmt.Errorf("failed to create new target builder: %w", err)
 	}
 
 	currentTarget, err := m.CurrentTarget()
@@ -229,7 +230,7 @@ func (m *managerImpl) UnsetTargetProject() (string, error) {
 func (m *managerImpl) TargetSeed(ctx context.Context, seedName string) error {
 	tb, err := NewTargetBuilder(m.config, m.clientProvider)
 	if err != nil {
-		return fmt.Errorf("failed to target seed: %w", err)
+		return fmt.Errorf("failed to create new target builder: %w", err)
 	}
 
 	currentTarget, err := m.CurrentTarget()
@@ -268,7 +269,7 @@ func (m *managerImpl) UnsetTargetSeed() (string, error) {
 func (m *managerImpl) TargetShoot(ctx context.Context, shootName string) error {
 	tb, err := NewTargetBuilder(m.config, m.clientProvider)
 	if err != nil {
-		return fmt.Errorf("failed to target shoot: %w", err)
+		return fmt.Errorf("failed to create new target builder: %w", err)
 	}
 
 	currentTarget, err := m.CurrentTarget()
@@ -308,7 +309,7 @@ func (m *managerImpl) UnsetTargetShoot() (string, error) {
 func (m *managerImpl) TargetControlPlane(ctx context.Context) error {
 	tb, err := NewTargetBuilder(m.config, m.clientProvider)
 	if err != nil {
-		return fmt.Errorf("failed to target shoot control plane: %w", err)
+		return fmt.Errorf("failed to create new target builder: %w", err)
 	}
 
 	currentTarget, err := m.CurrentTarget()
@@ -362,7 +363,7 @@ func (m *managerImpl) TargetMatchPattern(ctx context.Context, value string) erro
 
 	tb, err := NewTargetBuilder(m.config, m.clientProvider)
 	if err != nil {
-		return fmt.Errorf("failed to target with match pattern: %w", err)
+		return fmt.Errorf("failed to create new target builder: %w", err)
 	}
 
 	tb.Init(currentTarget)

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -144,7 +144,10 @@ func (m *managerImpl) Configuration() *config.Config {
 }
 
 func (m *managerImpl) TargetGarden(ctx context.Context, gardenNameOrAlias string) error {
-	tb := NewTargetBuilder(m.config, m.clientProvider)
+	tb, err := NewTargetBuilder(m.config, m.clientProvider)
+	if err != nil {
+		return fmt.Errorf("failed to target seed: %w", err)
+	}
 
 	currentTarget, err := m.CurrentTarget()
 	if err != nil {
@@ -184,7 +187,10 @@ func (m *managerImpl) UnsetTargetGarden() (string, error) {
 }
 
 func (m *managerImpl) TargetProject(ctx context.Context, projectName string) error {
-	tb := NewTargetBuilder(m.config, m.clientProvider)
+	tb, err := NewTargetBuilder(m.config, m.clientProvider)
+	if err != nil {
+		return fmt.Errorf("failed to target seed: %w", err)
+	}
 
 	currentTarget, err := m.CurrentTarget()
 	if err != nil {
@@ -222,7 +228,10 @@ func (m *managerImpl) UnsetTargetProject() (string, error) {
 }
 
 func (m *managerImpl) TargetSeed(ctx context.Context, seedName string) error {
-	tb := NewTargetBuilder(m.config, m.clientProvider)
+	tb, err := NewTargetBuilder(m.config, m.clientProvider)
+	if err != nil {
+		return fmt.Errorf("failed to target seed: %w", err)
+	}
 
 	currentTarget, err := m.CurrentTarget()
 	if err != nil {
@@ -258,7 +267,10 @@ func (m *managerImpl) UnsetTargetSeed() (string, error) {
 }
 
 func (m *managerImpl) TargetShoot(ctx context.Context, shootName string) error {
-	tb := NewTargetBuilder(m.config, m.clientProvider)
+	tb, err := NewTargetBuilder(m.config, m.clientProvider)
+	if err != nil {
+		return fmt.Errorf("failed to target shoot: %w", err)
+	}
 
 	currentTarget, err := m.CurrentTarget()
 	if err != nil {
@@ -295,7 +307,10 @@ func (m *managerImpl) UnsetTargetShoot() (string, error) {
 }
 
 func (m *managerImpl) TargetControlPlane(ctx context.Context) error {
-	tb := NewTargetBuilder(m.config, m.clientProvider)
+	tb, err := NewTargetBuilder(m.config, m.clientProvider)
+	if err != nil {
+		return fmt.Errorf("failed to target seed: %w", err)
+	}
 
 	currentTarget, err := m.CurrentTarget()
 	if err != nil {
@@ -330,16 +345,25 @@ func (m *managerImpl) UnsetTargetControlPlane() error {
 }
 
 func (m *managerImpl) TargetMatchPattern(ctx context.Context, value string) error {
-	tm, err := m.config.MatchPattern(value)
+	currentTarget, err := m.CurrentTarget()
+	if err != nil {
+		return fmt.Errorf("failed to get current target: %w", err)
+	}
+
+	gardenName := currentTarget.GardenName()
+
+	if m.config == nil {
+		return errors.New("config must not be nil")
+	}
+
+	tm, err := m.config.MatchPattern(value, gardenName)
 	if err != nil {
 		return fmt.Errorf("error occurred while trying to match value: %w", err)
 	}
 
-	tb := NewTargetBuilder(m.config, m.clientProvider)
-
-	currentTarget, err := m.CurrentTarget()
+	tb, err := NewTargetBuilder(m.config, m.clientProvider)
 	if err != nil {
-		return fmt.Errorf("failed to get current target: %w", err)
+		return fmt.Errorf("failed to target with match pattern: %w", err)
 	}
 
 	tb.Init(currentTarget)

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -55,11 +55,11 @@ func createTestShoot(name string, namespace string, seedName *string) *gardencor
 	return shoot
 }
 
-func createTestManager(t target.Target, cfg config.Config, clientProvider target.ClientProvider) (target.Manager, target.TargetProvider) {
+func createTestManager(t target.Target, cfg *config.Config, clientProvider target.ClientProvider) (target.Manager, target.TargetProvider) {
 	targetProvider := fake.NewFakeTargetProvider(t)
 
 	sessionDir := os.TempDir()
-	manager, err := target.NewManager(&cfg, targetProvider, clientProvider, sessionDir)
+	manager, err := target.NewManager(cfg, targetProvider, clientProvider, sessionDir)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(manager).NotTo(BeNil())
 
@@ -73,19 +73,21 @@ var _ = Describe("Target Manager", func() {
 	)
 
 	var (
-		ctrl                *gomock.Controller
-		prod1Project        *gardencorev1beta1.Project
-		prod2Project        *gardencorev1beta1.Project
-		unreadyProject      *gardencorev1beta1.Project
-		seed                *gardencorev1beta1.Seed
-		prod1GoldenShoot    *gardencorev1beta1.Shoot
-		prod1AmbiguousShoot *gardencorev1beta1.Shoot
-		prod2AmbiguousShoot *gardencorev1beta1.Shoot
-		prod1PendingShoot   *gardencorev1beta1.Shoot
-		cfg                 *config.Config
-		gardenClient        client.Client
-		clientProvider      *targetmocks.MockClientProvider
-		namespace           *corev1.Namespace
+		ctrl                                *gomock.Controller
+		prod1Project                        *gardencorev1beta1.Project
+		prod2Project                        *gardencorev1beta1.Project
+		unreadyProject                      *gardencorev1beta1.Project
+		seed                                *gardencorev1beta1.Seed
+		seedKubeconfigSecret                *corev1.Secret
+		prod1GoldenShoot                    *gardencorev1beta1.Shoot
+		prod1GoldenShootKubeconfigConfigMap *corev1.ConfigMap
+		prod1AmbiguousShoot                 *gardencorev1beta1.Shoot
+		prod2AmbiguousShoot                 *gardencorev1beta1.Shoot
+		prod1PendingShoot                   *gardencorev1beta1.Shoot
+		cfg                                 *config.Config
+		gardenClient                        client.Client
+		clientProvider                      *targetmocks.MockClientProvider
+		namespace                           *corev1.Namespace
 	)
 
 	BeforeEach(func() {
@@ -124,7 +126,7 @@ var _ = Describe("Target Manager", func() {
 			},
 		}
 
-		seedKubeconfigSecret := &corev1.Secret{
+		seedKubeconfigSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-seed.oidc",
 				Namespace: "garden",
@@ -150,7 +152,7 @@ var _ = Describe("Target Manager", func() {
 		}
 
 		prod1GoldenShoot = createTestShoot("golden-shoot", *prod1Project.Spec.Namespace, pointer.String(seed.Name))
-		prod1GoldenShootKubeconfigConfigMap := &corev1.ConfigMap{
+		prod1GoldenShootKubeconfigConfigMap = &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      prod1GoldenShoot.Name + ".kubeconfig",
 				Namespace: prod1GoldenShoot.Namespace,
@@ -179,7 +181,9 @@ var _ = Describe("Target Manager", func() {
 
 		ctrl = gomock.NewController(GinkgoT())
 		clientProvider = targetmocks.NewMockClientProvider(ctrl)
-		clientProvider.EXPECT().FromFile(gardenKubeconfig).Return(gardenClient, nil).AnyTimes()
+		clientConfig, err := cfg.ClientConfig(gardenName)
+		Expect(err).NotTo(HaveOccurred())
+		clientProvider.EXPECT().FromClientConfig(gomock.Eq(clientConfig)).Return(gardenClient, nil).AnyTimes()
 	})
 
 	AfterEach(func() {
@@ -188,7 +192,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to target valid gardens", func() {
 		t := target.NewTarget("", "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetGarden(ctx, gardenName)).To(Succeed())
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, "", "", ""))
@@ -196,7 +200,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should fail with invalid garden name", func() {
 		t := target.NewTarget("", "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetGarden(ctx, "does-not-exist")).NotTo(Succeed())
 		assertTargetProvider(targetProvider, t)
@@ -204,7 +208,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to target valid projects", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetProject(ctx, prod1Project.Name)).To(Succeed())
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", ""))
@@ -212,7 +216,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should fail with invalid project name", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetProject(ctx, "does-not-exist")).NotTo(Succeed())
 		assertTargetProvider(targetProvider, t)
@@ -220,7 +224,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should fail with unready project", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetProject(ctx, unreadyProject.Name)).NotTo(Succeed())
 		assertTargetProvider(targetProvider, t)
@@ -228,7 +232,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should unset deeper target levels when 'going back'", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		// go deep
 		Expect(manager.TargetProject(ctx, prod1Project.Name)).To(Succeed())
@@ -241,7 +245,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to target valid seeds and drop project and shoot target", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", prod1AmbiguousShoot.Name)
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetSeed(ctx, seed.Name)).To(Succeed())
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, "", seed.Name, ""))
@@ -249,7 +253,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should fail with invalid seed name", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetSeed(ctx, "does-not-exist")).NotTo(Succeed())
 		assertTargetProvider(targetProvider, t)
@@ -257,7 +261,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to target valid shoots with a project already targeted", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetShoot(ctx, prod1AmbiguousShoot.Name)).To(Succeed())
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1AmbiguousShoot.Name))
@@ -265,7 +269,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to target valid shoots with a seed already targeted. Should drop seed and set shoot project instead", func() {
 		t := target.NewTarget(gardenName, "", seed.Name, "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetShoot(ctx, prod1GoldenShoot.Name)).To(Succeed())
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name))
@@ -273,7 +277,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should not be able to target valid shoots with another seed already targeted", func() {
 		t := target.NewTarget(gardenName, "", seed.Name, "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		// another seed is already targeted, so even though this shoot exists, it does not match
 		Expect(manager.TargetShoot(ctx, prod1PendingShoot.Name)).NotTo(Succeed())
@@ -282,7 +286,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to target valid shoots with only garden targeted", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetShoot(ctx, prod1GoldenShoot.Name)).To(Succeed())
 		// project should be inserted into the path, as it is preferred over a seed step
@@ -291,7 +295,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should error when multiple shoots match", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetShoot(ctx, prod1AmbiguousShoot.Name)).NotTo(Succeed())
 		assertTargetProvider(targetProvider, t)
@@ -299,7 +303,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to target valid garden, project and shoot by matching a pattern", func() {
 		t := target.NewTarget("", "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetMatchPattern(ctx, fmt.Sprintf("%s/shoot--%s--%s", gardenName, prod1Project.Name, prod1GoldenShoot.Name))).To(Succeed())
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name))
@@ -307,7 +311,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to target valid project shoot by matching a pattern if garden is set", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetMatchPattern(ctx, fmt.Sprintf("shoot--%s--%s", prod1Project.Name, prod1GoldenShoot.Name))).To(Succeed())
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name))
@@ -315,7 +319,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to target shoot by matching a pattern if garden is not set", func() {
 		t := target.NewTarget("", "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetMatchPattern(ctx, fmt.Sprintf("shoot--%s--%s", prod1Project.Name, prod1GoldenShoot.Name))).To(Succeed())
 		assertTargetProvider(targetProvider, t)
@@ -323,7 +327,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should not target anything if target is not completely valid", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetMatchPattern(ctx, fmt.Sprintf("shoot--%s--%s", prod1Project.Name, "invalid shoot"))).NotTo(Succeed())
 		assertTargetProvider(targetProvider, t)
@@ -331,7 +335,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to target valid project by matching a pattern containing a namespace", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetMatchPattern(ctx, fmt.Sprintf("namespace:%s", *prod1Project.Spec.Namespace))).To(Succeed())
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", ""))
@@ -339,7 +343,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to target control plane for a shoot", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name)
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetControlPlane(ctx)).To(Succeed())
 		assertTargetProvider(targetProvider, t.WithControlPlane(true))
@@ -347,7 +351,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should fail to target control plane if shoot is not set", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetControlPlane(ctx)).NotTo(Succeed())
 		assertTargetProvider(targetProvider, t)
@@ -355,7 +359,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should provide a garden client", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, _ := createTestManager(t, *cfg, clientProvider)
+		manager, _ := createTestManager(t, cfg, clientProvider)
 
 		newClient, err := manager.GardenClient(t.GardenName())
 		Expect(err).NotTo(HaveOccurred())
@@ -364,15 +368,12 @@ var _ = Describe("Target Manager", func() {
 
 	It("should provide a seed client", func() {
 		t := target.NewTarget(gardenName, "", seed.Name, "")
-		manager, _ := createTestManager(t, *cfg, clientProvider)
+		manager, _ := createTestManager(t, cfg, clientProvider)
 
 		seedClient := fake.NewClientWithObjects()
-		clientProvider.EXPECT().FromClientConfig(gomock.Any()).Return(seedClient, nil).
-			Do(func(clientConfig clientcmd.ClientConfig) {
-				config, err := clientConfig.RawConfig()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(config.CurrentContext).To(Equal(seed.Name))
-			})
+		clientConfig, err := clientcmd.NewClientConfigFromBytes(seedKubeconfigSecret.Data["kubeconfig"])
+		Expect(err).NotTo(HaveOccurred())
+		clientProvider.EXPECT().FromClientConfig(gomock.Eq(clientConfig)).Return(seedClient, nil)
 
 		newClient, err := manager.SeedClient(ctx, t)
 		Expect(err).NotTo(HaveOccurred())
@@ -381,15 +382,12 @@ var _ = Describe("Target Manager", func() {
 
 	It("should provide a shoot client", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name)
-		manager, _ := createTestManager(t, *cfg, clientProvider)
+		manager, _ := createTestManager(t, cfg, clientProvider)
 
 		shootClient := fake.NewClientWithObjects()
-		clientProvider.EXPECT().FromClientConfig(gomock.Any()).Return(shootClient, nil).
-			Do(func(clientConfig clientcmd.ClientConfig) {
-				config, err := clientConfig.RawConfig()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(config.CurrentContext).To(Equal(prod1GoldenShoot.Name))
-			})
+		clientConfig, err := clientcmd.NewClientConfigFromBytes([]byte(prod1GoldenShootKubeconfigConfigMap.Data["kubeconfig"]))
+		Expect(err).NotTo(HaveOccurred())
+		clientProvider.EXPECT().FromClientConfig(gomock.Eq(clientConfig)).Return(shootClient, nil)
 
 		newClient, err := manager.ShootClient(ctx, t)
 		Expect(err).NotTo(HaveOccurred())
@@ -398,7 +396,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to unset selected garden", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.UnsetTargetGarden()).Should(Equal(gardenName))
 		assertTargetProvider(targetProvider, target.NewTarget("", "", "", ""))
@@ -406,7 +404,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should fail if no garden selected", func() {
 		t := target.NewTarget("", "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		res, unsetErr := manager.UnsetTargetGarden()
 		Expect(unsetErr).To(HaveOccurred())
@@ -416,7 +414,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should unset deeper target levels when unsetting garden", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1AmbiguousShoot.Name)
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		// Unset Garden
 		Expect(manager.UnsetTargetGarden()).Should(Equal(gardenName))
@@ -427,7 +425,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to unset selected project", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.UnsetTargetProject()).Should(Equal(prod1Project.Name))
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, "", "", ""))
@@ -435,7 +433,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should fail if no project selected", func() {
 		t := target.NewTarget(gardenName, "", "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		res, unsetErr := manager.UnsetTargetProject()
 		Expect(unsetErr).To(HaveOccurred())
@@ -445,7 +443,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should unset deeper target levels when unsetting project", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", prod1AmbiguousShoot.Name).WithControlPlane(true)
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		// Unset Project
 		Expect(manager.UnsetTargetProject()).Should(Equal(prod1Project.Name))
@@ -456,7 +454,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to unset selected shoot", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", prod1AmbiguousShoot.Name)
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.UnsetTargetShoot()).Should(Equal(prod1AmbiguousShoot.Name))
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", ""))
@@ -464,7 +462,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should fail if no shoot selected", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		res, unsetErr := manager.UnsetTargetShoot()
 		Expect(unsetErr).To(HaveOccurred())
@@ -474,7 +472,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to unset selected control plane", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", prod1AmbiguousShoot.Name).WithControlPlane(true)
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.UnsetTargetControlPlane()).To(Succeed())
 		assertTargetProvider(targetProvider, t.WithControlPlane(false))
@@ -482,7 +480,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should fail if no control plane targeted", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		unsetErr := manager.UnsetTargetControlPlane()
 		Expect(unsetErr).To(HaveOccurred())
@@ -491,7 +489,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should be able to unset selected seed", func() {
 		t := target.NewTarget(gardenName, "", seed.Name, "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.UnsetTargetSeed()).Should(Equal(seed.Name))
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, "", "", ""))
@@ -499,7 +497,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should fail if no seed selected", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", "")
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		res, unsetErr := manager.UnsetTargetSeed()
 		Expect(unsetErr).To(HaveOccurred())

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -363,7 +363,7 @@ var _ = Describe("Target Manager", func() {
 
 	It("should fail to target control plane if garden is not set", func() {
 		t := target.NewTarget("", prod1Project.Name, "", prod1GoldenShoot.Name)
-		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetControlPlane(ctx)).NotTo(Succeed())
 		assertTargetProvider(targetProvider, t)

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -93,11 +93,11 @@ var _ = Describe("Target Manager", func() {
 			Gardens: []config.Garden{{
 				Name:       gardenName,
 				Kubeconfig: gardenKubeconfig,
+				Patterns: []string{
+					fmt.Sprintf("^(%s/)?shoot--(?P<project>.+)--(?P<shoot>.+)$", gardenName),
+					"^namespace:(?P<namespace>[^/]+)$",
+				},
 			}},
-			MatchPatterns: []string{
-				"^((?P<garden>[^/]+)/)?shoot--(?P<project>.+)--(?P<shoot>.+)$",
-				"^namespace:(?P<namespace>[^/]+)$",
-			},
 		}
 
 		prod1Project = &gardencorev1beta1.Project{
@@ -313,11 +313,11 @@ var _ = Describe("Target Manager", func() {
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name))
 	})
 
-	It("should fail to target shoot by matching a pattern if garden is not set", func() {
+	It("should be able to target shoot by matching a pattern if garden is not set", func() {
 		t := target.NewTarget("", "", "", "")
 		manager, targetProvider := createTestManager(t, *cfg, clientProvider)
 
-		Expect(manager.TargetMatchPattern(ctx, fmt.Sprintf("shoot--%s--%s", prod1Project.Name, prod1GoldenShoot.Name))).NotTo(Succeed())
+		Expect(manager.TargetMatchPattern(ctx, fmt.Sprintf("shoot--%s--%s", prod1Project.Name, prod1GoldenShoot.Name))).To(Succeed())
 		assertTargetProvider(targetProvider, t)
 	})
 

--- a/pkg/target/mocks/mock_client_provider.go
+++ b/pkg/target/mocks/mock_client_provider.go
@@ -35,21 +35,6 @@ func (m *MockClientProvider) EXPECT() *MockClientProviderMockRecorder {
 	return m.recorder
 }
 
-// FromBytes mocks base method.
-func (m *MockClientProvider) FromBytes(arg0 []byte) (client.Client, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FromBytes", arg0)
-	ret0, _ := ret[0].(client.Client)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FromBytes indicates an expected call of FromBytes.
-func (mr *MockClientProviderMockRecorder) FromBytes(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FromBytes", reflect.TypeOf((*MockClientProvider)(nil).FromBytes), arg0)
-}
-
 // FromClientConfig mocks base method.
 func (m *MockClientProvider) FromClientConfig(arg0 clientcmd.ClientConfig) (client.Client, error) {
 	m.ctrl.T.Helper()
@@ -63,19 +48,4 @@ func (m *MockClientProvider) FromClientConfig(arg0 clientcmd.ClientConfig) (clie
 func (mr *MockClientProviderMockRecorder) FromClientConfig(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FromClientConfig", reflect.TypeOf((*MockClientProvider)(nil).FromClientConfig), arg0)
-}
-
-// FromFile mocks base method.
-func (m *MockClientProvider) FromFile(arg0 string) (client.Client, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FromFile", arg0)
-	ret0, _ := ret[0].(client.Client)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// FromFile indicates an expected call of FromFile.
-func (mr *MockClientProviderMockRecorder) FromFile(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FromFile", reflect.TypeOf((*MockClientProvider)(nil).FromFile), arg0)
 }

--- a/pkg/target/target_builder.go
+++ b/pkg/target/target_builder.go
@@ -22,7 +22,6 @@ type TargetBuilder interface {
 	// Use this function to overwrite target baseline data before updating with new values
 	Init(Target) TargetBuilder
 	// SetGarden updates TargetBuilder with a Garden name
-	// gardenName can be Garden Name or Alias as defined in the config
 	SetGarden(string) TargetBuilder
 	// SetProject updates TargetBuilder with a Project name
 	SetProject(context.Context, string) TargetBuilder

--- a/pkg/target/target_builder.go
+++ b/pkg/target/target_builder.go
@@ -53,11 +53,15 @@ type targetBuilderImpl struct {
 var _ TargetBuilder = &targetBuilderImpl{}
 
 // NewTargetBuilder returns a new target builder
-func NewTargetBuilder(config *config.Config, clientProvider ClientProvider) TargetBuilder {
+func NewTargetBuilder(config *config.Config, clientProvider ClientProvider) (TargetBuilder, error) {
+	if config == nil {
+		return nil, errors.New("config must not be nil")
+	}
+
 	return &targetBuilderImpl{
 		config:         config,
 		clientProvider: clientProvider,
-	}
+	}, nil
 }
 
 func (b *targetBuilderImpl) Init(t Target) TargetBuilder {
@@ -67,12 +71,12 @@ func (b *targetBuilderImpl) Init(t Target) TargetBuilder {
 
 func (b *targetBuilderImpl) SetGarden(name string) TargetBuilder {
 	b.actions = append(b.actions, func(t *targetImpl) error {
-		gardenName, err := b.config.GardenName(name)
+		garden, err := b.config.Garden(name)
 		if err != nil {
 			return fmt.Errorf("failed to set target garden: %w", err)
 		}
 
-		t.Garden = gardenName
+		t.Garden = garden.Name
 		t.Project = ""
 		t.Seed = ""
 		t.Shoot = ""


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is an alternative version of the #58 which has the following changes:
- Added config command to add, configure or delete gardens from the configuration
- View the garden configuration
- Define context for kubeconfig
- Moved patterns from global to gardens in configuration
- Dropped support for garden capture group (not required anymore, as each garden has own patterns now)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
