### PR TITLE
Generate gardenctl startup script

### DIFF
--- a/.gimps.yaml
+++ b/.gimps.yaml
@@ -1,0 +1,64 @@
+# This is the configuration for https://github.com/xrstf/gimps.
+
+importOrder: [std, external, project]
+
+exclude:
+  - "vendor/**"
+  - "third_party/**"
+  - "dev/**"
+  - "**/zz_generated.**"
+  - "**/zz_generated_**"
+  - "**/generated.pb.go"
+  - "**/generated.proto"
+  - "**/*_generated.go"
+  - ".git/**"
+  - "hack/boilerplate.go.txt"
+
+aliasRules:
+  - name: client-go
+    expr: '^k8s.io/client-go/tools/([a-z0-9-]+)/api/(v[a-z0-9-]+)$'
+    alias: '$1$2'
+
+  - name: client-go-latest
+    expr: '^k8s.io/client-go/tools/([a-z0-9-]+)/api/(latest)$'
+    alias: '$1$2'
+
+  - name: k8s-api
+    expr: '^k8s.io/api/([a-z0-9-]+)/(v[a-z0-9-]+)$'
+    alias: '$1$2'
+
+  - name: k8s-apimachinery
+    expr: '^k8s.io/apimachinery/pkg/apis/([a-z0-9-]+)/(v[a-z0-9-]+)(/([a-z0-9-]+))?$'
+    alias: '$1$2$4'
+
+  - name: gardener-garden-core-shorter
+    expr: '^github.com/gardener/gardener/pkg/apis/core/(validation)$'
+    alias: 'core$1'
+
+  - name: gardener-garden-core-short
+    expr: '^github.com/gardener/gardener/pkg/apis/core/(v[a-z0-9-]+)/([a-z0-9-]+)$'
+    alias: 'core$1$2'
+
+  - name: gardener-garden-core
+    expr: '^github.com/gardener/gardener/pkg/apis/core(/(v[a-z0-9-]+)(/([a-z0-9-]+))?)?$'
+    alias: 'gardencore$2$4'
+
+  - name: gardener-garden-other
+    expr: '^github.com/gardener/gardener/pkg/apis/([a-z0-9-]+)(/(v[a-z0-9-]+)(/([a-z0-9-]+))?)?$'
+    alias: '$1$3$5'
+
+  - name: gardener-garden-envtest
+    expr: '^github.com/gardener/gardener/pkg/envtest$'
+    alias: 'gardenenvtest'
+
+  - name: gardener-controllermanager
+    expr: '^github.com/gardener/gardener/pkg/controllermanager/apis/([a-z0-9-]+)(/(v[a-z0-9-]+)(/([a-z0-9-]+))?)?$'
+    alias: '$1$3$5'
+
+  - name: gardener-gardenlet
+    expr: '^github.com/gardener/gardener/pkg/gardenlet/apis/([a-z0-9-]+)(/(v[a-z0-9-]+)(/([a-z0-9-]+))?)?$'
+    alias: '$1$3$5'
+
+  - name: gardener-landscaper-gardenlet
+    expr: '^github.com/gardener/gardener/landscaper/pkg/gardenlet/apis/([a-z0-9-]+)(/(v[a-z0-9-]+)(/([a-z0-9-]+))?)?$'
+    alias: '$1$3$5'

--- a/docs/help/gardenctl.md
+++ b/docs/help/gardenctl.md
@@ -59,6 +59,7 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 * [gardenctl config](gardenctl_config.md)	 - Modify gardenctl configuration file using subcommands
 * [gardenctl kubectl-env](gardenctl_kubectl-env.md)	 - Generate a script that points KUBECONFIG to the targeted cluster for the specified shell
 * [gardenctl provider-env](gardenctl_provider-env.md)	 - Generate the cloud provider CLI configuration script for the specified shell
+* [gardenctl rc](gardenctl_rc.md)	 - Generate a gardenctl startup script for the specified shell
 * [gardenctl ssh](gardenctl_ssh.md)	 - Establish an SSH connection to a Shoot cluster's node
 * [gardenctl target](gardenctl_target.md)	 - Set scope for next operations, using subcommands or pattern
 * [gardenctl version](gardenctl_version.md)	 - Print the gardenctl version information

