### PR TITLE
Fixes #28, #110 , #111, #113 and #114 

### DIFF
--- a/docs/help/gardenctl_rc_bash.md
+++ b/docs/help/gardenctl_rc_bash.md
@@ -7,9 +7,11 @@ Generate a gardenctl startup script for bash
 Generate a gardenctl startup script for bash that contains various tweaks,
 such as setting environment variables, loading completions and adding some helpful aliases or functions.
 
-To load gardenctl startup script for each bash session, execute once:
+To load gardenctl startup script for each bash session add the following line at the end of the ~/.bashrc file:
 
-    echo 'source <(gardenctl rc bash)' >> ~/.bashrc
+    source <(gardenctl rc bash)
+
+You will need to start a new shell for this setup to take effect.
 
 
 ```
@@ -20,6 +22,7 @@ gardenctl rc bash [flags]
 
 ```
   -h, --help            help for bash
+      --no-completion   The startup script should not setup completion
   -p, --prefix string   The prefix used for aliases and functions (default "g")
 ```
 

--- a/docs/help/gardenctl_rc_fish.md
+++ b/docs/help/gardenctl_rc_fish.md
@@ -7,9 +7,11 @@ Generate a gardenctl startup script for fish
 Generate a gardenctl startup script for fish that contains various tweaks,
 such as setting environment variables, loading completions and adding some helpful aliases or functions.
 
-To load gardenctl startup script for each fish session, execute once:
+To load gardenctl startup script for each fish session add the following line at the end of the ~/.config/fish/config.fish file:
 
-    echo 'gardenctl rc fish | source' >> ~/.config/fish/config.fish
+    gardenctl rc fish | source
+
+You will need to start a new shell for this setup to take effect.
 
 
 ```
@@ -20,6 +22,7 @@ gardenctl rc fish [flags]
 
 ```
   -h, --help            help for fish
+      --no-completion   The startup script should not setup completion
   -p, --prefix string   The prefix used for aliases and functions (default "g")
 ```
 

--- a/docs/help/gardenctl_rc_powershell.md
+++ b/docs/help/gardenctl_rc_powershell.md
@@ -7,9 +7,11 @@ Generate a gardenctl startup script for powershell
 Generate a gardenctl startup script for powershell, that contains various tweaks,
 such as setting environment variables, loadings completions and adding some helpful aliases or functions.
 
-To load gardenctl startup script for each powershell session, execute once:
+To load gardenctl startup script for each powershell session add the following line at the end of the $profile file:
 
-    echo 'gardenctl rc powershell | Out-String | Invoke-Expression' >> $profile
+    gardenctl rc powershell | Out-String | Invoke-Expression
+
+You will need to start a new shell for this setup to take effect.
 
 
 ```
@@ -20,6 +22,7 @@ gardenctl rc powershell [flags]
 
 ```
   -h, --help            help for powershell
+      --no-completion   The startup script should not setup completion
   -p, --prefix string   The prefix used for aliases and functions (default "g")
 ```
 

--- a/docs/help/gardenctl_rc_zsh.md
+++ b/docs/help/gardenctl_rc_zsh.md
@@ -7,14 +7,46 @@ Generate a gardenctl startup script for zsh
 Generate a gardenctl startup script for zsh that contains various tweaks,
 such as setting environment variables, loading completions and adding some helpful aliases or functions.
 
-If shell completion is not already enabled in your environment you will need
-to enable it. You can execute the following once:
+If shell completion is not already enabled in your environment you need to add at least this command to your zsh configuration file:
 
-    echo "autoload -U compinit; compinit" >> ~/.zshrc
+    autoload -Uz compinit && compinit
 
-To load gardenctl startup script for each zsh session, execute once:
+To load gardenctl startup script for each zsh session add the following line at the end of the ~/.zshrc file:
 
-    echo 'source <(gardenctl rc zsh)' >> ~/.zshrc
+    source <(gardenctl rc zsh)
+
+You will need to start a new shell for this setup to take effect.
+
+### Zshell frameworks or plugin manager
+
+If you use a framework for managing your zsh configuration you may need to load this code as a custom plugin in your framework.
+
+#### oh-my-zsh:
+Create a file `~/.oh-my-zsh/custom/plugins/gardenctl/gardenctl.plugin.zsh` with the following content:
+
+    if (( $+commands[gardenctl] )); then
+      source <(gardenctl rc zsh)
+    fi
+
+To use it, add gardenctl to the plugins array in your ~/.zshrc file:
+
+    plugins=(... gardenctl)
+
+For more information about oh-my-zsh custom plugins please refer to https://github.com/ohmyzsh/ohmyzsh#custom-plugins-and-themes.
+
+#### zgen:
+Create an oh-my-zsh plugin for gardenctl like described above and load it in the .zshrc file:
+
+    zgen load /path/to/custom/plugins/gardenctl
+
+For more information about loading plugins with zgen please refer to https://github.com/tarjoilija/zgen#load-plugins-and-completions
+
+#### zinit:
+Create an oh-my-zsh plugin for gardenctl like described above and load it in the .zshrc file:
+
+    zinit snippet /path/to/custom/plugins/gardenctl/gardenctl.plugin.zsh
+
+For more information about loading plugins and snippets with zinit please refer to https://github.com/zdharma-continuum/zinit#plugins-and-snippets.
 
 
 ```
