### PR TITLE
Session isolation for `provider-env` command

### DIFF
--- a/pkg/cmd/env/env_suite_test.go
+++ b/pkg/cmd/env/env_suite_test.go
@@ -40,7 +40,7 @@ var _ = AfterSuite(func() {
 })
 
 func makeTempGardenHomeDir() string {
-	dir, err := os.MkdirTemp(os.TempDir(), "garden-*")
+	dir, err := os.MkdirTemp("", "garden-*")
 	Expect(err).NotTo(HaveOccurred())
 	Expect(os.Mkdir(filepath.Join(dir, "templates"), 0777)).NotTo(HaveOccurred())
 

--- a/pkg/cmd/env/env_suite_test.go
+++ b/pkg/cmd/env/env_suite_test.go
@@ -20,7 +20,10 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
-var gardenHomeDir string
+var (
+	gardenHomeDir string
+	sessionDir    string
+)
 
 func init() {
 	utilruntime.Must(gardencorev1beta1.AddToScheme(scheme.Scheme))
@@ -33,6 +36,7 @@ func TestCloudEnvCommand(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	gardenHomeDir = makeTempGardenHomeDir()
+	sessionDir = filepath.Join(gardenHomeDir, "sessions")
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/cmd/env/options.go
+++ b/pkg/cmd/env/options.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -33,6 +34,8 @@ type options struct {
 	Shell string
 	// GardenDir is the configuration directory of gardenctl.
 	GardenDir string
+	// SessionDir is the session directory of gardenctl.
+	SessionDir string
 	// CmdPath is the path of the called command.
 	CmdPath string
 	// CurrentTarget is the current target
@@ -56,6 +59,13 @@ func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) er
 			return err
 		}
 	}
+
+	manager, err := f.Manager()
+	if err != nil {
+		return err
+	}
+
+	o.SessionDir = manager.SessionDir()
 
 	return nil
 }
@@ -182,6 +192,13 @@ func execTmpl(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret,
 	}
 
 	switch o.ProviderType {
+	case "azure":
+		configDir, err := createProviderConfigDir(o.SessionDir, o.ProviderType)
+		if err != nil {
+			return err
+		}
+
+		data["configDir"] = configDir
 	case "gcp":
 		credentials := make(map[string]interface{})
 
@@ -190,6 +207,12 @@ func execTmpl(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret,
 			return err
 		}
 
+		configDir, err := createProviderConfigDir(o.SessionDir, o.ProviderType)
+		if err != nil {
+			return err
+		}
+
+		data["configDir"] = configDir
 		data["credentials"] = credentials
 		data["serviceaccount.json"] = string(serviceaccountJSON)
 	case "openstack":
@@ -274,4 +297,16 @@ func parseGCPCredentials(secret *corev1.Secret, credentials interface{}) ([]byte
 	}
 
 	return json.Marshal(credentials)
+}
+
+func createProviderConfigDir(sessionDir string, providerType string) (string, error) {
+	cli := getProviderCLI(providerType)
+	configDir := filepath.Join(sessionDir, ".config", cli)
+
+	err := os.MkdirAll(configDir, 0700)
+	if err != nil {
+		return "", fmt.Errorf("failed to create %s configuration directory: %w", cli, err)
+	}
+
+	return configDir, nil
 }

--- a/pkg/cmd/env/options.go
+++ b/pkg/cmd/env/options.go
@@ -53,19 +53,19 @@ func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) er
 	o.GardenDir = f.GardenHomeDir()
 	o.Template = newTemplate("usage-hint")
 
-	if o.ProviderType == "kubernetes" {
-		filename := filepath.Join(o.GardenDir, "templates", "kubernetes.tmpl")
-		if err := o.Template.ParseFiles(filename); err != nil {
-			return err
-		}
-	}
-
 	manager, err := f.Manager()
 	if err != nil {
 		return err
 	}
 
 	o.SessionDir = manager.SessionDir()
