### PR TITLE
control-plane flag support for the `kubectl-env` command

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -173,7 +173,7 @@ func (g *Garden) LoadRawConfig() (*clientcmdapi.Config, error) {
 	// this function returns an error if the currentContext does not exist
 	err = clientcmdapi.MinifyConfig(rawConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to mimify client configuration: %w", err)
+		return nil, fmt.Errorf("failed to minify client configuration: %w", err)
 	}
 
 	return rawConfig, nil

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -473,7 +473,7 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 
 	if t.ProjectName() != "" {
 		return m.getClientConfig(t, func(client gardenclient.Client) (clientcmd.ClientConfig, error) {
-			clientConfig, err := m.Configuration().ClientConfig(t.GardenName())
+			clientConfig, err := m.Configuration().DirectClientConfig(t.GardenName())
 			if err != nil {
 				return nil, err
 			}
@@ -488,7 +488,7 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 	}
 
 	if t.GardenName() != "" {
-		return m.Configuration().ClientConfig(t.GardenName())
+		return m.Configuration().DirectClientConfig(t.GardenName())
 	}
 
 	return nil, ErrNoGardenTargeted
@@ -628,12 +628,7 @@ func clientConfigWithNamespace(clientConfig clientcmd.ClientConfig, namespace st
 		return nil, fmt.Errorf("validation of client configuration failed: %w", err)
 	}
 
-	contextName := rawConfig.CurrentContext
-	if contextName == "" {
-		return nil, fmt.Errorf("client configuration has no current context defined")
-	}
-
-	if context, ok := rawConfig.Contexts[contextName]; ok {
+	for _, context := range rawConfig.Contexts {
 		context.Namespace = namespace
 	}
 

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -38,6 +38,20 @@ func assertTargetProvider(tp target.TargetProvider, expected target.Target) {
 	ExpectWithOffset(1, t.ControlPlane()).To(Equal(expected.ControlPlane()))
 }
 
+func assertClientConfig(clientConfig clientcmd.ClientConfig, name, ns string) {
+	namespace, overridden, err := clientConfig.Namespace()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, overridden).To(BeFalse())
+	ExpectWithOffset(1, namespace).To(Equal(ns))
+
+	rawConfig, err := clientConfig.RawConfig()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	currentContext := rawConfig.CurrentContext
+	ExpectWithOffset(1, currentContext).To(Equal(name))
+	ExpectWithOffset(1, rawConfig.Contexts[currentContext].Namespace).To(Equal(namespace))
+}
+
 func createTestShoot(name string, namespace string, seedName *string) *gardencorev1beta1.Shoot {
 	shoot := &gardencorev1beta1.Shoot{
 		ObjectMeta: metav1.ObjectMeta{
@@ -532,10 +546,7 @@ var _ = Describe("Target Manager", func() {
 			It("should return the client configuration", func() {
 				clientConfig, err := manager.ClientConfig(ctx, t)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(clientConfig.Namespace()).To(Equal(prod1GoldenShoot.Status.TechnicalID))
-				rawConfig, err := clientConfig.RawConfig()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(rawConfig.CurrentContext).To(Equal(*prod1GoldenShoot.Spec.SeedName))
+				assertClientConfig(clientConfig, *prod1GoldenShoot.Spec.SeedName, prod1GoldenShoot.Status.TechnicalID)
 			})
 		})
 
@@ -547,10 +558,7 @@ var _ = Describe("Target Manager", func() {
 			It("should return the client configuration", func() {
 				clientConfig, err := manager.ClientConfig(ctx, t)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(clientConfig.Namespace()).To(Equal("default"))
-				rawConfig, err := clientConfig.RawConfig()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(rawConfig.CurrentContext).To(Equal(prod1GoldenShoot.Name))
+				assertClientConfig(clientConfig, prod1GoldenShoot.Name, "default")
 			})
 		})
 
@@ -562,10 +570,7 @@ var _ = Describe("Target Manager", func() {
 			It("should return the client configuration", func() {
 				clientConfig, err := manager.ClientConfig(ctx, t)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(clientConfig.Namespace()).To(Equal("default"))
-				rawConfig, err := clientConfig.RawConfig()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(rawConfig.CurrentContext).To(Equal(seed.Name))
+				assertClientConfig(clientConfig, seed.Name, "default")
 			})
 		})
 
@@ -577,10 +582,7 @@ var _ = Describe("Target Manager", func() {
 			It("should return the client configuration", func() {
 				clientConfig, err := manager.ClientConfig(ctx, t)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(clientConfig.Namespace()).To(Equal(*prod1Project.Spec.Namespace))
-				rawConfig, err := clientConfig.RawConfig()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(rawConfig.CurrentContext).To(Equal(gardenName))
+				assertClientConfig(clientConfig, gardenName, *prod1Project.Spec.Namespace)
 			})
 		})
 
@@ -592,10 +594,7 @@ var _ = Describe("Target Manager", func() {
 			It("should return the client configuration", func() {
 				clientConfig, err := manager.ClientConfig(ctx, t)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(clientConfig.Namespace()).To(Equal("default"))
-				rawConfig, err := clientConfig.RawConfig()
-				Expect(err).NotTo(HaveOccurred())
-				Expect(rawConfig.CurrentContext).To(Equal(gardenName))
+				assertClientConfig(clientConfig, gardenName, "default")
 			})
 		})
 	})

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -30,12 +30,7 @@ import (
 func assertTargetProvider(tp target.TargetProvider, expected target.Target) {
 	t, err := tp.Read()
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, t).NotTo(BeNil())
-	ExpectWithOffset(1, t.GardenName()).To(Equal(expected.GardenName()))
-	ExpectWithOffset(1, t.ProjectName()).To(Equal(expected.ProjectName()))
-	ExpectWithOffset(1, t.SeedName()).To(Equal(expected.SeedName()))
-	ExpectWithOffset(1, t.ShootName()).To(Equal(expected.ShootName()))
-	ExpectWithOffset(1, t.ControlPlane()).To(Equal(expected.ControlPlane()))
+	ExpectWithOffset(1, t).To(Equal(expected))
 }
 
 func assertClientConfig(clientConfig clientcmd.ClientConfig, name, ns string) {

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -26,19 +26,15 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
-func assertTarget(t target.Target, expected target.Target) {
+func assertTargetProvider(tp target.TargetProvider, expected target.Target) {
+	t, err := tp.Read()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, t).NotTo(BeNil())
 	ExpectWithOffset(1, t.GardenName()).To(Equal(expected.GardenName()))
 	ExpectWithOffset(1, t.ProjectName()).To(Equal(expected.ProjectName()))
 	ExpectWithOffset(1, t.SeedName()).To(Equal(expected.SeedName()))
 	ExpectWithOffset(1, t.ShootName()).To(Equal(expected.ShootName()))
 	ExpectWithOffset(1, t.ControlPlane()).To(Equal(expected.ControlPlane()))
-}
-
-func assertTargetProvider(tp target.TargetProvider, expected target.Target) {
-	t, err := tp.Read()
-	Expect(err).NotTo(HaveOccurred())
-	Expect(t).NotTo(BeNil())
-	assertTarget(t, expected)
 }
 
 func createTestShoot(name string, namespace string, seedName *string) *gardencorev1beta1.Shoot {
@@ -64,8 +60,8 @@ func createTestManager(t target.Target, cfg *config.Config, clientProvider targe
 
 	sessionDir := os.TempDir()
 	manager, err := target.NewManager(cfg, targetProvider, clientProvider, sessionDir)
-	Expect(err).NotTo(HaveOccurred())
-	Expect(manager).NotTo(BeNil())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, manager).NotTo(BeNil())
 
 	return manager, targetProvider
 }

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -553,5 +553,50 @@ var _ = Describe("Target Manager", func() {
 				Expect(rawConfig.CurrentContext).To(Equal(prod1GoldenShoot.Name))
 			})
 		})
+
+		Context("when seed is targeted", func() {
+			BeforeEach(func() {
+				t = target.NewTarget(gardenName, prod1Project.Name, seed.Name, "")
+			})
+
+			It("should return the client configuration", func() {
+				clientConfig, err := manager.ClientConfig(ctx, t)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(clientConfig.Namespace()).To(Equal("default"))
+				rawConfig, err := clientConfig.RawConfig()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rawConfig.CurrentContext).To(Equal(seed.Name))
+			})
+		})
+
+		Context("when project is targeted", func() {
+			BeforeEach(func() {
+				t = target.NewTarget(gardenName, prod1Project.Name, "", "")
+			})
+
+			It("should return the client configuration", func() {
+				clientConfig, err := manager.ClientConfig(ctx, t)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(clientConfig.Namespace()).To(Equal(*prod1Project.Spec.Namespace))
+				rawConfig, err := clientConfig.RawConfig()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rawConfig.CurrentContext).To(Equal(gardenName))
+			})
+		})
+
+		Context("when garden is targeted", func() {
+			BeforeEach(func() {
+				t = target.NewTarget(gardenName, "", "", "")
+			})
+
+			It("should return the client configuration", func() {
+				clientConfig, err := manager.ClientConfig(ctx, t)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(clientConfig.Namespace()).To(Equal("default"))
+				rawConfig, err := clientConfig.RawConfig()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rawConfig.CurrentContext).To(Equal(gardenName))
+			})
+		})
 	})
 })

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -73,11 +73,6 @@ func createTestManager(t target.Target, cfg *config.Config, clientProvider targe
 }
 
 var _ = Describe("Target Manager", func() {
-	const (
-		gardenName       = "testgarden"
-		gardenKubeconfig = "/not/a/real/file"
-	)
-
 	var (
 		ctrl                                *gomock.Controller
 		prod1Project                        *gardencorev1beta1.Project

--- a/pkg/target/target_suite_test.go
+++ b/pkg/target/target_suite_test.go
@@ -72,7 +72,7 @@ func createTestKubeconfig(name string) []byte {
 	}
 	config.CurrentContext = name
 	data, err := clientcmd.Write(*config)
-	Expect(err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
 	return data
 }

--- a/pkg/target/target_suite_test.go
+++ b/pkg/target/target_suite_test.go
@@ -45,6 +45,18 @@ var _ = AfterSuite(func() {
 
 func createTestKubeconfig(name string) []byte {
 	config := clientcmdapi.NewConfig()
+	config.Clusters["cluster"] = &clientcmdapi.Cluster{
+		Server:                "https://kubernetes:6443/",
+		InsecureSkipTLSVerify: true,
+	}
+	config.AuthInfos["user"] = &clientcmdapi.AuthInfo{
+		Token: "token",
+	}
+	config.Contexts[name] = &clientcmdapi.Context{
+		Namespace: "default",
+		AuthInfo:  "user",
+		Cluster:   "cluster",
+	}
 	config.CurrentContext = name
 	data, err := clientcmd.Write(*config)
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/target/target_suite_test.go
+++ b/pkg/target/target_suite_test.go
@@ -8,6 +8,8 @@ package target_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -29,18 +31,29 @@ func TestTarget(t *testing.T) {
 	RunSpecs(t, "Target Package Test Suite")
 }
 
+const gardenName = "testgarden"
+
 var (
-	ctx    context.Context
-	cancel context.CancelFunc
+	ctx              context.Context
+	cancel           context.CancelFunc
+	gardenHomeDir    string
+	gardenKubeconfig string
 )
 
 var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
 
+	dir, err := os.MkdirTemp("", "garden-*")
+	Expect(err).NotTo(HaveOccurred())
+	gardenHomeDir = dir
+	gardenKubeconfig = filepath.Join(gardenHomeDir, "kubeconfig.yaml")
+	data := createTestKubeconfig(gardenName)
+	Expect(os.WriteFile(gardenKubeconfig, data, 0600)).To(Succeed())
 }, 60)
 
 var _ = AfterSuite(func() {
 	cancel()
+	Expect(os.RemoveAll(gardenHomeDir)).To(Succeed())
 }, 5)
 
 func createTestKubeconfig(name string) []byte {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enhances the `kubectl-env` command to also support if a shoot control-plane or project is targeted.

**Which issue(s) this PR fixes**:
Fixes #50

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