@@ -25,6 +57,7 @@ gardenctl rc zsh [flags]
 
 ```
   -h, --help            help for zsh
+      --no-completion   The startup script should not setup completion
   -p, --prefix string   The prefix used for aliases and functions (default "g")
 ```
 

--- a/internal/util/factory.go
+++ b/internal/util/factory.go
@@ -12,10 +12,23 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/target"
+)
+
+const (
+	envSessionID     = "GCTL_SESSION_ID"
+	envTermSessionID = "TERM_SESSION_ID"
+)
+
+var (
+	sidRegexp  = regexp.MustCompile(`^[\w-]{1,128}$`)
+	uuidRegexp = regexp.MustCompile(`([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})`)
 )
 
 //go:generate mockgen -destination=./mocks/mock_factory.go -package=mocks github.com/gardener/gardenctl-v2/internal/util Factory
@@ -50,12 +63,6 @@ type FactoryImpl struct {
 	// if empty.
 	ConfigFile string
 
-	// SessionDirectory is the temporary directory where the target fileand the kubeconfig files are located.
-	SessionDirectory string
-
-	// TargetFile is the filename where the currently active target is located.
-	TargetFile string
-
 	// TargetFlags can be used to completely override the target configuration
 	// stored on the filesystem via a CLI flags.
 	TargetFlags target.TargetFlags
@@ -73,10 +80,22 @@ func (f *FactoryImpl) Manager() (target.Manager, error) {
 		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
 
-	targetProvider := target.NewTargetProvider(f.TargetFile, f.TargetFlags)
+	sid, err := getSessionID()
+	if err != nil {
+		return nil, err
+	}
+
+	sessionDirectory := filepath.Join(os.TempDir(), "garden", sid)
+
+	err = os.MkdirAll(sessionDirectory, 0700)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create session directory: %w", err)
+	}
+
+	targetProvider := target.NewTargetProvider(filepath.Join(sessionDirectory, "target.yaml"), f.TargetFlags)
 	clientProvider := target.NewClientProvider()
 
-	return target.NewManager(cfg, targetProvider, clientProvider, f.SessionDirectory)
+	return target.NewManager(cfg, targetProvider, clientProvider, sessionDirectory)
 }
 
 func (f *FactoryImpl) GardenHomeDir() string {
@@ -133,4 +152,23 @@ func callIPify(ctx context.Context, domain string) (*net.IP, error) {
 	}
 
 	return &netIP, nil
+}
+
+func getSessionID() (string, error) {
+	if value, ok := os.LookupEnv(envSessionID); ok {
+		if sidRegexp.MatchString(value) {
+			return value, nil
+		}
+
+		return "", fmt.Errorf("Environment variable %s must only contain alphanumeric characters, underscore and dash and have a minimum length of 1 and a maximum length of 128", envSessionID)
+	}
+
+	if value, ok := os.LookupEnv(envTermSessionID); ok {
+		match := uuidRegexp.FindStringSubmatch(strings.ToLower(value))
+		if len(match) > 1 {
+			return match[1], nil
+		}
+	}
+
+	return "", fmt.Errorf("Environment variable %s is required. Use \"gardenctl help\" for more information about the requirements of gardenctl", envSessionID)
 }

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -12,8 +12,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"strings"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -36,18 +34,10 @@ const (
 	envPrefix        = "GCTL"
 	envGardenHomeDir = envPrefix + "_HOME"
 	envConfigName    = envPrefix + "_CONFIG_NAME"
-	envSessionID     = envPrefix + "_SESSION_ID"
-	envTermSessionID = "TERM_SESSION_ID"
 
 	gardenHomeFolder = ".garden"
 	configName       = "gardenctl-v2"
 	configExtension  = "yaml"
-	targetFilename   = "target.yaml"
-)
-
-var (
-	sidRegexp  = regexp.MustCompile(`^[\w-]{1,128}$`)
-	uuidRegexp = regexp.MustCompile(`([a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})`)
 )
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -202,15 +192,6 @@ func initConfig(f *util.FactoryImpl) {
 	}
 
 	f.GardenHomeDirectory = home
