### PR TITLE
Added `gcv` alias

### DIFF
--- a/pkg/cmd/env/rc_test.go
+++ b/pkg/cmd/env/rc_test.go
@@ -72,6 +72,7 @@ alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
 alias gk='eval $(gardenctl kubectl-env bash)'
 alias gp='eval $(gardenctl provider-env bash)'
+alias gcv='gardenctl config view -o yaml'
 `))
 		})
 
@@ -98,6 +99,7 @@ alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
 alias gk='eval $(gardenctl kubectl-env bash)'
 alias gp='eval $(gardenctl provider-env bash)'
+alias gcv='gardenctl config view -o yaml'
 `))
 		})
 
@@ -115,6 +117,7 @@ alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
 alias gk='eval (gardenctl kubectl-env bash)'
 alias gp='eval (gardenctl provider-env bash)'
+alias gcv='gardenctl config view -o yaml'
 `))
 		})
 
@@ -154,6 +157,10 @@ function Gardenctl-ProviderEnv {
   gardenctl provider-env powershell | Out-String | Invoke-Expression
 }
 Set-Alias -Name gp -Value Gardenctl-ProviderEnv -Option AllScope -Force
+function Gardenctl-Config-View {
+  gardenctl config view -o yaml
+}
+Set-Alias -Name gcv -Value Gardenctl-Config-View -Option AllScope -Force
 `))
 		})
 

--- a/pkg/cmd/env/rc_test.go
+++ b/pkg/cmd/env/rc_test.go
@@ -97,8 +97,8 @@ alias g=gardenctl
 alias gtv='gardenctl target view -o yaml'
 alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
-alias gk='eval $(gardenctl kubectl-env bash)'
-alias gp='eval $(gardenctl provider-env bash)'
+alias gk='eval $(gardenctl kubectl-env zsh)'
+alias gp='eval $(gardenctl provider-env zsh)'
 alias gcv='gardenctl config view -o yaml'
 `))
 		})
@@ -115,8 +115,8 @@ complete -c g -w gardenctl
 alias gtv='gardenctl target view -o yaml'
 alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
-alias gk='eval (gardenctl kubectl-env bash)'
-alias gp='eval (gardenctl provider-env bash)'
+alias gk='eval (gardenctl kubectl-env fish)'
+alias gp='eval (gardenctl provider-env fish)'
 alias gcv='gardenctl config view -o yaml'
 `))
 		})

--- a/pkg/cmd/env/templates/rc.tmpl
+++ b/pkg/cmd/env/templates/rc.tmpl
@@ -10,6 +10,7 @@ alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval $(gardenctl kubectl-env bash)'
 alias {{.prefix}}p='eval $(gardenctl provider-env bash)'
+alias {{.prefix}}cv='gardenctl config view -o yaml'
 {{end}}
 
 {{define "zsh" -}}
@@ -33,6 +34,7 @@ alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval $(gardenctl kubectl-env bash)'
 alias {{.prefix}}p='eval $(gardenctl provider-env bash)'
+alias {{.prefix}}cv='gardenctl config view -o yaml'
 {{end}}
 
 {{define "fish" -}}
@@ -47,6 +49,7 @@ alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval (gardenctl kubectl-env bash)'
 alias {{.prefix}}p='eval (gardenctl provider-env bash)'
+alias {{.prefix}}cv='gardenctl config view -o yaml'
 {{end}}
 
 {{define "powershell" -}}
@@ -83,4 +86,8 @@ function Gardenctl-ProviderEnv {
   gardenctl provider-env powershell | Out-String | Invoke-Expression
 }
 Set-Alias -Name {{.prefix}}p -Value Gardenctl-ProviderEnv -Option AllScope -Force
+function Gardenctl-Config-View {
+  gardenctl config view -o yaml
+}
+Set-Alias -Name {{.prefix}}cv -Value Gardenctl-Config-View -Option AllScope -Force
 {{end}}

--- a/pkg/cmd/env/templates/rc.tmpl
+++ b/pkg/cmd/env/templates/rc.tmpl
@@ -2,14 +2,14 @@
 if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
-source <(gardenctl completion bash)
+source <(gardenctl completion {{.shell}})
 alias {{.prefix}}=gardenctl
 complete -o default -F __start_gardenctl {{.prefix}}
 alias {{.prefix}}tv='gardenctl target view -o yaml'
 alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