--- a/docs/help/gardenctl_rc.md
+++ b/docs/help/gardenctl_rc.md
@@ -1,0 +1,50 @@
+## gardenctl rc
+
+Generate a gardenctl startup script for the specified shell
+
+### Synopsis
+
+Generate a gardenctl startup script for the specified shell that contains various tweaks,
+such as setting environment variables, loading completions and adding some helpful aliases or functions.
+
+See each sub-command's help for details on how to use the generated shell startup script.
+
+
+### Options
+
+```
+  -h, --help   help for rc
+```
+
+### Options inherited from parent commands
+
+```
+      --add-dir-header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+      --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+      --control-plane                    target control plane of shoot, use together with shoot argument
+      --garden string                    target the given garden cluster
+      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log-dir string                   If non-empty, write log files in this directory
+      --log-file string                  If non-empty, use this log file
+      --log-file-max-size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files (default true)
+      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+      --project string                   target the given project
+      --seed string                      target the given seed cluster
+      --shoot string                     target the given shoot cluster
+      --skip-headers                     If true, avoid header prefixes in the log messages
+      --skip-log-headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+
+* [gardenctl](gardenctl.md)	 - Gardenctl is a utility to interact with Gardener installations
+* [gardenctl rc bash](gardenctl_rc_bash.md)	 - Generate a gardenctl startup script for bash
+* [gardenctl rc fish](gardenctl_rc_fish.md)	 - Generate a gardenctl startup script for fish
+* [gardenctl rc powershell](gardenctl_rc_powershell.md)	 - Generate a gardenctl startup script for powershell
+* [gardenctl rc zsh](gardenctl_rc_zsh.md)	 - Generate a gardenctl startup script for zsh
+

--- a/docs/help/gardenctl_rc_bash.md
+++ b/docs/help/gardenctl_rc_bash.md
@@ -1,0 +1,53 @@
+## gardenctl rc bash
+
+Generate a gardenctl startup script for bash
+
+### Synopsis
+
+Generate a gardenctl startup script for bash that contains various tweaks,
+such as setting environment variables, loading completions and adding some helpful aliases or functions.
+
+To load gardenctl startup script for each bash session, execute once:
+
+    echo 'source <(gardenctl rc bash)' >> ~/.bashrc
+
+
+```
+gardenctl rc bash [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for bash
+  -p, --prefix string   The prefix used for aliases and functions (default "g")
+```
+
+### Options inherited from parent commands
+
+```
+      --add-dir-header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+      --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+      --control-plane                    target control plane of shoot, use together with shoot argument
+      --garden string                    target the given garden cluster
+      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log-dir string                   If non-empty, write log files in this directory
+      --log-file string                  If non-empty, use this log file
+      --log-file-max-size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files (default true)
+      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+      --project string                   target the given project
+      --seed string                      target the given seed cluster
+      --shoot string                     target the given shoot cluster
+      --skip-headers                     If true, avoid header prefixes in the log messages
+      --skip-log-headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+
+* [gardenctl rc](gardenctl_rc.md)	 - Generate a gardenctl startup script for the specified shell
+

--- a/docs/help/gardenctl_rc_fish.md
+++ b/docs/help/gardenctl_rc_fish.md
@@ -1,0 +1,53 @@
+## gardenctl rc fish
+
+Generate a gardenctl startup script for fish
+
+### Synopsis
+
+Generate a gardenctl startup script for fish that contains various tweaks,
+such as setting environment variables, loading completions and adding some helpful aliases or functions.
+
+To load gardenctl startup script for each fish session, execute once:
+
+    echo 'gardenctl rc fish | source' >> ~/.config/fish/config.fish
+
+
+```
+gardenctl rc fish [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for fish
+  -p, --prefix string   The prefix used for aliases and functions (default "g")
+```
+
+### Options inherited from parent commands
+
+```
+      --add-dir-header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+      --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+      --control-plane                    target control plane of shoot, use together with shoot argument
+      --garden string                    target the given garden cluster
+      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log-dir string                   If non-empty, write log files in this directory
+      --log-file string                  If non-empty, use this log file
+      --log-file-max-size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files (default true)
+      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+      --project string                   target the given project
+      --seed string                      target the given seed cluster
+      --shoot string                     target the given shoot cluster
+      --skip-headers                     If true, avoid header prefixes in the log messages
+      --skip-log-headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+
+* [gardenctl rc](gardenctl_rc.md)	 - Generate a gardenctl startup script for the specified shell
+

--- a/docs/help/gardenctl_rc_powershell.md
+++ b/docs/help/gardenctl_rc_powershell.md
@@ -1,0 +1,53 @@
+## gardenctl rc powershell
+
+Generate a gardenctl startup script for powershell
+
+### Synopsis
+
+Generate a gardenctl startup script for powershell, that contains various tweaks,
+such as setting environment variables, loadings completions and adding some helpful aliases or functions.
+
+To load gardenctl startup script for each powershell session, execute once:
+
+    echo 'gardenctl rc powershell | Out-String | Invoke-Expression' >> $profile
+
+
+```
+gardenctl rc powershell [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for powershell
+  -p, --prefix string   The prefix used for aliases and functions (default "g")
+```
+
+### Options inherited from parent commands
+
+```
+      --add-dir-header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+      --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+      --control-plane                    target control plane of shoot, use together with shoot argument
+      --garden string                    target the given garden cluster
+      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log-dir string                   If non-empty, write log files in this directory
+      --log-file string                  If non-empty, use this log file
+      --log-file-max-size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files (default true)
+      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+      --project string                   target the given project
+      --seed string                      target the given seed cluster
+      --shoot string                     target the given shoot cluster
+      --skip-headers                     If true, avoid header prefixes in the log messages
+      --skip-log-headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+
+* [gardenctl rc](gardenctl_rc.md)	 - Generate a gardenctl startup script for the specified shell
+

--- a/docs/help/gardenctl_rc_zsh.md
+++ b/docs/help/gardenctl_rc_zsh.md
@@ -1,0 +1,58 @@
+## gardenctl rc zsh
+
+Generate a gardenctl startup script for zsh
+
+### Synopsis
+
+Generate a gardenctl startup script for zsh that contains various tweaks,
+such as setting environment variables, loading completions and adding some helpful aliases or functions.
+
+If shell completion is not already enabled in your environment you will need
+to enable it. You can execute the following once:
+
+    echo "autoload -U compinit; compinit" >> ~/.zshrc
+
+To load gardenctl startup script for each zsh session, execute once:
+
+    echo 'source <(gardenctl rc zsh)' >> ~/.zshrc
+
+
+```
+gardenctl rc zsh [flags]
+```
+
+### Options
+
+```
+  -h, --help            help for zsh
+  -p, --prefix string   The prefix used for aliases and functions (default "g")
+```
+
+### Options inherited from parent commands
+
+```
+      --add-dir-header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+      --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+      --control-plane                    target control plane of shoot, use together with shoot argument
+      --garden string                    target the given garden cluster
+      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log-dir string                   If non-empty, write log files in this directory
+      --log-file string                  If non-empty, use this log file
+      --log-file-max-size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files (default true)
+      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+      --project string                   target the given project
+      --seed string                      target the given seed cluster
+      --shoot string                     target the given shoot cluster
+      --skip-headers                     If true, avoid header prefixes in the log messages
+      --skip-log-headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+
+* [gardenctl rc](gardenctl_rc.md)	 - Generate a gardenctl startup script for the specified shell
+

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -135,7 +135,7 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 	cmd.AddCommand(cmdconfig.NewCmdConfig(f, ioStreams))
 	cmd.AddCommand(cmdenv.NewCmdProviderEnv(f, ioStreams))
 	cmd.AddCommand(cmdenv.NewCmdKubectlEnv(f, ioStreams))
-	cmd.AddCommand(cmdenv.NewCmdRunCommands(f, ioStreams))
+	cmd.AddCommand(cmdenv.NewCmdRC(f, ioStreams))
 
 	return cmd
 }

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -135,6 +135,7 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 	cmd.AddCommand(cmdconfig.NewCmdConfig(f, ioStreams))
 	cmd.AddCommand(cmdenv.NewCmdProviderEnv(f, ioStreams))
 	cmd.AddCommand(cmdenv.NewCmdKubectlEnv(f, ioStreams))
+	cmd.AddCommand(cmdenv.NewCmdRunCommands(f, ioStreams))
 
 	return cmd
 }

--- a/pkg/cmd/env/export_test.go
+++ b/pkg/cmd/env/export_test.go
@@ -9,11 +9,11 @@ package env
 import (
 	"text/template"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
 var (

--- a/pkg/cmd/env/export_test.go
+++ b/pkg/cmd/env/export_test.go
@@ -9,11 +9,11 @@ package env
 import (
 	"text/template"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
 var (

--- a/pkg/cmd/env/export_test.go
+++ b/pkg/cmd/env/export_test.go
@@ -26,6 +26,10 @@ var (
 	NewTemplate         = newTemplate
 )
 
+type RCOptions struct {
+	rcOptions
+}
+
 type TestOptions struct {
 	options
 	out *util.SafeBytesBuffer

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -3,6 +3,7 @@ package env
 import (
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -136,6 +137,8 @@ To load gardenctl startup script for each %[1]s session, execute once:
 	}
 }
 
+var prefixRegexp = regexp.MustCompile(`^[[:alpha:]][\w-]*$`)
+
 type rcOptions struct {
 	base.Options
 	// Shell to configure.
@@ -166,6 +169,10 @@ func (o *rcOptions) Validate() error {
 	s := Shell(o.Shell)
 	if err := s.Validate(); err != nil {
 		return err
+	}
+
+	if !prefixRegexp.MatchString(o.Prefix) {
+		return fmt.Errorf("prefix must start with an alphabetic character may followed by alphanumeric characters, underscore or dash")
 	}
 
 	return nil

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -21,8 +21,8 @@ func NewCmdRC(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "rc",
 		Short: "Generate a gardenctl startup script for the specified shell",
-		Long: `Generate a gardenctl startup script for the specified shell, that contains various tweaks,
-such as setting environment variables, loadings completions and adding some helpful aliases or functions.
+		Long: `Generate a gardenctl startup script for the specified shell that contains various tweaks,
+such as setting environment variables, loading completions and adding some helpful aliases or functions.
 
 See each sub-command's help for details on how to use the generated shell startup script.
 `,
@@ -70,8 +70,8 @@ func createBashCommand(cmdPath string) *cobra.Command {
 	return &cobra.Command{
 		Use:   string(shell),
 		Short: fmt.Sprintf("Generate a gardenctl startup script for %s", shell),
-		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s, that contains various tweaks,
-such as setting environment variables, loadings completions and adding some helpful aliases or functions.
+		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s that contains various tweaks,
+such as setting environment variables, loading completions and adding some helpful aliases or functions.
 
 To load gardenctl startup script for each %[1]s session, execute once:
 
@@ -88,8 +88,8 @@ func createZshCommand(cmdPath string) *cobra.Command {
 	return &cobra.Command{
 		Use:   string(shell),
 		Short: fmt.Sprintf("Generate a gardenctl startup script for %s", shell),
-		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s, that contains various tweaks,
-such as setting environment variables, loadings completions and adding some helpful aliases or functions.
+		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s that contains various tweaks,
+such as setting environment variables, loading completions and adding some helpful aliases or functions.
 
 To load gardenctl startup script for each %[1]s session, execute once:
 
@@ -106,8 +106,8 @@ func createFishCommand(cmdPath string) *cobra.Command {
 	return &cobra.Command{
 		Use:   string(shell),
 		Short: fmt.Sprintf("Generate a gardenctl startup script for %s", shell),
-		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s, that contains various tweaks,
-such as setting environment variables, loadings completions and adding some helpful aliases or functions.
+		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s that contains various tweaks,
+such as setting environment variables, loading completions and adding some helpful aliases or functions.
 
 To load gardenctl startup script for each %[1]s session, execute once:
 

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -1,0 +1,187 @@
+package env
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+)
+
+// NewCmdRunCommands returns a new rc command.
+func NewCmdRunCommands(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	o := &rcOptions{
+		Options: base.Options{
+			IOStreams: ioStreams,
+		},
+	}
+	cmd := &cobra.Command{
+		Use:   "rc",
+		Short: "Generate a gardenctl startup script for the specified shell",
+		Long: `Generate a gardenctl startup script for the specified shell, that contains various tweaks,
+such as setting environment variables, loadings completions and adding some helpful aliases or functions.
+
+See each sub-command's help for details on how to use the generated shell startup script.
+`,
+		Aliases: []string{"profile"},
+	}
+
+	var (
+		subCmd   *cobra.Command
+		selfPath = "gardenctl"
+	)
+
+	if p, err := os.Executable(); err != nil {
+		selfPath = p
+	}
+
+	cmdPath := selfPath + " rc"
+	runE := base.WrapRunE(o, f)
+
+	subCmd = createBashCommand(cmdPath)
+	subCmd.RunE = runE
+	o.AddFlags(subCmd.Flags())
+	cmd.AddCommand(subCmd)
+
+	subCmd = createZshCommand(cmdPath)
+	subCmd.RunE = runE
+	o.AddFlags(subCmd.Flags())
+	cmd.AddCommand(subCmd)
+
+	subCmd = createFishCommand(cmdPath)
+	subCmd.RunE = runE
+	o.AddFlags(subCmd.Flags())
+	cmd.AddCommand(subCmd)
+
+	subCmd = createPwshCommand(cmdPath)
+	subCmd.RunE = runE
+	o.AddFlags(subCmd.Flags())
+	cmd.AddCommand(subCmd)
+
+	return cmd
+}
+
+func createBashCommand(cmdPath string) *cobra.Command {
+	shell := Shell("bash")
+
+	return &cobra.Command{
+		Use:   string(shell),
+		Short: fmt.Sprintf("Generate a gardenctl startup script for %s", shell),
+		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s, that contains various tweaks,
+such as setting environment variables, loadings completions and adding some helpful aliases or functions.
+
+To load gardenctl startup script for each %[1]s session, execute once:
+
+    echo 'source <(%[2]s %[1]s)' >> ~/.bashrc
+`,
+			shell, cmdPath,
+		),
+	}
+}
+
+func createZshCommand(cmdPath string) *cobra.Command {
+	shell := Shell("zsh")
+
+	return &cobra.Command{
+		Use:   string(shell),
+		Short: fmt.Sprintf("Generate a gardenctl startup script for %s", shell),
+		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s, that contains various tweaks,
+such as setting environment variables, loadings completions and adding some helpful aliases or functions.
+
+To load gardenctl startup script for each %[1]s session, execute once:
+
+    echo 'source <(%[2]s %[1]s)' >> ~/.zshrc
+`,
+			shell, cmdPath,
+		),
+	}
+}
+
+func createFishCommand(cmdPath string) *cobra.Command {
+	shell := Shell("fish")
+
+	return &cobra.Command{
+		Use:   string(shell),
+		Short: fmt.Sprintf("Generate a gardenctl startup script for %s", shell),
+		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s, that contains various tweaks,
+such as setting environment variables, loadings completions and adding some helpful aliases or functions.
+
+To load gardenctl startup script for each %[1]s session, execute once:
+
+    echo '%[2]s %[1]s | source' >> ~/.config/fish/config.fish
+`,
+			shell, cmdPath,
+		),
+	}
+}
+
+func createPwshCommand(cmdPath string) *cobra.Command {
+	shell := Shell("powershell")
+
+	return &cobra.Command{
+		Use:   string(shell),
+		Short: fmt.Sprintf("Generate a gardenctl startup script for %s", shell),
+		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s, that contains various tweaks,
+such as setting environment variables, loadings completions and adding some helpful aliases or functions.
+
+To load gardenctl startup script for each %[1]s session, execute once:
+
+    echo '%[2]s %[1]s | Out-String | Invoke-Expression' >> $profile
+`,
+			shell, cmdPath,
+		),
+	}
+}
+
+type rcOptions struct {
+	base.Options
+	// Shell to configure.
+	Shell string
+	// CmdPath is the path of the called command.
+	CmdPath string
+	// Prefix is prefix for shell aliases and functions
+	Prefix string
+	// Template is the script template
+	Template Template
+}
+
+// Complete adapts from the command line args to the data required.
+func (o *rcOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+	o.Shell = cmd.Name()
+	o.CmdPath = cmd.Parent().CommandPath()
+	o.Template = newTemplate("rc")
+
+	return nil
+}
+
+// Validate validates the provided command options.
+func (o *rcOptions) Validate() error {
+	if o.Shell == "" {
+		return pflag.ErrHelp
+	}
+
+	s := Shell(o.Shell)
+	if err := s.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run does the actual work of the command.
+func (o *rcOptions) Run(f util.Factory) error {
+	data := map[string]interface{}{
+		"shell":  o.Shell,
+		"prefix": o.Prefix,
+	}
+
+	return o.Template.ExecuteTemplate(o.IOStreams.Out, o.Shell, data)
+}
+
+// AddFlags binds the command options to a given flagset.
+func (o *rcOptions) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVarP(&o.Prefix, "prefix", "p", "g", "The prefix used for aliases and functions")
+}

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -183,7 +183,7 @@ func (o *rcOptions) Validate() error {
 	}
 
 	if !prefixRegexp.MatchString(o.Prefix) {
-		return fmt.Errorf("prefix must start with an alphabetic character may followed by alphanumeric characters, underscore or dash")
+		return fmt.Errorf("prefix must start with an alphabetic character may be followed by alphanumeric characters, underscore or dash")
 	}
 
 	return nil

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -56,7 +56,7 @@ See each sub-command's help for details on how to use the generated shell startu
 	o.AddFlags(subCmd.Flags())
 	cmd.AddCommand(subCmd)
 
-	subCmd = createPwshCommand(cmdPath)
+	subCmd = createPowershellCommand(cmdPath)
 	subCmd.RunE = runE
 	o.AddFlags(subCmd.Flags())
 	cmd.AddCommand(subCmd)
@@ -118,7 +118,7 @@ To load gardenctl startup script for each %[1]s session, execute once:
 	}
 }
 
-func createPwshCommand(cmdPath string) *cobra.Command {
+func createPowershellCommand(cmdPath string) *cobra.Command {
 	shell := Shell("powershell")
 
 	return &cobra.Command{

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -8,7 +8,6 @@ package env
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 
 	"github.com/spf13/cobra"
@@ -36,37 +35,20 @@ See each sub-command's help for details on how to use the generated shell startu
 		Aliases: []string{"profile"},
 	}
 
-	var (
-		subCmd   *cobra.Command
-		selfPath = "gardenctl"
-	)
-
-	if p, err := os.Executable(); err != nil {
-		selfPath = p
+	runE := base.WrapRunE(o, f)
+	cmdPath := "gardenctl rc"
+	subCmds := []*cobra.Command{
+		createBashCommand(cmdPath),
+		createZshCommand(cmdPath),
+		createFishCommand(cmdPath),
+		createPowershellCommand(cmdPath),
 	}
 
-	cmdPath := selfPath + " rc"
-	runE := base.WrapRunE(o, f)
-
-	subCmd = createBashCommand(cmdPath)
-	subCmd.RunE = runE
-	o.AddFlags(subCmd.Flags())
-	cmd.AddCommand(subCmd)
-
-	subCmd = createZshCommand(cmdPath)
-	subCmd.RunE = runE
-	o.AddFlags(subCmd.Flags())
-	cmd.AddCommand(subCmd)
-
-	subCmd = createFishCommand(cmdPath)
-	subCmd.RunE = runE
-	o.AddFlags(subCmd.Flags())
-	cmd.AddCommand(subCmd)
-
-	subCmd = createPowershellCommand(cmdPath)
-	subCmd.RunE = runE
-	o.AddFlags(subCmd.Flags())
-	cmd.AddCommand(subCmd)
+	for _, subCmd := range subCmds {
+		subCmd.RunE = runE
+		o.AddFlags(subCmd.Flags())
+		cmd.AddCommand(subCmd)
+	}
 
 	return cmd
 }

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -1,3 +1,9 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package env
 
 import (

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -11,8 +11,8 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 )
 
-// NewCmdRunCommands returns a new rc command.
-func NewCmdRunCommands(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+// NewCmdRC returns a new rc command.
+func NewCmdRC(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
 	o := &rcOptions{
 		Options: base.Options{
 			IOStreams: ioStreams,

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -92,6 +92,11 @@ func createZshCommand(cmdPath string) *cobra.Command {
 		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s that contains various tweaks,
 such as setting environment variables, loading completions and adding some helpful aliases or functions.
 
+If shell completion is not already enabled in your environment you will need
+to enable it. You can execute the following once:
+
+    echo "autoload -U compinit; compinit" >> ~/.zshrc
+
 To load gardenctl startup script for each %[1]s session, execute once:
 
     echo 'source <(%[2]s %[1]s)' >> ~/.zshrc

--- a/pkg/cmd/env/rc_test.go
+++ b/pkg/cmd/env/rc_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 */

--- a/pkg/cmd/env/rc_test.go
+++ b/pkg/cmd/env/rc_test.go
@@ -81,10 +81,18 @@ alias gp='eval $(gardenctl provider-env bash)'
 			Expect(out.String()).To(Equal(`if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
-source <(gardenctl completion zsh)
-compdef _gardenctl gardenctl
+if (( $+commands[gardenctl] )); then
+    gctl_completion_file="${fpath[1]}/_gardenctl"
+    if [[ ! -f "$gctl_completion_file" ]]; then
+        gardenctl completion zsh >| "$gctl_completion_file"
+        source "$gctl_completion_file"
+    else
+        source "$gctl_completion_file"
+        gardenctl completion zsh >| "$gctl_completion_file" &|
+    fi
+    unset gctl_completion_file
+fi
 alias g=gardenctl
-compdef _gardenctl g
 alias gtv='gardenctl target view -o yaml'
 alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'

--- a/pkg/cmd/env/rc_test.go
+++ b/pkg/cmd/env/rc_test.go
@@ -1,0 +1,187 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package env_test
+
+import (
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+	utilmocks "github.com/gardener/gardenctl-v2/internal/util/mocks"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/env"
+)
+
+var _ = Describe("Env Commands", func() {
+	Describe("Having a RC command instance", func() {
+		var (
+			ctrl    *gomock.Controller
+			factory *utilmocks.MockFactory
+			streams util.IOStreams
+			out     *util.SafeBytesBuffer
+			cmd     *cobra.Command
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			factory = utilmocks.NewMockFactory(ctrl)
+			streams, _, out, _ = util.NewTestIOStreams()
+			cmd = env.NewCmdRC(factory, streams)
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should have Use, Flags and SubCommands", func() {
+			Expect(cmd.Use).To(Equal("rc"))
+			Expect(cmd.Aliases).To(HaveLen(1))
+			Expect(cmd.Aliases).To(Equal([]string{"profile"}))
+			Expect(cmd.Flag("output")).To(BeNil())
+			subCmds := cmd.Commands()
+			Expect(len(subCmds)).To(Equal(4))
+			for _, c := range subCmds {
+				s := env.Shell(c.Name())
+				Expect(s).To(BeElementOf(env.ValidShells))
+				flag := c.Flag("prefix")
+				Expect(flag).NotTo(BeNil())
+				Expect(flag.Shorthand).To(Equal("p"))
+				Expect(flag.DefValue).To(Equal("g"))
+			}
+		})
+
+		It("should execute the bash subcommand", func() {
+			cmd.SetArgs([]string{"bash"})
+			Expect(cmd.Execute()).To(Succeed())
+			Expect(out.String()).To(Equal(`if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
+  export GCTL_SESSION_ID=$(uuidgen)
+fi
+source <(gardenctl completion bash)
+alias g=gardenctl
+complete -o default -F __start_gardenctl g
+alias gtv='gardenctl target view -o yaml'
+alias gtc='gardenctl target control-plane'
+alias gtc-='gardenctl target unset control-plane'
+alias gk='eval $(gardenctl kubectl-env bash)'
+alias gp='eval $(gardenctl provider-env bash)'
+`))
+		})
+
+		It("should execute the zsh subcommand", func() {
+			cmd.SetArgs([]string{"zsh"})
+			Expect(cmd.Execute()).To(Succeed())
+			Expect(out.String()).To(Equal(`if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
+  export GCTL_SESSION_ID=$(uuidgen)
+fi
+source <(gardenctl completion zsh)
+compdef _gardenctl gardenctl
+alias g=gardenctl
+compdef _gardenctl g
+alias gtv='gardenctl target view -o yaml'
+alias gtc='gardenctl target control-plane'
+alias gtc-='gardenctl target unset control-plane'
+alias gk='eval $(gardenctl kubectl-env bash)'
+alias gp='eval $(gardenctl provider-env bash)'
+`))
+		})
+
+		It("should execute the fish subcommand", func() {
+			cmd.SetArgs([]string{"fish"})
+			Expect(cmd.Execute()).To(Succeed())
+			Expect(out.String()).To(Equal(`if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ];
+  set -gx GCTL_SESSION_ID (uuidgen)
+end
+gardenctl completion fish | source
+alias g=gardenctl
+complete -c g -w gardenctl
+alias gtv='gardenctl target view -o yaml'
+alias gtc='gardenctl target control-plane'
+alias gtc-='gardenctl target unset control-plane'
+alias gk='eval (gardenctl kubectl-env bash)'
+alias gp='eval (gardenctl provider-env bash)'
+`))
+		})
+
+		It("should execute the powershell subcommand", func() {
+			cmd.SetArgs([]string{"powershell"})
+			Expect(cmd.Execute()).To(Succeed())
+			Expect(out.String()).To(Equal(`if ( !(Test-Path Env:GCTL_SESSION_ID) -and !(Test-Path Env:TERM_SESSION_ID) ) {
+  $Env:GCTL_SESSION_ID = [guid]::NewGuid().ToString()
+}
+Set-Alias -Name g -Value (get-command gardenctl).Path -Option AllScope -Force
+function Gardenctl-Completion-Powershell {
+  $s = (gardenctl completion powershell)
+  @(
+    ($s -replace "(?ms)^Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock", "` + "`" + `$scriptBlock =")
+    "Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock ` + "`" + `$scriptBlock"
+    "Register-ArgumentCompleter -CommandName 'g' -ScriptBlock ` + "`" + `$scriptBlock"
+  )
+}
+Gardenctl-Completion-Powershell | Out-String | Invoke-Expression
+function Gardenctl-Target-View {
+  gardenctl target view -o yaml
+}
+Set-Alias -Name gtv -Value Gardenctl-Target-View -Option AllScope -Force
+function Gardenctl-Target-ControlPlane {
+  gardenctl target control-plane
+}
+Set-Alias -Name gtc -Value Gardenctl-Target-ControlPlane -Option AllScope -Force
+function Gardenctl-Target-Unset-ControlPlane {
+  gardenctl target unset control-plane
+}
+Set-Alias -Name gtc- -Value Gardenctl-Target-Unset-ControlPlane -Option AllScope -Force
+function Gardenctl-KubectlEnv {
+  gardenctl kubectl-env powershell | Out-String | Invoke-Expression
+}
+Set-Alias -Name gk -Value Gardenctl-KubectlEnv -Option AllScope -Force
+function Gardenctl-ProviderEnv {
+  gardenctl provider-env powershell | Out-String | Invoke-Expression
+}
+Set-Alias -Name gp -Value Gardenctl-ProviderEnv -Option AllScope -Force
+`))
+		})
+
+		It("should execute the bash subcommand with prefix flag", func() {
+			cmd.SetArgs([]string{"--prefix=gctl", "bash"})
+			Expect(cmd.Execute()).To(Succeed())
+			Expect(out.String()).To(MatchRegexp(`(?m)^alias gctl=gardenctl$`))
+		})
+	})
+
+	Describe("Validating the RC command options", func() {
+		var options *env.RCOptions
+
+		BeforeEach(func() {
+			options = &env.RCOptions{}
+			options.Shell = "bash"
+			options.Prefix = "g"
+		})
+
+		It("should successfully validate the options", func() {
+			Expect(options.Validate()).To(Succeed())
+		})
+
+		It("should return an error when the shell is empty", func() {
+			options.Shell = ""
+			Expect(options.Validate()).To(MatchError(pflag.ErrHelp))
+		})
+
+		It("should return an error when the shell is invalid", func() {
+			options.Shell = "cmd"
+			Expect(options.Validate()).To(MatchError(fmt.Sprintf("invalid shell given, must be one of %v", env.ValidShells)))
+		})
+
+		It("should return an error when the prefix is invalid", func() {
+			options.Prefix = "!"
+			Expect(options.Validate()).To(MatchError("prefix must start with an alphabetic character may be followed by alphanumeric characters, underscore or dash"))
+		})
+	})
+})

--- a/pkg/cmd/env/templates/rc.tmpl
+++ b/pkg/cmd/env/templates/rc.tmpl
@@ -1,0 +1,57 @@
+{{define "bash" -}}
+if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
+  export GCTL_SESSION_ID=$(uuidgen)
+fi
+source <(gardenctl completion bash)
+alias {{.prefix}}=gardenctl
+complete -o default -F __start_gardenctl {{.prefix}}
+alias {{.prefix}}tv='gardenctl target view -o yaml'
+alias {{.prefix}}k='eval $(gardenctl kubectl-env bash)'
+alias {{.prefix}}p='eval $(gardenctl provider-env bash)'
+{{end}}
+
+{{define "zsh" -}}
+if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
+  export GCTL_SESSION_ID=$(uuidgen)
+fi
+source <(gardenctl completion zsh)
+alias {{.prefix}}=gardenctl
+compdef _gardenctl {{.prefix}}
+alias {{.prefix}}tv='gardenctl target view -o yaml'
+alias {{.prefix}}k='eval $(gardenctl kubectl-env bash)'
+alias {{.prefix}}p='eval $(gardenctl provider-env bash)'
+{{end}}
+
+{{define "fish" -}}
+if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ];
+  set -gx GCTL_SESSION_ID (uuidgen)
+end
+kubectl completion fish | source
+alias {{.prefix}}=gardenctl
+complete -c {{.prefix}} -w gardenctl
+alias {{.prefix}}tv='gardenctl target view -o yaml'
+alias {{.prefix}}k='eval (gardenctl kubectl-env bash)'
+alias {{.prefix}}p='eval (gardenctl provider-env bash)'
+{{end}}
+
+{{define "powershell" -}}
+if ( !(Test-Path Env:GCTL_SESSION_ID) -and !(Test-Path Env:TERM_SESSION_ID) ) {
+  $Env:GCTL_SESSION_ID = [guid]::NewGuid().ToString()
+}
+Set-Alias -Name {{.prefix}} -Value (get-command gardenctl).Path -Option AllScope -Force
+function Gardenctl-Completion-Powershell {
+  $s = (gardenctl completion powershell)
+  @(
+    ($s -replace "(?ms)^Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock", "`$scriptBlock =")
+    "Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock `$scriptBlock"
+    "Register-ArgumentCompleter -CommandName '{{.prefix}}' -ScriptBlock `$scriptBlock"
+  )
+}
+Gardenctl-Completion-Powershell | Out-String | Invoke-Expression
+function Gardenctl-Target-View { gardenctl target view -o yaml }
+Set-Alias -Name {{.prefix}}tv -Value Gardenctl-Target-View -Option AllScope -Force
+function Gardenctl-KubectlEnv { gardenctl kubectl-env powershell | Out-String | Invoke-Expression }
+Set-Alias -Name {{.prefix}}k -Value Gardenctl-KubectlEnv -Option AllScope -Force
+function Gardenctl-ProviderEnv { gardenctl provider-env powershell | Out-String | Invoke-Expression }
+Set-Alias -Name {{.prefix}}p -Value Gardenctl-ProviderEnv -Option AllScope -Force
+{{end}}

--- a/pkg/cmd/env/templates/rc.tmpl
+++ b/pkg/cmd/env/templates/rc.tmpl
@@ -49,10 +49,16 @@ function Gardenctl-Completion-Powershell {
   )
 }
 Gardenctl-Completion-Powershell | Out-String | Invoke-Expression
-function Gardenctl-Target-View { gardenctl target view -o yaml }
+function Gardenctl-Target-View {
+  gardenctl target view -o yaml
+}
 Set-Alias -Name {{.prefix}}tv -Value Gardenctl-Target-View -Option AllScope -Force
-function Gardenctl-KubectlEnv { gardenctl kubectl-env powershell | Out-String | Invoke-Expression }
+function Gardenctl-KubectlEnv {
+  gardenctl kubectl-env powershell | Out-String | Invoke-Expression
+}
 Set-Alias -Name {{.prefix}}k -Value Gardenctl-KubectlEnv -Option AllScope -Force
-function Gardenctl-ProviderEnv { gardenctl provider-env powershell | Out-String | Invoke-Expression }
+function Gardenctl-ProviderEnv {
+  gardenctl provider-env powershell | Out-String | Invoke-Expression
+}
 Set-Alias -Name {{.prefix}}p -Value Gardenctl-ProviderEnv -Option AllScope -Force
 {{end}}

--- a/pkg/cmd/env/templates/rc.tmpl
+++ b/pkg/cmd/env/templates/rc.tmpl
@@ -6,6 +6,8 @@ source <(gardenctl completion bash)
 alias {{.prefix}}=gardenctl
 complete -o default -F __start_gardenctl {{.prefix}}
 alias {{.prefix}}tv='gardenctl target view -o yaml'
+alias {{.prefix}}tc='gardenctl target control-plane'
+alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval $(gardenctl kubectl-env bash)'
 alias {{.prefix}}p='eval $(gardenctl provider-env bash)'
 {{end}}
@@ -19,6 +21,8 @@ compdef _gardenctl gardenctl
 alias {{.prefix}}=gardenctl
 compdef _gardenctl {{.prefix}}
 alias {{.prefix}}tv='gardenctl target view -o yaml'
+alias {{.prefix}}tc='gardenctl target control-plane'
+alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval $(gardenctl kubectl-env bash)'
 alias {{.prefix}}p='eval $(gardenctl provider-env bash)'
 {{end}}
@@ -31,6 +35,8 @@ gardenctl completion fish | source
 alias {{.prefix}}=gardenctl
 complete -c {{.prefix}} -w gardenctl
 alias {{.prefix}}tv='gardenctl target view -o yaml'
+alias {{.prefix}}tc='gardenctl target control-plane'
+alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval (gardenctl kubectl-env bash)'
 alias {{.prefix}}p='eval (gardenctl provider-env bash)'
 {{end}}
@@ -53,6 +59,14 @@ function Gardenctl-Target-View {
   gardenctl target view -o yaml
 }
 Set-Alias -Name {{.prefix}}tv -Value Gardenctl-Target-View -Option AllScope -Force
+function Gardenctl-Target-ControlPlane {
+  gardenctl target control-plane
+}
+Set-Alias -Name {{.prefix}}tc -Value Gardenctl-Target-ControlPlane -Option AllScope -Force
+function Gardenctl-Target-Unset-ControlPlane {
+  gardenctl target unset control-plane
+}
+Set-Alias -Name {{.prefix}}tc- -Value Gardenctl-Target-Unset-ControlPlane -Option AllScope -Force
 function Gardenctl-KubectlEnv {
   gardenctl kubectl-env powershell | Out-String | Invoke-Expression
 }

--- a/pkg/cmd/env/templates/rc.tmpl
+++ b/pkg/cmd/env/templates/rc.tmpl
@@ -16,10 +16,18 @@ alias {{.prefix}}p='eval $(gardenctl provider-env bash)'
 if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
-source <(gardenctl completion zsh)
-compdef _gardenctl gardenctl
+if (( $+commands[gardenctl] )); then
+    gctl_completion_file="${fpath[1]}/_gardenctl"
+    if [[ ! -f "$gctl_completion_file" ]]; then
+        gardenctl completion zsh >| "$gctl_completion_file"
+        source "$gctl_completion_file"
+    else
+        source "$gctl_completion_file"
+        gardenctl completion zsh >| "$gctl_completion_file" &|
+    fi
+    unset gctl_completion_file
+fi
 alias {{.prefix}}=gardenctl
-compdef _gardenctl {{.prefix}}
 alias {{.prefix}}tv='gardenctl target view -o yaml'
 alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'

--- a/pkg/cmd/env/templates/rc.tmpl
+++ b/pkg/cmd/env/templates/rc.tmpl
@@ -15,6 +15,7 @@ if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
 source <(gardenctl completion zsh)
+compdef _gardenctl gardenctl
 alias {{.prefix}}=gardenctl
 compdef _gardenctl {{.prefix}}
 alias {{.prefix}}tv='gardenctl target view -o yaml'
@@ -26,7 +27,7 @@ alias {{.prefix}}p='eval $(gardenctl provider-env bash)'
 if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ];
   set -gx GCTL_SESSION_ID (uuidgen)
 end
-kubectl completion fish | source
+gardenctl completion fish | source
 alias {{.prefix}}=gardenctl
 complete -c {{.prefix}} -w gardenctl
 alias {{.prefix}}tv='gardenctl target view -o yaml'


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR it will be super easy to get started with `gardenctl`. It providers a new command the generates a startup script for the four supported shells. To load gardenctl startup script for each session, execute once:
#### bash
```bash
echo 'source <(gardenctl rc bash)' >> ~/.bashrc
```
#### zsh
```zsh
echo 'source <(gardenctl rc zsh)' >> ~/.zshrc
```
#### fish
```fish
echo 'gardenctl rc fish | source' >> ~/.config/fish/config.fish
```
#### powershell
```powershell
echo 'gardenctl rc powershell | Out-String | Invoke-Expression' >> $profile
```

Example startup script for bash:
```bash
if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
  export GCTL_SESSION_ID=$(uuidgen)
fi
source <(gardenctl completion bash)
alias g=gardenctl
complete -o default -F __start_gardenctl g
alias gtv='gardenctl target view -o yaml'
alias gtc='gardenctl target control-plane'
alias gtc-='gardenctl target unset control-plane'
alias gk='eval $(gardenctl kubectl-env bash)'
alias gp='eval $(gardenctl provider-env bash)'
```

**Which issue(s) this PR fixes**:
Fixes #59

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Generate gardenctl startup script that should be added to the users shell profile 
```
