### PR TITLE
Fix `kubectl-env` and `provider-env` command help

### DIFF
--- a/docs/help/gardenctl_kubectl-env_bash.md
+++ b/docs/help/gardenctl_kubectl-env_bash.md
@@ -7,7 +7,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for bash
 Generate a script that points KUBECONFIG to the targeted cluster for bash.
 
 To load the kubectl configuration script in your current shell session:
-$ eval $(kubectl-env bash)
+$ eval $(gardenctl kubectl-env bash)
 
 
 ```

--- a/docs/help/gardenctl_kubectl-env_fish.md
+++ b/docs/help/gardenctl_kubectl-env_fish.md
@@ -7,7 +7,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for fish
 Generate a script that points KUBECONFIG to the targeted cluster for fish.
 
 To load the kubectl configuration script in your current shell session:
-$ eval (kubectl-env fish)
+$ eval (gardenctl kubectl-env fish)
 
 
 ```

--- a/docs/help/gardenctl_kubectl-env_powershell.md
+++ b/docs/help/gardenctl_kubectl-env_powershell.md
@@ -7,7 +7,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for powershell
 Generate a script that points KUBECONFIG to the targeted cluster for powershell.
 
 To load the kubectl configuration script in your current shell session:
-PS /> & kubectl-env powershell | Invoke-Expression
+PS /> & gardenctl kubectl-env powershell | Invoke-Expression
 
 
 ```

--- a/docs/help/gardenctl_kubectl-env_zsh.md
+++ b/docs/help/gardenctl_kubectl-env_zsh.md
@@ -7,7 +7,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for zsh
 Generate a script that points KUBECONFIG to the targeted cluster for zsh.
 
 To load the kubectl configuration script in your current shell session:
-$ eval $(kubectl-env zsh)
+$ eval $(gardenctl kubectl-env zsh)
 
 
 ```

--- a/docs/help/gardenctl_provider-env_bash.md
+++ b/docs/help/gardenctl_provider-env_bash.md
@@ -7,7 +7,7 @@ Generate the cloud provider CLI configuration script for bash
 Generate the cloud provider CLI configuration script for bash.
 
 To load the cloud provider CLI configuration script in your current shell session:
-$ eval $(provider-env bash)
+$ eval $(gardenctl provider-env bash)
 
 
 ```

--- a/docs/help/gardenctl_provider-env_fish.md
+++ b/docs/help/gardenctl_provider-env_fish.md
@@ -7,7 +7,7 @@ Generate the cloud provider CLI configuration script for fish
 Generate the cloud provider CLI configuration script for fish.
 
 To load the cloud provider CLI configuration script in your current shell session:
-$ eval (provider-env fish)
+$ eval (gardenctl provider-env fish)
 
 
 ```

--- a/docs/help/gardenctl_provider-env_powershell.md
+++ b/docs/help/gardenctl_provider-env_powershell.md
@@ -7,7 +7,7 @@ Generate the cloud provider CLI configuration script for powershell
 Generate the cloud provider CLI configuration script for powershell.
 
 To load the cloud provider CLI configuration script in your current shell session:
-PS /> & provider-env powershell | Invoke-Expression
+PS /> & gardenctl provider-env powershell | Invoke-Expression
 
 
 ```

--- a/docs/help/gardenctl_provider-env_zsh.md
+++ b/docs/help/gardenctl_provider-env_zsh.md
@@ -7,7 +7,7 @@ Generate the cloud provider CLI configuration script for zsh
 Generate the cloud provider CLI configuration script for zsh.
 
 To load the cloud provider CLI configuration script in your current shell session:
-$ eval $(provider-env zsh)
+$ eval $(gardenctl provider-env zsh)
 
 
 ```

--- a/pkg/cmd/env/env.go
+++ b/pkg/cmd/env/env.go
@@ -59,7 +59,7 @@ here https://github.com/gardener/gardenctl-v2/tree/master/pkg/cmd/env/templates.
 			Short: fmt.Sprintf("Generate the cloud provider CLI configuration script for %s", s),
 			Long: fmt.Sprintf("Generate the cloud provider CLI configuration script for %s.\n\n"+
 				"To load the cloud provider CLI configuration script in your current shell session:\n%s\n",
-				s, s.Prompt(runtime.GOOS)+s.EvalCommand(fmt.Sprintf("%s %s", cmd.CommandPath(), s)),
+				s, s.Prompt(runtime.GOOS)+s.EvalCommand(fmt.Sprintf("gardenctl %s %s", cmd.Name(), s)),
 			),
 			RunE: runE,
 		})
@@ -95,7 +95,7 @@ The generated script points the KUBECONFIG environment variable to the currently
 			Short: fmt.Sprintf("Generate a script that points KUBECONFIG to the targeted cluster for %s", s),
 			Long: fmt.Sprintf("Generate a script that points KUBECONFIG to the targeted cluster for %s.\n\n"+
 				"To load the kubectl configuration script in your current shell session:\n%s\n",
-				s, s.Prompt(runtime.GOOS)+s.EvalCommand(fmt.Sprintf("%s %s", cmd.CommandPath(), s)),
+				s, s.Prompt(runtime.GOOS)+s.EvalCommand(fmt.Sprintf("gardenctl %s %s", cmd.Name(), s)),
 			),
 			RunE: runE,
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the wrong command path of `kubectl-env` and `provider-env` command help and regerates the markdown docs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
