### PR TITLE
Use .login suffix for Seed Secrets. Fallback to .oidc

### DIFF
--- a/internal/gardenclient/client_test.go
+++ b/internal/gardenclient/client_test.go
@@ -1,0 +1,128 @@
+/*
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package gardenclient_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/gardener/gardenctl-v2/internal/fake"
+	"github.com/gardener/gardenctl-v2/internal/gardenclient"
+)
+
+var _ = Describe("Client", func() {
+	var (
+		ctx          context.Context
+		gardenClient gardenclient.Client
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	Describe("GetSeedClientConfig", func() {
+		var (
+			seed string
+		)
+
+		BeforeEach(func() {
+			seed = "test-seed"
+		})
+
+		Context("when the secret exists", func() {
+			var (
+				secret string
+			)
+
+			JustBeforeEach(func() {
+				seedKubeconfigSecret := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secret,
+						Namespace: "garden",
+					},
+					Data: map[string][]byte{
+						"kubeconfig": createTestKubeconfig(seed),
+					},
+				}
+
+				gardenClient = gardenclient.NewGardenClient(
+					fake.NewClientWithObjects(seedKubeconfigSecret),
+				)
+			})
+
+			assertKubeconfig := func() {
+				It("should return the kubeconfig", func() {
+					sc, err := gardenClient.GetSeedClientConfig(ctx, seed)
+					Expect(err).NotTo(HaveOccurred())
+
+					rawConfig, err := sc.RawConfig()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(rawConfig.CurrentContext).To(Equal(seed))
+				})
+			}
+
+			Context(".login secret", func() {
+				BeforeEach(func() {
+					secret = "test-seed.login"
+				})
+
+				assertKubeconfig()
+			})
+
+			Context(".oidc secret", func() {
+				BeforeEach(func() {
+					secret = "test-seed.oidc"
+				})
+
+				assertKubeconfig()
+			})
+		})
+
+		Context("when the secret does not exist", func() {
+			JustBeforeEach(func() {
+				gardenClient = gardenclient.NewGardenClient(
+					fake.NewClientWithObjects(),
+				)
+			})
+
+			It("it should fail with not found error", func() {
+				_, err := gardenClient.GetSeedClientConfig(ctx, seed)
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			})
+		})
+	})
+})
+
+// TODO copied from target_suite_test. Move into a test helper package for better reuse
+func createTestKubeconfig(name string) []byte {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["cluster"] = &clientcmdapi.Cluster{
+		Server:                "https://kubernetes:6443/",
+		InsecureSkipTLSVerify: true,
+	}
+	config.AuthInfos["user"] = &clientcmdapi.AuthInfo{
+		Token: "token",
+	}
+	config.Contexts[name] = &clientcmdapi.Context{
+		Namespace: "default",
+		AuthInfo:  "user",
+		Cluster:   "cluster",
+	}
+	config.CurrentContext = name
+	data, err := clientcmd.Write(*config)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	return data
+}

--- a/internal/gardenclient/gardenclient_suite_test.go
+++ b/internal/gardenclient/gardenclient_suite_test.go
@@ -1,0 +1,19 @@
+/*
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package gardenclient_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCloudEnvCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardenclient Test Suite")
+}

--- a/internal/util/target_test.go
+++ b/internal/util/target_test.go
@@ -48,16 +48,6 @@ var _ = Describe("Target Utilities", func() {
 			},
 		}
 
-		testSeedKubeconfig := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-seed-kubeconfig",
-				Namespace: "garden",
-			},
-			Data: map[string][]byte{
-				"data": []byte("not-used"),
-			},
-		}
-
 		testSeed = &gardencorev1beta1.Seed{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-seed",
@@ -87,7 +77,6 @@ var _ = Describe("Target Utilities", func() {
 		gardenClient = gardenclient.NewGardenClient(fake.NewClientWithObjects(
 			testReadyProject,
 			testUnreadyProject,
-			testSeedKubeconfig,
 			testSeed,
 			testShootKubeconfig,
 			testShoot,

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -151,16 +151,6 @@ var _ = Describe("SSH Command", func() {
 			},
 		}
 
-		testSeedKubeconfig := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-seed.oidc",
-				Namespace: "garden",
-			},
-			Data: map[string][]byte{
-				"kubeconfig": createTestKubeconfig("test-seed"),
-			},
-		}
-
 		testSeed = &gardencorev1beta1.Seed{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-seed",
@@ -200,7 +190,6 @@ var _ = Describe("SSH Command", func() {
 		gardenClient = internalfake.NewClientWithObjects(
 			testProject,
 			testSeed,
-			testSeedKubeconfig,
 			testShoot,
 			testShootKubeconfig,
 			testShootKeypair,

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
@@ -389,7 +389,7 @@ var _ = Describe("SSH Command", func() {
 
 				Eventually(func() bool {
 					bastion := &operationsv1alpha1.Bastion{}
-					if err := gardenClient.Get(ctx, key, bastion); errors.IsNotFound(err) {
+					if err := gardenClient.Get(ctx, key, bastion); apierrors.IsNotFound(err) {
 						return false
 					}
 

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Target Manager", func() {
 
 		seedKubeconfigSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-seed.oidc",
+				Name:      "test-seed.login",
 				Namespace: "garden",
 			},
 			Data: map[string][]byte{


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR `gardenctl` will look for a secret named `<seed-name>.login` to get the kubeconfig for the seed cluster. Ideally (for security reasons) this kubeconfig should not contain any credentials (e.g. only oidc or auth-provider configuration), but we do not make any assumptions as of now.
For compatibility reasons we will fallback to `<seed-name>.oidc`. We will remove the fallback in a future `gardenctl` release.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
