### PR TITLE
Do not remove config dir because revoke and logout commands will fails

### DIFF
--- a/pkg/cmd/env/options.go
+++ b/pkg/cmd/env/options.go
@@ -201,11 +201,6 @@ func execTmpl(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret,
 			}
 
 			data["configDir"] = configDir
-		} else {
-			err := removeProviderConfigDir(o.SessionDir, o.ProviderType)
-			if err != nil {
-				return err
-			}
 		}
 	case "gcp":
 		credentials := make(map[string]interface{})
@@ -222,11 +217,6 @@ func execTmpl(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret,
 			}
 
 			data["configDir"] = configDir
-		} else {
-			err := removeProviderConfigDir(o.SessionDir, o.ProviderType)
-			if err != nil {
-				return err
-			}
 		}
 
 		data["credentials"] = credentials
@@ -325,16 +315,4 @@ func createProviderConfigDir(sessionDir string, providerType string) (string, er
 	}
 
 	return configDir, nil
-}
-
-func removeProviderConfigDir(sessionDir string, providerType string) error {
-	cli := getProviderCLI(providerType)
-	configDir := filepath.Join(sessionDir, ".config", cli)
-
-	err := os.RemoveAll(configDir)
-	if err != nil {
-		return fmt.Errorf("failed to remove %s configuration directory: %w", cli, err)
-	}
-
-	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug that has been introduced with PR #74. It is not possible to remove cloud provider config dir in the session folder before the generated provider-env unset script is executed because the logout / revoke commands in the script will fail.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
