### PR TITLE
doc: Improve install from Github release

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ arch=amd64 # choose between amd64, arm64
 version=$(curl -s https://raw.githubusercontent.com/gardener/gardenctl-v2/master/LATEST)
 
 # Download gardenctl
-curl -LO https://github.com/gardener/gardenctl-v2/releases/download/$(curl -s https://raw.githubusercontent.com/gardener/gardenctl-v2/master/LATEST)/"gardenctl_v2_${os}_${arch}"
+curl -LO "https://github.com/gardener/gardenctl-v2/releases/download/${version}/gardenctl_v2_${os}_${arch}"
 
 # Make the gardenctl binary executable
 chmod +x "./gardenctl_v2_${os}_${arch}"


### PR DESCRIPTION
There should be a reason why we have a version var (unused otherwise).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
