### PR TITLE
Ambiguous Shoot targeting should return an error

### DIFF
--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -160,7 +160,7 @@ func (g *clientImpl) GetShoot(ctx context.Context, namespace, name string) (*gar
 }
 
 func (g *clientImpl) FindShoot(ctx context.Context, opts ...client.ListOption) (*gardencorev1beta1.Shoot, error) {
-	opts = append(opts, client.Limit(1))
+	opts = append(opts, client.Limit(2))
 
 	shootList, err := g.ListShoots(ctx, opts...)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
When targeting a shoot without specifying project or seed and there are multiple shoots on the `garden` with the same name an error should be returned.
This was not the case as [`remainingItemCount`](https://github.com/gardener/gardenctl-v2/blob/master/internal/gardenclient/client.go#L174-L177) was not set. From the documentation it says

> 	// [...] If the list request contained label or field selectors, then the number of
> 	// remaining items is unknown and the field will be left unset and omitted during serialization.

in our case the list request contained a field selector, hence `remainingItemCount` is unset.

Instead, we will fetch up to two items in order to figure out if there are multiple search results

**Which issue(s) this PR fixes**:
Fixes #117 

**Special notes for your reviewer**:
We could also get rid of the `RemainingItemCount` handling as we anyhow increased the limit to `2`. Please let me know in case I should remove it

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
