### PR TITLE
Fix yaml indentation

### DIFF
--- a/pkg/cmd/base/options.go
+++ b/pkg/cmd/base/options.go
@@ -77,13 +77,15 @@ func (o *Options) PrintObject(obj interface{}) error {
 		fmt.Fprintf(o.IOStreams.Out, "%v", obj)
 
 	case "yaml":
-		marshalled, err := yaml.Marshal(&obj)
+		yamlEncoder := yaml.NewEncoder(o.IOStreams.Out)
+		defer yamlEncoder.Close()
+
+		yamlEncoder.SetIndent(2)
+
+		err := yamlEncoder.Encode(&obj)
 		if err != nil {
 			return err
 		}
-
-		fmt.Fprintln(o.IOStreams.Out, string(marshalled))
-
 	case "json":
 		marshalled, err := json.MarshalIndent(&obj, "", "  ")
 		if err != nil {

--- a/pkg/cmd/base/options_test.go
+++ b/pkg/cmd/base/options_test.go
@@ -23,9 +23,13 @@ import (
 
 var _ = Describe("Base Options", func() {
 	Describe("given an instance", func() {
+		type barType struct {
+			Baz string
+		}
+
 		type fooType struct {
 			Foo string
-			Bar string
+			Bar barType
 		}
 
 		var (
@@ -40,7 +44,9 @@ var _ = Describe("Base Options", func() {
 			options = base.NewOptions(streams)
 			foo = &fooType{
 				Foo: "foo",
-				Bar: "bar",
+				Bar: barType{
+					Baz: "baz",
+				},
 			}
 		})
 
@@ -70,7 +76,14 @@ var _ = Describe("Base Options", func() {
 
 			It("should print with json format", func() {
 				Expect(options.PrintObject(foo)).To(Succeed())
-				Expect(buf.String()).To(Equal(fmt.Sprintf("{\n  \"Foo\": %q,\n  \"Bar\": %q\n}\n", foo.Foo, foo.Bar)))
+				Expect(buf.String()).To(Equal(fmt.Sprintf(
+					`{
+  "Foo": %q,
+  "Bar": {
+    "Baz": %q
+  }
+}
+`, foo.Foo, foo.Bar.Baz)))
 			})
 		})
 
@@ -85,7 +98,12 @@ var _ = Describe("Base Options", func() {
 
 			It("should print with yaml format", func() {
 				Expect(options.PrintObject(foo)).To(Succeed())
-				Expect(buf.String()).To(Equal(fmt.Sprintf("foo: %s\nbar: %s\n\n", foo.Foo, foo.Bar)))
+				Expect(buf.String()).To(Equal(fmt.Sprintf(
+					`foo: %s
+bar:
+  baz: %s
+`,
+					foo.Foo, foo.Bar.Baz)))
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when running e.g. `gardenctl config view -oyaml` it prints out the yaml with an indentation of `4`.
```yaml
gardens:
    - identity: landscape-dev
      kubeconfig: /path/to/kubeconfig.yaml
```

The indentation is changed to 2.

```yaml
gardens:
  - identity: landscape-dev
    kubeconfig: /path/to/kubeconfig.yaml
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