-alias {{.prefix}}k='eval $(gardenctl kubectl-env bash)'
-alias {{.prefix}}p='eval $(gardenctl provider-env bash)'
+alias {{.prefix}}k='eval $(gardenctl kubectl-env {{.shell}})'
+alias {{.prefix}}p='eval $(gardenctl provider-env {{.shell}})'
 alias {{.prefix}}cv='gardenctl config view -o yaml'
 {{end}}
 
@@ -20,11 +20,11 @@ fi
 if (( $+commands[gardenctl] )); then
     gctl_completion_file="${fpath[1]}/_gardenctl"
     if [[ ! -f "$gctl_completion_file" ]]; then
-        gardenctl completion zsh >| "$gctl_completion_file"
+        gardenctl completion {{.shell}} >| "$gctl_completion_file"
         source "$gctl_completion_file"
     else
         source "$gctl_completion_file"
-        gardenctl completion zsh >| "$gctl_completion_file" &|
+        gardenctl completion {{.shell}} >| "$gctl_completion_file" &|
     fi
     unset gctl_completion_file
 fi
@@ -32,8 +32,8 @@ alias {{.prefix}}=gardenctl
 alias {{.prefix}}tv='gardenctl target view -o yaml'
 alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
-alias {{.prefix}}k='eval $(gardenctl kubectl-env bash)'
-alias {{.prefix}}p='eval $(gardenctl provider-env bash)'
+alias {{.prefix}}k='eval $(gardenctl kubectl-env {{.shell}})'
+alias {{.prefix}}p='eval $(gardenctl provider-env {{.shell}})'
 alias {{.prefix}}cv='gardenctl config view -o yaml'
 {{end}}
 
@@ -41,14 +41,14 @@ alias {{.prefix}}cv='gardenctl config view -o yaml'
 if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ];
   set -gx GCTL_SESSION_ID (uuidgen)
 end
-gardenctl completion fish | source
+gardenctl completion {{.shell}} | source
 alias {{.prefix}}=gardenctl
 complete -c {{.prefix}} -w gardenctl
 alias {{.prefix}}tv='gardenctl target view -o yaml'
 alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
-alias {{.prefix}}k='eval (gardenctl kubectl-env bash)'
-alias {{.prefix}}p='eval (gardenctl provider-env bash)'
+alias {{.prefix}}k='eval (gardenctl kubectl-env {{.shell}})'
+alias {{.prefix}}p='eval (gardenctl provider-env {{.shell}})'
 alias {{.prefix}}cv='gardenctl config view -o yaml'
 {{end}}
 
@@ -58,7 +58,7 @@ if ( !(Test-Path Env:GCTL_SESSION_ID) -and !(Test-Path Env:TERM_SESSION_ID) ) {
 }
 Set-Alias -Name {{.prefix}} -Value (get-command gardenctl).Path -Option AllScope -Force
 function Gardenctl-Completion-Powershell {
-  $s = (gardenctl completion powershell)
+  $s = (gardenctl completion {{.shell}})
   @(
     ($s -replace "(?ms)^Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock", "`$scriptBlock =")
     "Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock `$scriptBlock"
@@ -79,11 +79,11 @@ function Gardenctl-Target-Unset-ControlPlane {
 }
 Set-Alias -Name {{.prefix}}tc- -Value Gardenctl-Target-Unset-ControlPlane -Option AllScope -Force
 function Gardenctl-KubectlEnv {
-  gardenctl kubectl-env powershell | Out-String | Invoke-Expression
+  gardenctl kubectl-env {{.shell}} | Out-String | Invoke-Expression
 }
 Set-Alias -Name {{.prefix}}k -Value Gardenctl-KubectlEnv -Option AllScope -Force
 function Gardenctl-ProviderEnv {
-  gardenctl provider-env powershell | Out-String | Invoke-Expression
+  gardenctl provider-env {{.shell}} | Out-String | Invoke-Expression
 }
 Set-Alias -Name {{.prefix}}p -Value Gardenctl-ProviderEnv -Option AllScope -Force
 function Gardenctl-Config-View {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new alias `gcv` to the startup script:
```sh
alias gcv='gardenctl config view -o yaml'
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