+
+	if o.ProviderType == "kubernetes" {
+		filename := filepath.Join(o.GardenDir, "templates", "kubernetes.tmpl")
+		if err := o.Template.ParseFiles(filename); err != nil {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/pkg/cmd/env/options.go
+++ b/pkg/cmd/env/options.go
@@ -53,18 +53,19 @@ func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) er
 	o.GardenDir = f.GardenHomeDir()
 	o.Template = newTemplate("usage-hint")
 
-	manager, err := f.Manager()
-	if err != nil {
-		return err
-	}
-
-	o.SessionDir = manager.SessionDir()
-
-	if o.ProviderType == "kubernetes" {
+	switch o.ProviderType {
+	case "kubernetes":
 		filename := filepath.Join(o.GardenDir, "templates", "kubernetes.tmpl")
 		if err := o.Template.ParseFiles(filename); err != nil {
 			return err
 		}
+	case "azure", "gcp":
+		manager, err := f.Manager()
+		if err != nil {
+			return err
+		}
+
+		o.SessionDir = manager.SessionDir()
 	}
 
 	return nil

--- a/pkg/cmd/env/options.go
+++ b/pkg/cmd/env/options.go
@@ -59,7 +59,7 @@ func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) er
 		if err := o.Template.ParseFiles(filename); err != nil {
 			return err
 		}
-	case "azure", "gcp":
+	default:
 		manager, err := f.Manager()
 		if err != nil {
 			return err

--- a/pkg/cmd/env/options_test.go
+++ b/pkg/cmd/env/options_test.go
@@ -37,8 +37,6 @@ import (
 
 var _ = Describe("Env Commands - Options", func() {
 	Describe("having an Options instance", func() {
-		const sessionDir = "session-dir"
-
 		var (
 			ctrl    *gomock.Controller
 			factory *utilmocks.MockFactory

--- a/pkg/cmd/env/options_test.go
+++ b/pkg/cmd/env/options_test.go
@@ -357,7 +357,7 @@ var _ = Describe("Env Commands - Options", func() {
 
 					It("does the work when the shoot is targeted via project", func() {
 						Expect(options.Run(factory)).To(Succeed())
-						Expect(options.String()).To(Equal(readTestFile("gcp/export.bash")))
+						Expect(options.String()).To(Equal(fmt.Sprintf(readTestFile("gcp/export.bash"), sessionDir)))
 					})
 
 					It("should print how to reset configuration for powershell", func() {
@@ -377,7 +377,7 @@ var _ = Describe("Env Commands - Options", func() {
 
 					It("does the work when the shoot is targeted via seed", func() {
 						Expect(options.Run(factory)).To(Succeed())
-						Expect(options.String()).To(Equal(readTestFile("gcp/export.seed.bash")))
+						Expect(options.String()).To(Equal(fmt.Sprintf(readTestFile("gcp/export.seed.bash"), sessionDir)))
 					})
 				})
 			})
@@ -538,7 +538,7 @@ var _ = Describe("Env Commands - Options", func() {
 
 				It("should render the template successfully", func() {
 					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(Succeed())
-					Expect(options.String()).To(Equal(readTestFile("gcp/export.bash")))
+					Expect(options.String()).To(Equal(fmt.Sprintf(readTestFile("gcp/export.bash"), sessionDir)))
 				})
 			})
 
@@ -684,7 +684,7 @@ var _ = Describe("Env Commands - Options", func() {
 
 				It("should render the template successfully", func() {
 					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(Succeed())
-					Expect(options.String()).To(Equal(readTestFile("azure/export.fish")))
+					Expect(options.String()).To(Equal(fmt.Sprintf(readTestFile("azure/export.fish"), sessionDir)))
 				})
 
 				It("should fail with mkdir error", func() {

--- a/pkg/cmd/env/template_test.go
+++ b/pkg/cmd/env/template_test.go
@@ -131,6 +131,7 @@ var _ = Describe("Env Commands - Template", func() {
 export GOOGLE_CREDENTIALS_ACCOUNT='%[3]s';
 export CLOUDSDK_CORE_PROJECT='%[4]s';
 export CLOUDSDK_COMPUTE_REGION='%[2]s';
+export CLOUDSDK_CONFIG='%[5]s';
 gcloud auth activate-service-account $GOOGLE_CREDENTIALS_ACCOUNT --key-file <(printf "%%s" "$GOOGLE_CREDENTIALS");
 printf 'Run the following command to revoke access credentials:\n$ eval $(gardenctl provider-env --garden garden --project project --shoot shoot -u %[1]s)\n';
 
@@ -143,6 +144,7 @@ unset GOOGLE_CREDENTIALS;
 unset GOOGLE_CREDENTIALS_ACCOUNT;
 unset CLOUDSDK_CORE_PROJECT;
 unset CLOUDSDK_COMPUTE_REGION;
+unset CLOUDSDK_CONFIG;
 
 # Run this command to reset the gcloud configuration for your shell:
 # eval $(gardenctl provider-env -u %[1]s)
@@ -150,6 +152,7 @@ unset CLOUDSDK_COMPUTE_REGION;
 		var (
 			clientEmail = "john.doe@example.org"
 			projectID   = "test"
+			configDir   = "config-dir"
 		)
 
 		BeforeEach(func() {
@@ -163,6 +166,7 @@ unset CLOUDSDK_COMPUTE_REGION;
 				"client_email": clientEmail,
 				"project_id":   projectID,
 			}
+			data["configDir"] = configDir
 		})
 
 		DescribeTable("executing the bash template",
@@ -170,7 +174,7 @@ unset CLOUDSDK_COMPUTE_REGION;
 				metadata["shell"] = shell
 				metadata["unset"] = unset
 				Expect(t.ExecuteTemplate(out, shell, data)).To(Succeed())
-				Expect(out.String()).To(Equal(fmt.Sprintf(format, shell, region, clientEmail, projectID)))
+				Expect(out.String()).To(Equal(fmt.Sprintf(format, shell, region, clientEmail, projectID, configDir)))
 			},
 			Entry("export environment variables", false, exportFormat),
 			Entry("unset environment variables", true, unsetFormat),
@@ -182,6 +186,7 @@ unset CLOUDSDK_COMPUTE_REGION;
 $Env:AZURE_CLIENT_SECRET = '%[3]s';
 $Env:AZURE_TENANT_ID = '%[4]s';
 $Env:AZURE_SUBSCRIPTION_ID = '%[5]s';
+$Env:AZURE_CONFIG_DIR = '%[6]s';
 az login --service-principal --username "$Env:AZURE_CLIENT_ID" --password "$Env:AZURE_CLIENT_SECRET" --tenant "$Env:AZURE_TENANT_ID";
 az account set --subscription "$Env:AZURE_SUBSCRIPTION_ID";
 printf 'Run the following command to log out and remove access to Azure subscriptions:\n$ & gardenctl provider-env --garden garden --project project --shoot shoot -u %[1]s | Invoke-Expression\n';
@@ -194,6 +199,7 @@ Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_CLIENT_ID;
 Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_CLIENT_SECRET;
 Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_TENANT_ID;
 Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_SUBSCRIPTION_ID;
+Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_CONFIG_DIR;
 # Run this command to reset the az configuration for your shell:
 # & gardenctl provider-env -u %[1]s | Invoke-Expression
 `
@@ -202,6 +208,7 @@ Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_SUBSCRIPTION_ID;
 			clientSecret   = "secret"
 			tenantID       = "tenant"
 			subscriptionID = "subscription"
+			configDir      = "config-dir"
 		)
 
 		BeforeEach(func() {
@@ -216,6 +223,7 @@ Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_SUBSCRIPTION_ID;
 			data["clientSecret"] = clientSecret
 			data["tenantID"] = tenantID
 			data["subscriptionID"] = subscriptionID
+			data["configDir"] = configDir
 		})
 
 		DescribeTable("executing the bash template",
@@ -223,7 +231,7 @@ Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_SUBSCRIPTION_ID;
 				metadata["shell"] = shell
 				metadata["unset"] = unset
 				Expect(t.ExecuteTemplate(out, shell, data)).To(Succeed())
-				Expect(out.String()).To(Equal(fmt.Sprintf(format, shell, clientID, clientSecret, tenantID, subscriptionID)))
+				Expect(out.String()).To(Equal(fmt.Sprintf(format, shell, clientID, clientSecret, tenantID, subscriptionID, configDir)))
 			},
 			Entry("export environment variables", false, exportFormat),
 			Entry("unset environment variables", true, unsetFormat),

--- a/pkg/cmd/env/templates/azure.tmpl
+++ b/pkg/cmd/env/templates/azure.tmpl
@@ -9,6 +9,7 @@ export AZURE_CLIENT_ID={{.clientID | shellEscape}};
 export AZURE_CLIENT_SECRET={{.clientSecret | shellEscape}};
 export AZURE_TENANT_ID={{.tenantID | shellEscape}};
 export AZURE_SUBSCRIPTION_ID={{.subscriptionID | shellEscape}};
+export AZURE_CONFIG_DIR={{.configDir | shellEscape}};
 az login --service-principal --username "$AZURE_CLIENT_ID" --password "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID";
 az account set --subscription "$AZURE_SUBSCRIPTION_ID";
 {{end}}{{template "azure-usage-hint" .__meta}}{{end}}
@@ -27,6 +28,7 @@ set -gx AZURE_CLIENT_ID {{.clientID | shellEscape}};
 set -gx AZURE_CLIENT_SECRET {{.clientSecret | shellEscape}};
 set -gx AZURE_TENANT_ID {{.tenantID | shellEscape}};
 set -gx AZURE_SUBSCRIPTION_ID {{.subscriptionID | shellEscape}};
+set -gx AZURE_CONFIG_DIR {{.configDir | shellEscape}};
 az login --service-principal --username "$AZURE_CLIENT_ID" --password "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID";
 az account set --subscription "$AZURE_SUBSCRIPTION_ID";
 {{end}}{{template "azure-usage-hint" .__meta}}{{end}}
@@ -42,6 +44,7 @@ $Env:AZURE_CLIENT_ID = {{.clientID | shellEscape}};
 $Env:AZURE_CLIENT_SECRET = {{.clientSecret | shellEscape}};
 $Env:AZURE_TENANT_ID = {{.tenantID | shellEscape}};
 $Env:AZURE_SUBSCRIPTION_ID = {{.subscriptionID | shellEscape}};
+$Env:AZURE_CONFIG_DIR = {{.configDir | shellEscape}};
 az login --service-principal --username "$Env:AZURE_CLIENT_ID" --password "$Env:AZURE_CLIENT_SECRET" --tenant "$Env:AZURE_TENANT_ID";
 az account set --subscription "$Env:AZURE_SUBSCRIPTION_ID";
 {{end}}{{template "azure-usage-hint" .__meta}}{{end}}

--- a/pkg/cmd/env/templates/azure.tmpl
+++ b/pkg/cmd/env/templates/azure.tmpl
@@ -4,6 +4,7 @@ unset AZURE_CLIENT_ID;
 unset AZURE_CLIENT_SECRET;
 unset AZURE_TENANT_ID;
 unset AZURE_SUBSCRIPTION_ID;
+unset AZURE_CONFIG_DIR;
 {{else -}}
 export AZURE_CLIENT_ID={{.clientID | shellEscape}};
 export AZURE_CLIENT_SECRET={{.clientSecret | shellEscape}};
@@ -23,6 +24,7 @@ set -e AZURE_CLIENT_ID;
 set -e AZURE_CLIENT_SECRET;
 set -e AZURE_TENANT_ID;
 set -e AZURE_SUBSCRIPTION_ID;
+set -e AZURE_CONFIG_DIR;
 {{else -}}
 set -gx AZURE_CLIENT_ID {{.clientID | shellEscape}};
 set -gx AZURE_CLIENT_SECRET {{.clientSecret | shellEscape}};
@@ -39,6 +41,7 @@ Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_CLIENT_ID;
 Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_CLIENT_SECRET;
 Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_TENANT_ID;
 Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_SUBSCRIPTION_ID;
+Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_CONFIG_DIR;
 {{else -}}
 $Env:AZURE_CLIENT_ID = {{.clientID | shellEscape}};
 $Env:AZURE_CLIENT_SECRET = {{.clientSecret | shellEscape}};

--- a/pkg/cmd/env/templates/gcp.tmpl
+++ b/pkg/cmd/env/templates/gcp.tmpl
@@ -9,6 +9,7 @@ export GOOGLE_CREDENTIALS={{.credentials | toJson | shellEscape}};
 export GOOGLE_CREDENTIALS_ACCOUNT={{.credentials.client_email | shellEscape}};
 export CLOUDSDK_CORE_PROJECT={{.credentials.project_id | shellEscape}};
 export CLOUDSDK_COMPUTE_REGION={{.region | shellEscape}};
+export CLOUDSDK_CONFIG={{.configDir | shellEscape}};
 gcloud auth activate-service-account $GOOGLE_CREDENTIALS_ACCOUNT --key-file <(printf "%s" "$GOOGLE_CREDENTIALS");
 {{end}}{{template "gcp-usage-hint" .__meta}}{{end}}
 
@@ -26,6 +27,7 @@ set -gx GOOGLE_CREDENTIALS {{.credentials | toJson | shellEscape}};
 set -gx GOOGLE_CREDENTIALS_ACCOUNT {{.credentials.client_email | shellEscape}};
 set -gx CLOUDSDK_CORE_PROJECT {{.credentials.project_id | shellEscape}};
 set -gx CLOUDSDK_COMPUTE_REGION {{.region | shellEscape}};
+set -gx CLOUDSDK_CONFIG {{.configDir | shellEscape}};
 gcloud auth activate-service-account $GOOGLE_CREDENTIALS_ACCOUNT --key-file (printf "%s" "$GOOGLE_CREDENTIALS" | psub);
 {{end}}{{template "gcp-usage-hint" .__meta}}{{end}}
 
@@ -39,6 +41,7 @@ $Env:GOOGLE_CREDENTIALS = {{.credentials | toJson | shellEscape}};
 $Env:GOOGLE_CREDENTIALS_ACCOUNT = {{.credentials.client_email | shellEscape}};
 $Env:CLOUDSDK_CORE_PROJECT = {{.credentials.project_id | shellEscape}};
 $Env:CLOUDSDK_COMPUTE_REGION = {{.region | shellEscape}};
+$Env:CLOUDSDK_CONFIG = {{.configDir | shellEscape}};
 function Invoke-WithGoogleCredentials {param([Parameter(Mandatory)] [ScriptBlock] $sb); $f = New-TemporaryFile; try {$Env:GOOGLE_CREDENTIALS | Out-File -Encoding utf8 $f; Invoke-Command -ScriptBlock $sb -ArgumentList $f} finally {Remove-Item -ErrorAction SilentlyContinue $f}};
 Invoke-WithGoogleCredentials {param($f) gcloud auth activate-service-account $Env:GOOGLE_CREDENTIALS_ACCOUNT --key-file $f};
 {{end}}{{template "gcp-usage-hint" .__meta}}{{end}}

--- a/pkg/cmd/env/templates/gcp.tmpl
+++ b/pkg/cmd/env/templates/gcp.tmpl
@@ -4,6 +4,7 @@ unset GOOGLE_CREDENTIALS;
 unset GOOGLE_CREDENTIALS_ACCOUNT;
 unset CLOUDSDK_CORE_PROJECT;
 unset CLOUDSDK_COMPUTE_REGION;
+unset CLOUDSDK_CONFIG;
 {{else -}}
 export GOOGLE_CREDENTIALS={{.credentials | toJson | shellEscape}};
 export GOOGLE_CREDENTIALS_ACCOUNT={{.credentials.client_email | shellEscape}};
@@ -22,6 +23,7 @@ set -e GOOGLE_CREDENTIALS;
 set -e GOOGLE_CREDENTIALS_ACCOUNT;
 set -e CLOUDSDK_CORE_PROJECT;
 set -e CLOUDSDK_COMPUTE_REGION;
+set -e CLOUDSDK_CONFIG;
 {{else -}}
 set -gx GOOGLE_CREDENTIALS {{.credentials | toJson | shellEscape}};
 set -gx GOOGLE_CREDENTIALS_ACCOUNT {{.credentials.client_email | shellEscape}};
@@ -36,6 +38,7 @@ gcloud auth revoke $Env:GOOGLE_CREDENTIALS_ACCOUNT --verbosity=error;
 Remove-Item -ErrorAction SilentlyContinue Env:\GOOGLE_CREDENTIALS;
 Remove-Item -ErrorAction SilentlyContinue Env:\CLOUDSDK_CORE_PROJECT;
 Remove-Item -ErrorAction SilentlyContinue Env:\CLOUDSDK_COMPUTE_REGION;
+Remove-Item -ErrorAction SilentlyContinue Env:\CLOUDSDK_CONFIG;
 {{else -}}
 $Env:GOOGLE_CREDENTIALS = {{.credentials | toJson | shellEscape}};
 $Env:GOOGLE_CREDENTIALS_ACCOUNT = {{.credentials.client_email | shellEscape}};

--- a/pkg/cmd/env/testdata/azure/export.fish
+++ b/pkg/cmd/env/testdata/azure/export.fish
@@ -1,0 +1,11 @@
+set -gx AZURE_CLIENT_ID 'client-id';
+set -gx AZURE_CLIENT_SECRET 'client-secret';
+set -gx AZURE_TENANT_ID 'tenant-id';
+set -gx AZURE_SUBSCRIPTION_ID 'subscription-id';
+set -gx AZURE_CONFIG_DIR 'session-dir/.config/az';
+az login --service-principal --username "$AZURE_CLIENT_ID" --password "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID";
+az account set --subscription "$AZURE_SUBSCRIPTION_ID";
+printf 'Run the following command to log out and remove access to Azure subscriptions:\n$ eval (gardenctl provider-env --garden test --project project --shoot shoot -u fish)\n';
+
+# Run this command to configure az for your shell:
+# eval (gardenctl provider-env fish)

--- a/pkg/cmd/env/testdata/azure/export.fish
+++ b/pkg/cmd/env/testdata/azure/export.fish
@@ -2,7 +2,7 @@ set -gx AZURE_CLIENT_ID 'client-id';
 set -gx AZURE_CLIENT_SECRET 'client-secret';
 set -gx AZURE_TENANT_ID 'tenant-id';
 set -gx AZURE_SUBSCRIPTION_ID 'subscription-id';
-set -gx AZURE_CONFIG_DIR 'session-dir/.config/az';
+set -gx AZURE_CONFIG_DIR '%[1]s/.config/az';
 az login --service-principal --username "$AZURE_CLIENT_ID" --password "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID";
 az account set --subscription "$AZURE_SUBSCRIPTION_ID";
 printf 'Run the following command to log out and remove access to Azure subscriptions:\n$ eval (gardenctl provider-env --garden test --project project --shoot shoot -u fish)\n';

--- a/pkg/cmd/env/testdata/gcp/export.bash
+++ b/pkg/cmd/env/testdata/gcp/export.bash
@@ -2,6 +2,7 @@ export GOOGLE_CREDENTIALS='{"client_email":"test@example.org","project_id":"test
 export GOOGLE_CREDENTIALS_ACCOUNT='test@example.org';
 export CLOUDSDK_CORE_PROJECT='test';
 export CLOUDSDK_COMPUTE_REGION='europe';
+export CLOUDSDK_CONFIG='session-dir/.config/gcloud';
 gcloud auth activate-service-account $GOOGLE_CREDENTIALS_ACCOUNT --key-file <(printf "%s" "$GOOGLE_CREDENTIALS");
 printf 'Run the following command to revoke access credentials:\n$ eval $(gardenctl provider-env --garden test --project project --shoot shoot -u bash)\n';
 

--- a/pkg/cmd/env/testdata/gcp/export.bash
+++ b/pkg/cmd/env/testdata/gcp/export.bash
@@ -2,8 +2,8 @@ export GOOGLE_CREDENTIALS='{"client_email":"test@example.org","project_id":"test
 export GOOGLE_CREDENTIALS_ACCOUNT='test@example.org';
 export CLOUDSDK_CORE_PROJECT='test';
 export CLOUDSDK_COMPUTE_REGION='europe';
-export CLOUDSDK_CONFIG='session-dir/.config/gcloud';
-gcloud auth activate-service-account $GOOGLE_CREDENTIALS_ACCOUNT --key-file <(printf "%s" "$GOOGLE_CREDENTIALS");
+export CLOUDSDK_CONFIG='%[1]s/.config/gcloud';
+gcloud auth activate-service-account $GOOGLE_CREDENTIALS_ACCOUNT --key-file <(printf "%%s" "$GOOGLE_CREDENTIALS");
 printf 'Run the following command to revoke access credentials:\n$ eval $(gardenctl provider-env --garden test --project project --shoot shoot -u bash)\n';
 
 # Run this command to configure gcloud for your shell:

--- a/pkg/cmd/env/testdata/gcp/export.seed.bash
+++ b/pkg/cmd/env/testdata/gcp/export.seed.bash
@@ -2,8 +2,8 @@ export GOOGLE_CREDENTIALS='{"client_email":"test@example.org","project_id":"test
 export GOOGLE_CREDENTIALS_ACCOUNT='test@example.org';
 export CLOUDSDK_CORE_PROJECT='test';
 export CLOUDSDK_COMPUTE_REGION='europe';
-export CLOUDSDK_CONFIG='session-dir/.config/gcloud';
-gcloud auth activate-service-account $GOOGLE_CREDENTIALS_ACCOUNT --key-file <(printf "%s" "$GOOGLE_CREDENTIALS");
+export CLOUDSDK_CONFIG='%[1]s/.config/gcloud';
+gcloud auth activate-service-account $GOOGLE_CREDENTIALS_ACCOUNT --key-file <(printf "%%s" "$GOOGLE_CREDENTIALS");
 printf 'Run the following command to revoke access credentials:\n$ eval $(gardenctl provider-env --garden test --seed seed --shoot shoot -u bash)\n';
 
 # Run this command to configure gcloud for your shell:

--- a/pkg/cmd/env/testdata/gcp/export.seed.bash
+++ b/pkg/cmd/env/testdata/gcp/export.seed.bash
@@ -2,6 +2,7 @@ export GOOGLE_CREDENTIALS='{"client_email":"test@example.org","project_id":"test
 export GOOGLE_CREDENTIALS_ACCOUNT='test@example.org';
 export CLOUDSDK_CORE_PROJECT='test';
 export CLOUDSDK_COMPUTE_REGION='europe';
+export CLOUDSDK_CONFIG='session-dir/.config/gcloud';
 gcloud auth activate-service-account $GOOGLE_CREDENTIALS_ACCOUNT --key-file <(printf "%s" "$GOOGLE_CREDENTIALS");
 printf 'Run the following command to revoke access credentials:\n$ eval $(gardenctl provider-env --garden test --seed seed --shoot shoot -u bash)\n';
 

--- a/pkg/cmd/env/testdata/gcp/unset.pwsh
+++ b/pkg/cmd/env/testdata/gcp/unset.pwsh
@@ -2,5 +2,6 @@ gcloud auth revoke $Env:GOOGLE_CREDENTIALS_ACCOUNT --verbosity=error;
 Remove-Item -ErrorAction SilentlyContinue Env:\GOOGLE_CREDENTIALS;
 Remove-Item -ErrorAction SilentlyContinue Env:\CLOUDSDK_CORE_PROJECT;
 Remove-Item -ErrorAction SilentlyContinue Env:\CLOUDSDK_COMPUTE_REGION;
+Remove-Item -ErrorAction SilentlyContinue Env:\CLOUDSDK_CONFIG;
 # Run this command to reset the gcloud configuration for your shell:
 # & gardenctl provider-env -u powershell | Invoke-Expression

--- a/pkg/cmd/env/testdata/testdata.go
+++ b/pkg/cmd/env/testdata/testdata.go
@@ -2,5 +2,5 @@ package testdata
 
 import "embed"
 
-//go:embed templates gcp openstack test
+//go:embed templates azure gcp openstack test
 var FS embed.FS

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -81,6 +81,9 @@ type Manager interface {
 	// ShootClient controller-runtime client for accessing the configured shoot cluster
 	ShootClient(ctx context.Context, t Target) (client.Client, error)
 
+	// SessionDir is the path of the session directory. All state related to
+	// the current gardenctl shell session will be stored under this directory.
+	SessionDir() string
 	// Configuration returns the current gardenctl configuration
 	Configuration() *config.Config
 
@@ -508,6 +511,10 @@ func (m *managerImpl) WriteClientConfig(config clientcmd.ClientConfig) (string, 
 	}
 
 	return filename, nil
+}
+
+func (m *managerImpl) SessionDir() string {
+	return m.sessionDirectory
 }
 
 func (m *managerImpl) SeedClient(ctx context.Context, t Target) (client.Client, error) {

--- a/pkg/target/mocks/mock_manager.go
+++ b/pkg/target/mocks/mock_manager.go
@@ -113,6 +113,20 @@ func (mr *MockManagerMockRecorder) SeedClient(arg0, arg1 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SeedClient", reflect.TypeOf((*MockManager)(nil).SeedClient), arg0, arg1)
 }
 
+// SessionDir mocks base method.
+func (m *MockManager) SessionDir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SessionDir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// SessionDir indicates an expected call of SessionDir.
+func (mr *MockManagerMockRecorder) SessionDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SessionDir", reflect.TypeOf((*MockManager)(nil).SessionDir))
+}
+
 // ShootClient mocks base method.
 func (m *MockManager) ShootClient(arg0 context.Context, arg1 target.Target) (client.Client, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What this PR does / why we need it**:
If the user closes a shell session (e.g by closing the window or entering exit) there should be no leftovers if he opens new shell in a new window. If the user has two shell sessions in two separate windows there should be no side effects in the second window if he runs a `gardenctl` in the first window. Each session should be completely isolated from other sessions.

**Which issue(s) this PR fixes**:
Fixes #73

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
