### PR TITLE
Added gardenctl command long description

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -72,8 +72,24 @@ func NewDefaultGardenctlCommand() *cobra.Command {
 // NewGardenctlCommand creates the `gardenctl` command
 func NewGardenctlCommand(f *util.FactoryImpl, ioStreams util.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:          "gardenctl",
-		Short:        "gardenctl is a utility to interact with Gardener installations",
+		Use:   "gardenctl",
+		Short: "gardenctl is a utility to interact with Gardener installations",
+		Long: `Gardenctl is a utility to interact with Gardener installations.
+
+The state of gardenctl is bound to a shell session and is not shared across windows, tabs or panes.
+A shell session is defined by the environment variable GCTL_SESSION_ID. If this is not defined,
+the value of the TERM_SESSION_ID environment variable is used instead.If both are not defined,
+this leads to an error and gardenctl cannot be executed. The target.yaml and temporary
+kubeconfig.*.yaml files are store in the following directory ${TMPDIR}/garden/${GCTL_SESSION_ID}.
+
+You can make sure that whether GCTL_SESSION_ID or TERM_SESSION_ID is always present by adding
+the following code to your terminal profile ~/.profile, ~/.bashrc or comparable file.
+  bash and zsh: [ -n "$TERM_SESSION_ID" ] || export TERM_SESSION_ID="$(uuidgen)"
+  fish:         [ -n "$TERM_SESSION_ID" ] || set -gx TERM_SESSION_ID "$(uuidgen)"
+  powershell:   $Env:TERM_SESSION_ID ??= [guid]::NewGuid().ToString()
+
+Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/README.md
+`,
 		SilenceUsage: true,
 	}
 
@@ -294,5 +310,5 @@ func getSessionID() (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("Environment variable %s is required", envSessionID)
+	return "", fmt.Errorf("Environment variable %s is required. Use \"gardenctl help\" for more information about the requirements of gardenctl", envSessionID)
 }

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -84,9 +84,9 @@ kubeconfig.*.yaml files are store in the following directory ${TMPDIR}/garden/${
 
 You can make sure that GCTL_SESSION_ID or TERM_SESSION_ID is always present by adding
 the following code to your terminal profile ~/.profile, ~/.bashrc or comparable file.
-  bash and zsh: [ -n "$TERM_SESSION_ID" ] || export TERM_SESSION_ID="$(uuidgen)"
-  fish:         [ -n "$TERM_SESSION_ID" ] || set -gx TERM_SESSION_ID "$(uuidgen)"
-  powershell:   $Env:TERM_SESSION_ID ??= [guid]::NewGuid().ToString()
+  bash and zsh: [ -n "$GCTL_SESSION_ID" ] || [ -n "$TERM_SESSION_ID" ] || export GCTL_SESSION_ID=$(uuidgen)
+  fish:         [ -n "$GCTL_SESSION_ID" ] || [ -n "$TERM_SESSION_ID" ] || set -gx GCTL_SESSION_ID (uuidgen)
+  powershell:   if ( !(Test-Path Env:GCTL_SESSION_ID) -and !(Test-Path Env:TERM_SESSION_ID) ) { $Env:GCTL_SESSION_ID = [guid]::NewGuid().ToString() }
 
 Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/README.md
 `,

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -82,7 +82,7 @@ the value of the TERM_SESSION_ID environment variable is used instead. If both a
 this leads to an error and gardenctl cannot be executed. The target.yaml and temporary
 kubeconfig.*.yaml files are store in the following directory ${TMPDIR}/garden/${GCTL_SESSION_ID}.
 
-You can make sure that whether GCTL_SESSION_ID or TERM_SESSION_ID is always present by adding
+You can make sure that GCTL_SESSION_ID or TERM_SESSION_ID is always present by adding
 the following code to your terminal profile ~/.profile, ~/.bashrc or comparable file.
   bash and zsh: [ -n "$TERM_SESSION_ID" ] || export TERM_SESSION_ID="$(uuidgen)"
   fish:         [ -n "$TERM_SESSION_ID" ] || set -gx TERM_SESSION_ID "$(uuidgen)"

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -33,11 +33,11 @@ import (
 )
 
 const (
-	envPrefix         = "GCTL"
-	envGardenHomeDir  = envPrefix + "_HOME"
-	envConfigName     = envPrefix + "_CONFIG_NAME"
-	envSessionID      = envPrefix + "_SESSION_ID"
-	envItermSessionID = "ITERM_SESSION_ID"
+	envPrefix        = "GCTL"
+	envGardenHomeDir = envPrefix + "_HOME"
+	envConfigName    = envPrefix + "_CONFIG_NAME"
+	envSessionID     = envPrefix + "_SESSION_ID"
+	envTermSessionID = "TERM_SESSION_ID"
 
 	gardenHomeFolder = ".garden"
 	configName       = "gardenctl-v2"
@@ -287,7 +287,7 @@ func getSessionID() (string, error) {
 		return "", fmt.Errorf("Environment variable %s must only contain alphanumeric characters, underscore and dash and have a minimum length of 1 and a maximum length of 128", envSessionID)
 	}
 
-	if value, ok := os.LookupEnv(envItermSessionID); ok {
+	if value, ok := os.LookupEnv(envTermSessionID); ok {
 		match := uuidRegexp.FindStringSubmatch(strings.ToLower(value))
 		if len(match) > 1 {
 			return match[1], nil

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -78,7 +78,7 @@ func NewGardenctlCommand(f *util.FactoryImpl, ioStreams util.IOStreams) *cobra.C
 
 The state of gardenctl is bound to a shell session and is not shared across windows, tabs or panes.
 A shell session is defined by the environment variable GCTL_SESSION_ID. If this is not defined,
-the value of the TERM_SESSION_ID environment variable is used instead.If both are not defined,
+the value of the TERM_SESSION_ID environment variable is used instead. If both are not defined,
 this leads to an error and gardenctl cannot be executed. The target.yaml and temporary
 kubeconfig.*.yaml files are store in the following directory ${TMPDIR}/garden/${GCTL_SESSION_ID}.
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the fallback sessionID from `ITERM_SESSION_ID` to the more generic `TERM_SESSION_ID` environment variable. It adds a long description to the gardenctl root command. The error message, if no sessionID is found, now refers to the gardenctl help.

```
$ gardenctl  help
Gardenctl is a utility to interact with Gardener installations.

The state of gardenctl is bound to a shell session and is not shared across windows, tabs or panes.
A shell session is defined by the environment variable GCTL_SESSION_ID. If this is not defined,
the value of the TERM_SESSION_ID environment variable is used instead. If both are not defined,
this leads to an error and gardenctl cannot be executed. The target.yaml and temporary
kubeconfig.*.yaml files are store in the following directory ${TMPDIR}/garden/${GCTL_SESSION_ID}.

You can make sure that GCTL_SESSION_ID or TERM_SESSION_ID is always present by adding
the following code to your terminal profile ~/.profile, ~/.bashrc or comparable file.
  bash and zsh: [ -n "$GCTL_SESSION_ID" ] || [ -n "$TERM_SESSION_ID" ] || export GCTL_SESSION_ID=$(uuidgen)
  fish:         [ -n "$GCTL_SESSION_ID" ] || [ -n "$TERM_SESSION_ID" ] || set -gx GCTL_SESSION_ID (uuidgen)
  powershell:   if ( !(Test-Path Env:GCTL_SESSION_ID) -and !(Test-Path Env:TERM_SESSION_ID) ) { $Env:GCTL_SESSION_ID = [guid]::NewGuid().ToString() }

Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/README.md

Usage:
  gardenctl [command]

Available Commands:
  ...

Flags:
  ...

Use "gardenctl [command] --help" for more information about a command.
```  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