-
-	sid, err := getSessionID()
-	cobra.CheckErr(err)
-
-	f.SessionDirectory = filepath.Join(os.TempDir(), "garden", sid)
-	err = os.MkdirAll(f.SessionDirectory, 0700)
-	cobra.CheckErr(err)
-
-	f.TargetFile = filepath.Join(f.SessionDirectory, targetFilename)
 }
 
 func registerCompletionFuncForGlobalFlags(cmd *cobra.Command, f *util.FactoryImpl, ioStreams util.IOStreams) {
@@ -266,23 +247,4 @@ func addKlogFlags(fs *pflag.FlagSet) {
 	local.VisitAll(func(fl *flag.Flag) {
 		fs.AddGoFlag(fl)
 	})
-}
-
-func getSessionID() (string, error) {
-	if value, ok := os.LookupEnv(envSessionID); ok {
-		if sidRegexp.MatchString(value) {
-			return value, nil
-		}
-
-		return "", fmt.Errorf("Environment variable %s must only contain alphanumeric characters, underscore and dash and have a minimum length of 1 and a maximum length of 128", envSessionID)
-	}
-
-	if value, ok := os.LookupEnv(envTermSessionID); ok {
-		match := uuidRegexp.FindStringSubmatch(strings.ToLower(value))
-		if len(match) > 1 {
-			return match[1], nil
-		}
-	}
-
-	return "", fmt.Errorf("Environment variable %s is required. Use \"gardenctl help\" for more information about the requirements of gardenctl", envSessionID)
 }

--- a/pkg/cmd/cmd_suite_test.go
+++ b/pkg/cmd/cmd_suite_test.go
@@ -28,7 +28,6 @@ var (
 	gardenHomeDir string
 	sessionDir    string
 	configFile    string
-	targetFile    string
 	cfg           *config.Config
 )
 
@@ -50,7 +49,6 @@ var _ = BeforeSuite(func() {
 	Expect(os.Setenv(cmd.EnvSessionID, sessionID)).To(Succeed())
 	sessionDir = filepath.Join(os.TempDir(), "garden", sessionID)
 	Expect(os.MkdirAll(sessionDir, os.ModePerm))
-	targetFile = filepath.Join(sessionDir, cmd.TargetFilename)
 	cfg = &config.Config{
 		Filename:       configFile,
 		LinkKubeconfig: pointer.Bool(false),

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -292,7 +292,7 @@ var _ = Describe("Gardenctl command", func() {
 			})
 
 			It("should fail when loading the config", func() {
-				factory.ConfigFile = ""
+				factory.ConfigFile = string([]byte{0})
 				wrapped := cmd.CompletionWrapper(factory, streams, func(ctx context.Context, manager target.Manager) ([]string, error) {
 					return []string{"foo", "bar"}, nil
 				})

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -53,7 +54,7 @@ var _ = Describe("Gardenctl command", func() {
 
 		targetFlags = target.NewTargetFlags("", "", "", "", false)
 
-		targetProvider := target.NewTargetProvider(targetFile, nil)
+		targetProvider := target.NewTargetProvider(filepath.Join(sessionDir, "target.yaml"), nil)
 		Expect(targetProvider.Write(target.NewTarget(gardenName1, projectName, "", shootName))).To(Succeed())
 	})
 
@@ -321,7 +322,6 @@ var _ = Describe("Gardenctl command", func() {
 				head := strings.Split(out.String(), "\n")[0]
 				Expect(head).To(Equal("#compdef _gardenctl gardenctl"))
 				Expect(factory.ConfigFile).To(Equal(configFile))
-				Expect(factory.TargetFile).To(Equal(targetFile))
 				Expect(factory.GardenHomeDirectory).To(Equal(gardenHomeDir))
 
 				manager, err := factory.Manager()

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -178,7 +178,7 @@ type rcOptions struct {
 	CmdPath string
 	// Prefix is prefix for shell aliases and functions
 	Prefix string
-	// NoCompletion if the value is true tab completion is not part of the startip script
+	// NoCompletion if the value is true tab completion is not part of the startup script
 	NoCompletion bool
 	// Template is the script template
 	Template Template

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -62,9 +62,11 @@ func createBashCommand(cmdPath string) *cobra.Command {
 		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s that contains various tweaks,
 such as setting environment variables, loading completions and adding some helpful aliases or functions.
 
-To load gardenctl startup script for each %[1]s session, execute once:
+To load gardenctl startup script for each %[1]s session add the following line at the end of the ~/.bashrc file:
 
-    echo 'source <(%[2]s %[1]s)' >> ~/.bashrc
+    source <(%[2]s %[1]s)
+
+You will need to start a new shell for this setup to take effect.
 `,
 			shell, cmdPath,
 		),
@@ -80,14 +82,46 @@ func createZshCommand(cmdPath string) *cobra.Command {
 		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s that contains various tweaks,
 such as setting environment variables, loading completions and adding some helpful aliases or functions.
 
-If shell completion is not already enabled in your environment you will need
-to enable it. You can execute the following once:
+If shell completion is not already enabled in your environment you need to add at least this command to your zsh configuration file:
 
-    echo "autoload -U compinit; compinit" >> ~/.zshrc
+    autoload -Uz compinit && compinit
 
-To load gardenctl startup script for each %[1]s session, execute once:
+To load gardenctl startup script for each %[1]s session add the following line at the end of the ~/.zshrc file:
 
-    echo 'source <(%[2]s %[1]s)' >> ~/.zshrc
+    source <(%[2]s %[1]s)
+
+You will need to start a new shell for this setup to take effect.
+
+### Zshell frameworks or plugin manager
+
+If you use a framework for managing your zsh configuration you may need to load this code as a custom plugin in your framework.
+
+#### oh-my-zsh:
+Create a file `+"`"+`~/.oh-my-zsh/custom/plugins/gardenctl/gardenctl.plugin.zsh`+"`"+` with the following content:
+
+    if (( $+commands[gardenctl] )); then
+      source <(gardenctl rc zsh)
+    fi
+
+To use it, add gardenctl to the plugins array in your ~/.zshrc file:
+
+    plugins=(... gardenctl)
+
+For more information about oh-my-zsh custom plugins please refer to https://github.com/ohmyzsh/ohmyzsh#custom-plugins-and-themes.
+
+#### zgen:
+Create an oh-my-zsh plugin for gardenctl like described above and load it in the .zshrc file:
+
+    zgen load /path/to/custom/plugins/gardenctl
+
+For more information about loading plugins with zgen please refer to https://github.com/tarjoilija/zgen#load-plugins-and-completions
+
+#### zinit:
+Create an oh-my-zsh plugin for gardenctl like described above and load it in the .zshrc file:
+
+    zinit snippet /path/to/custom/plugins/gardenctl/gardenctl.plugin.zsh
+
+For more information about loading plugins and snippets with zinit please refer to https://github.com/zdharma-continuum/zinit#plugins-and-snippets.
 `,
 			shell, cmdPath,
 		),
@@ -103,9 +137,11 @@ func createFishCommand(cmdPath string) *cobra.Command {
 		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s that contains various tweaks,
 such as setting environment variables, loading completions and adding some helpful aliases or functions.
 
-To load gardenctl startup script for each %[1]s session, execute once:
+To load gardenctl startup script for each %[1]s session add the following line at the end of the ~/.config/fish/config.fish file:
 
-    echo '%[2]s %[1]s | source' >> ~/.config/fish/config.fish
+    %[2]s %[1]s | source
+
+You will need to start a new shell for this setup to take effect.
 `,
 			shell, cmdPath,
 		),
@@ -121,9 +157,11 @@ func createPowershellCommand(cmdPath string) *cobra.Command {
 		Long: fmt.Sprintf(`Generate a gardenctl startup script for %[1]s, that contains various tweaks,
 such as setting environment variables, loadings completions and adding some helpful aliases or functions.
 
-To load gardenctl startup script for each %[1]s session, execute once:
+To load gardenctl startup script for each %[1]s session add the following line at the end of the $profile file:
 
-    echo '%[2]s %[1]s | Out-String | Invoke-Expression' >> $profile
+    %[2]s %[1]s | Out-String | Invoke-Expression
+
+You will need to start a new shell for this setup to take effect.
 `,
 			shell, cmdPath,
 		),

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -140,6 +140,8 @@ type rcOptions struct {
 	CmdPath string
 	// Prefix is prefix for shell aliases and functions
 	Prefix string
+	// NoCompletion if the value is true tab completion is not part of the startip script
+	NoCompletion bool
 	// Template is the script template
 	Template Template
 }
@@ -174,8 +176,9 @@ func (o *rcOptions) Validate() error {
 // Run does the actual work of the command.
 func (o *rcOptions) Run(f util.Factory) error {
 	data := map[string]interface{}{
-		"shell":  o.Shell,
-		"prefix": o.Prefix,
+		"shell":        o.Shell,
+		"prefix":       o.Prefix,
+		"noCompletion": o.NoCompletion,
 	}
 
 	return o.Template.ExecuteTemplate(o.IOStreams.Out, o.Shell, data)
@@ -184,4 +187,5 @@ func (o *rcOptions) Run(f util.Factory) error {
 // AddFlags binds the command options to a given flagset.
 func (o *rcOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.Prefix, "prefix", "p", "g", "The prefix used for aliases and functions")
+	flags.BoolVar(&o.NoCompletion, "no-completion", false, "The startup script should not setup completion")
 }

--- a/pkg/cmd/env/rc_test.go
+++ b/pkg/cmd/env/rc_test.go
@@ -83,15 +83,18 @@ alias gcv='gardenctl config view -o yaml'
   export GCTL_SESSION_ID=$(uuidgen)
 fi
 if (( $+commands[gardenctl] )); then
-    gctl_completion_file="${fpath[1]}/_gardenctl"
-    if [[ ! -f "$gctl_completion_file" ]]; then
-        gardenctl completion zsh >| "$gctl_completion_file"
-        source "$gctl_completion_file"
-    else
-        source "$gctl_completion_file"
-        gardenctl completion zsh >| "$gctl_completion_file" &|
-    fi
-    unset gctl_completion_file
+  if [ -d "$ZSH_CACHE_DIR/completions" ] && (($fpath[(Ie)$ZSH_CACHE_DIR/completions])); then
+    GCTL_COMPLETION_FILE="$ZSH_CACHE_DIR/completions/_gardenctl"
+  else
+    GCTL_COMPLETION_FILE="${fpath[1]}/_gardenctl"
+  fi
+  if [[ ! -f "$GCTL_COMPLETION_FILE" ]]; then
+    typeset -g -A _comps
+    autoload -Uz _gardenctl
+    _comps[gardenctl]=_gardenctl
+  fi
+  gardenctl completion zsh >| "$GCTL_COMPLETION_FILE" &|
+  unset GCTL_COMPLETION_FILE
 fi
 alias g=gardenctl
 alias gtv='gardenctl target view -o yaml'

--- a/pkg/cmd/env/templates/rc.tmpl
+++ b/pkg/cmd/env/templates/rc.tmpl
@@ -2,9 +2,11 @@
 if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
+{{if not .noCompletion -}}
 source <(gardenctl completion {{.shell}})
 alias {{.prefix}}=gardenctl
 complete -o default -F __start_gardenctl {{.prefix}}
+{{end -}}
 alias {{.prefix}}tv='gardenctl target view -o yaml'
 alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
@@ -17,17 +19,22 @@ alias {{.prefix}}cv='gardenctl config view -o yaml'
 if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
+{{if not .noCompletion -}}
 if (( $+commands[gardenctl] )); then
-    gctl_completion_file="${fpath[1]}/_gardenctl"
-    if [[ ! -f "$gctl_completion_file" ]]; then
-        gardenctl completion {{.shell}} >| "$gctl_completion_file"
-        source "$gctl_completion_file"
-    else
-        source "$gctl_completion_file"
-        gardenctl completion {{.shell}} >| "$gctl_completion_file" &|
-    fi
-    unset gctl_completion_file
+  if [ -d "$ZSH_CACHE_DIR/completions" ] && (($fpath[(Ie)$ZSH_CACHE_DIR/completions])); then
+    GCTL_COMPLETION_FILE="$ZSH_CACHE_DIR/completions/_gardenctl"
+  else
+    GCTL_COMPLETION_FILE="${fpath[1]}/_gardenctl"
+  fi
+  if [[ ! -f "$GCTL_COMPLETION_FILE" ]]; then
+    typeset -g -A _comps
+    autoload -Uz _gardenctl
+    _comps[gardenctl]=_gardenctl
+  fi
+  gardenctl completion zsh >| "$GCTL_COMPLETION_FILE" &|
+  unset GCTL_COMPLETION_FILE
 fi
+{{end -}}
 alias {{.prefix}}=gardenctl
 alias {{.prefix}}tv='gardenctl target view -o yaml'
 alias {{.prefix}}tc='gardenctl target control-plane'
@@ -41,9 +48,11 @@ alias {{.prefix}}cv='gardenctl config view -o yaml'
 if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ];
   set -gx GCTL_SESSION_ID (uuidgen)
 end
+{{if not .noCompletion -}}
 gardenctl completion {{.shell}} | source
 alias {{.prefix}}=gardenctl
 complete -c {{.prefix}} -w gardenctl
+{{end -}}
 alias {{.prefix}}tv='gardenctl target view -o yaml'
 alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
@@ -57,6 +66,7 @@ if ( !(Test-Path Env:GCTL_SESSION_ID) -and !(Test-Path Env:TERM_SESSION_ID) ) {
   $Env:GCTL_SESSION_ID = [guid]::NewGuid().ToString()
 }
 Set-Alias -Name {{.prefix}} -Value (get-command gardenctl).Path -Option AllScope -Force
+{{if not .noCompletion -}}
 function Gardenctl-Completion-Powershell {
   $s = (gardenctl completion {{.shell}})
   @(
@@ -66,6 +76,7 @@ function Gardenctl-Completion-Powershell {
   )
 }
 Gardenctl-Completion-Powershell | Out-String | Invoke-Expression
+{{end -}}
 function Gardenctl-Target-View {
   gardenctl target view -o yaml
 }

--- a/pkg/cmd/export_test.go
+++ b/pkg/cmd/export_test.go
@@ -8,9 +8,8 @@ package cmd
 
 const (
 	EnvGardenHomeDir = envGardenHomeDir
-	EnvSessionID     = envSessionID
+	EnvSessionID     = envPrefix + "_SESSION_ID"
 	ConfigName       = configName
-	TargetFilename   = targetFilename
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR a not existing config file is treated like an empty config file. An initial config struct with a default filename is created if no config file exists. The user can create a new config file with:
```sh
gardenctl config set-garden dev --kubeconfig /path/to/kubeconfig
```
The initialization of the sessionDirectory and the targetFilename is done when the manager is created and not in the initConfig of the root command. The `version`, `help`, `completion` and `rc` do no more throw an error if `GCTL_SESSION_ID` is not set.

The help of the `gradenctl rc zsh` has been improved and the startup script has been adapted to also support zsh frameworks and plugin manager. Example configuration with gardenctl zsh custom plugin are described for [oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh), [zgen](https://github.com/tarjoilija/zgen) and [zinit](https://github.com/zdharma-continuum/zinit) .

**Which issue(s) this PR fixes**:
Fixes #28 
Fixes #110 
Fixes #111
Fixes #113
Fixes #114

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
