### PR TITLE
use referred shoot of managed seeds for targeting, provider-env and ssh command

### DIFF
--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -281,13 +281,7 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string) (clie
 	if shoot, err := g.GetShootOfManagedSeed(ctx, name); err != nil {
 		return nil, err
 	} else if shoot != nil {
-		// TODO: Discuss if we want to have the fallback in case GetShootClientConfig returns an error or better just do:
-		// return g.GetShootClientConfig(ctx, "garden", shoot.Name)
-		if config, err := g.GetShootClientConfig(ctx, "garden", shoot.Name); err == nil {
-			return config, nil
-		} else if !apierrors.IsNotFound(err) {
-			return nil, err
-		}
+		return g.GetShootClientConfig(ctx, "garden", shoot.Name)
 	}
 
 	key := types.NamespacedName{Name: name}

--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -11,6 +11,8 @@ import (
 	"errors"
 	"fmt"
 
+	"k8s.io/klog/v2"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -273,6 +275,8 @@ func (g *clientImpl) GetShootOfManagedSeed(ctx context.Context, name string) (*s
 
 		return nil, fmt.Errorf("failed to get managed seed %v: %w", key, err)
 	}
+
+	klog.V(1).Infof("using referred shoot %q for seed %q", managedSeed.Spec.Shoot.Name, name)
 
 	return managedSeed.Spec.Shoot, nil
 }

--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -11,11 +11,6 @@ import (
 	"errors"
 	"fmt"
 
-	openstackinstall "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/install"
-	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
-	gardencore "github.com/gardener/gardener/pkg/apis/core"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +21,12 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openstackinstall "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/install"
+	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 )
 
 var decoder runtime.Decoder
@@ -263,7 +264,7 @@ func (g *clientImpl) GetManagedSeed(ctx context.Context, name string) (*seedmana
 	key := types.NamespacedName{Name: name, Namespace: "garden"} // Currently, managed seeds are restricted to the garden namespace
 
 	if err := g.c.Get(ctx, key, managedSeed); err != nil {
-		return nil, fmt.Errorf("failed to get managed seed %v: %w", name, err)
+		return nil, fmt.Errorf("failed to get managed seed %v: %w", key, err)
 	}
 
 	return managedSeed, nil
@@ -276,7 +277,14 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string) (clie
 	}
 
 	if managedSeed != nil {
-		return g.GetShootClientConfig(ctx, managedSeed.Namespace, managedSeed.Name)
+		clientConfig, err := g.GetShootClientConfig(ctx, managedSeed.Namespace, managedSeed.Name)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+
+		if clientConfig != nil {
+			return clientConfig, nil
+		}
 	}
 
 	key := types.NamespacedName{Name: name}

--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -11,6 +11,11 @@ import (
 	"errors"
 	"fmt"
 
+	openstackinstall "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/install"
+	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,12 +26,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	openstackinstall "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/install"
-	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
-	gardencore "github.com/gardener/gardener/pkg/apis/core"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 )
 
 var decoder runtime.Decoder
@@ -77,6 +76,9 @@ type Client interface {
 	GetSecret(ctx context.Context, namespace, name string) (*corev1.Secret, error)
 	// GetConfigMap returns a Kubernetes configmap resource
 	GetConfigMap(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error)
+
+	// GetManagedSeed returns a Gardener Seed Management ManagedSeed resource
+	GetManagedSeed(ctx context.Context, name string) (*seedmanagementv1alpha1.ManagedSeed, error)
 
 	// RuntimeClient returns the underlying kubernetes runtime client
 	// TODO: Remove this when we switched all APIs to the new gardenclient
@@ -283,6 +285,7 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string) (clie
 		}
 
 		if clientConfig != nil {
+			// TODO write notification message
 			return clientConfig, nil
 		}
 	}

--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -280,7 +280,7 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string) (clie
 	}
 
 	if managedSeed != nil {
-		clientConfig, err := g.GetShootClientConfig(ctx, managedSeed.Namespace, managedSeed.Name)
+		clientConfig, err := g.GetShootClientConfig(ctx, managedSeed.Namespace, managedSeed.Spec.Shoot.Name)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return nil, err
 		}

--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -11,11 +11,6 @@ import (
 	"errors"
 	"fmt"
 
-	openstackinstall "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/install"
-	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
-	gardencore "github.com/gardener/gardener/pkg/apis/core"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +21,12 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	openstackinstall "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/install"
+	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 )
 
 var decoder runtime.Decoder
@@ -285,7 +286,6 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string) (clie
 		}
 
 		if clientConfig != nil {
-			// TODO write notification message
 			return clientConfig, nil
 		}
 	}

--- a/internal/gardenclient/client_test.go
+++ b/internal/gardenclient/client_test.go
@@ -9,7 +9,6 @@ package gardenclient_test
 import (
 	"context"
 
-	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -18,6 +17,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 
 	"github.com/gardener/gardenctl-v2/internal/fake"
 	"github.com/gardener/gardenctl-v2/internal/gardenclient"
@@ -89,8 +90,23 @@ var _ = Describe("Client", func() {
 					"kubeconfig": string(createTestKubeconfig("managedSeed-2")),
 				},
 			}
+			managedSeed3 := &seedmanagementv1alpha1.ManagedSeed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "managedSeed-3",
+					Namespace: "garden",
+				},
+			}
+			loginSecret3 := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "managedSeed-3.login",
+					Namespace: "garden",
+				},
+				Data: map[string][]byte{
+					"kubeconfig": createTestKubeconfig("managedSeed-3"),
+				},
+			}
 			gardenClient = gardenclient.NewGardenClient(
-				fake.NewClientWithObjects(oidcSecret, loginSecret, managedSeed1Secret, managedSeed1, ms1ShootConfigMap, managedSeed2, ms2ShootConfigMap),
+				fake.NewClientWithObjects(oidcSecret, loginSecret, managedSeed1Secret, managedSeed1, ms1ShootConfigMap, managedSeed2, ms2ShootConfigMap, managedSeed3, loginSecret3),
 			)
 		})
 
@@ -105,6 +121,7 @@ var _ = Describe("Client", func() {
 			Entry("and the secretName has suffix .oidc", "seed-1"),
 			Entry("and the secretName has suffix .login", "seed-2"),
 			Entry("and seed is a managed seed, return shoot client config", "managedSeed-1"),
+			Entry("and seed is a managed seed, but shoot client config return not found, fallback to seed secret", "managedSeed-3"),
 		)
 
 		Context("when the secret does not exist", func() {

--- a/internal/gardenclient/client_test.go
+++ b/internal/gardenclient/client_test.go
@@ -9,6 +9,7 @@ package gardenclient_test
 import (
 	"context"
 
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -17,8 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-
-	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 
 	"github.com/gardener/gardenctl-v2/internal/fake"
 	"github.com/gardener/gardenctl-v2/internal/gardenclient"

--- a/internal/gardenclient/client_test.go
+++ b/internal/gardenclient/client_test.go
@@ -9,7 +9,6 @@ package gardenclient_test
 import (
 	"context"
 
-	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
@@ -18,6 +17,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 
 	"github.com/gardener/gardenctl-v2/internal/fake"
 	"github.com/gardener/gardenctl-v2/internal/gardenclient"
@@ -64,6 +65,11 @@ var _ = Describe("Client", func() {
 					Name:      "managedSeed-1",
 					Namespace: "garden",
 				},
+				Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+					Shoot: &seedmanagementv1alpha1.Shoot{
+						Name: "managedSeed-1",
+					},
+				},
 			}
 			ms1ShootConfigMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -79,6 +85,11 @@ var _ = Describe("Client", func() {
 					Name:      "managedSeed-2",
 					Namespace: "garden",
 				},
+				Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+					Shoot: &seedmanagementv1alpha1.Shoot{
+						Name: "managedSeed-2",
+					},
+				},
 			}
 			ms2ShootConfigMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -93,6 +104,11 @@ var _ = Describe("Client", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "managedSeed-3",
 					Namespace: "garden",
+				},
+				Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+					Shoot: &seedmanagementv1alpha1.Shoot{
+						Name: "managedSeed-3",
+					},
 				},
 			}
 			loginSecret3 := &corev1.Secret{

--- a/internal/gardenclient/client_test.go
+++ b/internal/gardenclient/client_test.go
@@ -136,7 +136,6 @@ var _ = Describe("Client", func() {
 			Entry("and the secretName has suffix .oidc", "seed-1"),
 			Entry("and the secretName has suffix .login", "seed-2"),
 			Entry("and seed is a managed seed, return shoot client config", "managedSeed-1"),
-			Entry("and seed is a managed seed, but shoot client config return not found, fallback to seed secret", "managedSeed-3"),
 		)
 
 		Context("when the secret does not exist", func() {

--- a/internal/gardenclient/gardenclient_suite_test.go
+++ b/internal/gardenclient/gardenclient_suite_test.go
@@ -9,9 +9,16 @@ package gardenclient_test
 import (
 	"testing"
 
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 )
+
+func init() {
+	utilruntime.Must(seedmanagementv1alpha1.AddToScheme(scheme.Scheme))
+}
 
 func TestCloudEnvCommand(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/gardenclient/mocks/mock_client.go
+++ b/internal/gardenclient/mocks/mock_client.go
@@ -8,15 +8,14 @@ import (
 	context "context"
 	reflect "reflect"
 
-	"github.com/gardener/gardenctl-v2/internal/gardenclient"
-
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 
+	gardenclient "github.com/gardener/gardenctl-v2/internal/gardenclient"
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	v1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 )
 
 // MockClient is a mock of Client interface.
@@ -90,21 +89,6 @@ func (m *MockClient) GetConfigMap(ctx context.Context, namespace, name string) (
 func (mr *MockClientMockRecorder) GetConfigMap(ctx, namespace, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockClient)(nil).GetConfigMap), ctx, namespace, name)
-}
-
-// GetManagedSeed mocks base method.
-func (m *MockClient) GetManagedSeed(ctx context.Context, name string) (*v1alpha1.ManagedSeed, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetManagedSeed", ctx, name)
-	ret0, _ := ret[0].(*v1alpha1.ManagedSeed)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetManagedSeed indicates an expected call of GetManagedSeed.
-func (mr *MockClientMockRecorder) GetManagedSeed(ctx, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManagedSeed", reflect.TypeOf((*MockClient)(nil).GetManagedSeed), ctx, name)
 }
 
 // GetNamespace mocks base method.
@@ -240,6 +224,21 @@ func (m *MockClient) GetShootClientConfig(ctx context.Context, namespace, name s
 func (mr *MockClientMockRecorder) GetShootClientConfig(ctx, namespace, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShootClientConfig", reflect.TypeOf((*MockClient)(nil).GetShootClientConfig), ctx, namespace, name)
+}
+
+// GetShootOfManagedSeed mocks base method.
+func (m *MockClient) GetShootOfManagedSeed(ctx context.Context, name string) (*v1alpha1.Shoot, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetShootOfManagedSeed", ctx, name)
+	ret0, _ := ret[0].(*v1alpha1.Shoot)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetShootOfManagedSeed indicates an expected call of GetShootOfManagedSeed.
+func (mr *MockClientMockRecorder) GetShootOfManagedSeed(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShootOfManagedSeed", reflect.TypeOf((*MockClient)(nil).GetShootOfManagedSeed), ctx, name)
 }
 
 // ListProjects mocks base method.

--- a/internal/gardenclient/mocks/mock_client.go
+++ b/internal/gardenclient/mocks/mock_client.go
@@ -8,11 +8,15 @@ import (
 	context "context"
 	reflect "reflect"
 
-	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardenctl-v2/internal/gardenclient"
+
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 )
 
 // MockClient is a mock of Client interface.
@@ -39,10 +43,10 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // FindShoot mocks base method.
-func (m *MockClient) FindShoot(arg0 context.Context, arg1 ...client.ListOption) (*v1beta1.Shoot, error) {
+func (m *MockClient) FindShoot(ctx context.Context, opts ...client.ListOption) (*v1beta1.Shoot, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0}
-	for _, a := range arg1 {
+	varargs := []interface{}{ctx}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "FindShoot", varargs...)
@@ -52,182 +56,197 @@ func (m *MockClient) FindShoot(arg0 context.Context, arg1 ...client.ListOption) 
 }
 
 // FindShoot indicates an expected call of FindShoot.
-func (mr *MockClientMockRecorder) FindShoot(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) FindShoot(ctx interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0}, arg1...)
+	varargs := append([]interface{}{ctx}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindShoot", reflect.TypeOf((*MockClient)(nil).FindShoot), varargs...)
 }
 
 // GetCloudProfile mocks base method.
-func (m *MockClient) GetCloudProfile(arg0 context.Context, arg1 string) (*v1beta1.CloudProfile, error) {
+func (m *MockClient) GetCloudProfile(ctx context.Context, name string) (*v1beta1.CloudProfile, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCloudProfile", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetCloudProfile", ctx, name)
 	ret0, _ := ret[0].(*v1beta1.CloudProfile)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCloudProfile indicates an expected call of GetCloudProfile.
-func (mr *MockClientMockRecorder) GetCloudProfile(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetCloudProfile(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudProfile", reflect.TypeOf((*MockClient)(nil).GetCloudProfile), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloudProfile", reflect.TypeOf((*MockClient)(nil).GetCloudProfile), ctx, name)
 }
 
 // GetConfigMap mocks base method.
-func (m *MockClient) GetConfigMap(arg0 context.Context, arg1, arg2 string) (*v1.ConfigMap, error) {
+func (m *MockClient) GetConfigMap(ctx context.Context, namespace, name string) (*v1.ConfigMap, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConfigMap", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetConfigMap", ctx, namespace, name)
 	ret0, _ := ret[0].(*v1.ConfigMap)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetConfigMap indicates an expected call of GetConfigMap.
-func (mr *MockClientMockRecorder) GetConfigMap(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetConfigMap(ctx, namespace, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockClient)(nil).GetConfigMap), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockClient)(nil).GetConfigMap), ctx, namespace, name)
+}
+
+// GetManagedSeed mocks base method.
+func (m *MockClient) GetManagedSeed(ctx context.Context, name string) (*v1alpha1.ManagedSeed, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetManagedSeed", ctx, name)
+	ret0, _ := ret[0].(*v1alpha1.ManagedSeed)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetManagedSeed indicates an expected call of GetManagedSeed.
+func (mr *MockClientMockRecorder) GetManagedSeed(ctx, name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetManagedSeed", reflect.TypeOf((*MockClient)(nil).GetManagedSeed), ctx, name)
 }
 
 // GetNamespace mocks base method.
-func (m *MockClient) GetNamespace(arg0 context.Context, arg1 string) (*v1.Namespace, error) {
+func (m *MockClient) GetNamespace(ctx context.Context, name string) (*v1.Namespace, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNamespace", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetNamespace", ctx, name)
 	ret0, _ := ret[0].(*v1.Namespace)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNamespace indicates an expected call of GetNamespace.
-func (mr *MockClientMockRecorder) GetNamespace(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetNamespace(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockClient)(nil).GetNamespace), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockClient)(nil).GetNamespace), ctx, name)
 }
 
 // GetProject mocks base method.
-func (m *MockClient) GetProject(arg0 context.Context, arg1 string) (*v1beta1.Project, error) {
+func (m *MockClient) GetProject(ctx context.Context, name string) (*v1beta1.Project, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProject", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetProject", ctx, name)
 	ret0, _ := ret[0].(*v1beta1.Project)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProject indicates an expected call of GetProject.
-func (mr *MockClientMockRecorder) GetProject(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetProject(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockClient)(nil).GetProject), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProject", reflect.TypeOf((*MockClient)(nil).GetProject), ctx, name)
 }
 
 // GetProjectByNamespace mocks base method.
-func (m *MockClient) GetProjectByNamespace(arg0 context.Context, arg1 string) (*v1beta1.Project, error) {
+func (m *MockClient) GetProjectByNamespace(ctx context.Context, namespace string) (*v1beta1.Project, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjectByNamespace", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetProjectByNamespace", ctx, namespace)
 	ret0, _ := ret[0].(*v1beta1.Project)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetProjectByNamespace indicates an expected call of GetProjectByNamespace.
-func (mr *MockClientMockRecorder) GetProjectByNamespace(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetProjectByNamespace(ctx, namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectByNamespace", reflect.TypeOf((*MockClient)(nil).GetProjectByNamespace), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectByNamespace", reflect.TypeOf((*MockClient)(nil).GetProjectByNamespace), ctx, namespace)
 }
 
 // GetSecret mocks base method.
-func (m *MockClient) GetSecret(arg0 context.Context, arg1, arg2 string) (*v1.Secret, error) {
+func (m *MockClient) GetSecret(ctx context.Context, namespace, name string) (*v1.Secret, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecret", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetSecret", ctx, namespace, name)
 	ret0, _ := ret[0].(*v1.Secret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecret indicates an expected call of GetSecret.
-func (mr *MockClientMockRecorder) GetSecret(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetSecret(ctx, namespace, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockClient)(nil).GetSecret), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecret", reflect.TypeOf((*MockClient)(nil).GetSecret), ctx, namespace, name)
 }
 
 // GetSecretBinding mocks base method.
-func (m *MockClient) GetSecretBinding(arg0 context.Context, arg1, arg2 string) (*v1beta1.SecretBinding, error) {
+func (m *MockClient) GetSecretBinding(ctx context.Context, namespace, name string) (*v1beta1.SecretBinding, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSecretBinding", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetSecretBinding", ctx, namespace, name)
 	ret0, _ := ret[0].(*v1beta1.SecretBinding)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSecretBinding indicates an expected call of GetSecretBinding.
-func (mr *MockClientMockRecorder) GetSecretBinding(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetSecretBinding(ctx, namespace, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretBinding", reflect.TypeOf((*MockClient)(nil).GetSecretBinding), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSecretBinding", reflect.TypeOf((*MockClient)(nil).GetSecretBinding), ctx, namespace, name)
 }
 
 // GetSeed mocks base method.
-func (m *MockClient) GetSeed(arg0 context.Context, arg1 string) (*v1beta1.Seed, error) {
+func (m *MockClient) GetSeed(ctx context.Context, name string) (*v1beta1.Seed, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSeed", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetSeed", ctx, name)
 	ret0, _ := ret[0].(*v1beta1.Seed)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSeed indicates an expected call of GetSeed.
-func (mr *MockClientMockRecorder) GetSeed(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetSeed(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeed", reflect.TypeOf((*MockClient)(nil).GetSeed), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeed", reflect.TypeOf((*MockClient)(nil).GetSeed), ctx, name)
 }
 
 // GetSeedClientConfig mocks base method.
-func (m *MockClient) GetSeedClientConfig(arg0 context.Context, arg1 string) (clientcmd.ClientConfig, error) {
+func (m *MockClient) GetSeedClientConfig(ctx context.Context, name string) (clientcmd.ClientConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSeedClientConfig", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetSeedClientConfig", ctx, name)
 	ret0, _ := ret[0].(clientcmd.ClientConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSeedClientConfig indicates an expected call of GetSeedClientConfig.
-func (mr *MockClientMockRecorder) GetSeedClientConfig(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetSeedClientConfig(ctx, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeedClientConfig", reflect.TypeOf((*MockClient)(nil).GetSeedClientConfig), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeedClientConfig", reflect.TypeOf((*MockClient)(nil).GetSeedClientConfig), ctx, name)
 }
 
 // GetShoot mocks base method.
-func (m *MockClient) GetShoot(arg0 context.Context, arg1, arg2 string) (*v1beta1.Shoot, error) {
+func (m *MockClient) GetShoot(ctx context.Context, namespace, name string) (*v1beta1.Shoot, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetShoot", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetShoot", ctx, namespace, name)
 	ret0, _ := ret[0].(*v1beta1.Shoot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetShoot indicates an expected call of GetShoot.
-func (mr *MockClientMockRecorder) GetShoot(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetShoot(ctx, namespace, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShoot", reflect.TypeOf((*MockClient)(nil).GetShoot), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShoot", reflect.TypeOf((*MockClient)(nil).GetShoot), ctx, namespace, name)
 }
 
 // GetShootClientConfig mocks base method.
-func (m *MockClient) GetShootClientConfig(arg0 context.Context, arg1, arg2 string) (clientcmd.ClientConfig, error) {
+func (m *MockClient) GetShootClientConfig(ctx context.Context, namespace, name string) (clientcmd.ClientConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetShootClientConfig", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetShootClientConfig", ctx, namespace, name)
 	ret0, _ := ret[0].(clientcmd.ClientConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetShootClientConfig indicates an expected call of GetShootClientConfig.
-func (mr *MockClientMockRecorder) GetShootClientConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetShootClientConfig(ctx, namespace, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShootClientConfig", reflect.TypeOf((*MockClient)(nil).GetShootClientConfig), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShootClientConfig", reflect.TypeOf((*MockClient)(nil).GetShootClientConfig), ctx, namespace, name)
 }
 
 // ListProjects mocks base method.
-func (m *MockClient) ListProjects(arg0 context.Context, arg1 ...client.ListOption) (*v1beta1.ProjectList, error) {
+func (m *MockClient) ListProjects(ctx context.Context, opts ...client.ListOption) (*v1beta1.ProjectList, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0}
-	for _, a := range arg1 {
+	varargs := []interface{}{ctx}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ListProjects", varargs...)
@@ -237,17 +256,17 @@ func (m *MockClient) ListProjects(arg0 context.Context, arg1 ...client.ListOptio
 }
 
 // ListProjects indicates an expected call of ListProjects.
-func (mr *MockClientMockRecorder) ListProjects(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ListProjects(ctx interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0}, arg1...)
+	varargs := append([]interface{}{ctx}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProjects", reflect.TypeOf((*MockClient)(nil).ListProjects), varargs...)
 }
 
 // ListSeeds mocks base method.
-func (m *MockClient) ListSeeds(arg0 context.Context, arg1 ...client.ListOption) (*v1beta1.SeedList, error) {
+func (m *MockClient) ListSeeds(ctx context.Context, opts ...client.ListOption) (*v1beta1.SeedList, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0}
-	for _, a := range arg1 {
+	varargs := []interface{}{ctx}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ListSeeds", varargs...)
@@ -257,17 +276,17 @@ func (m *MockClient) ListSeeds(arg0 context.Context, arg1 ...client.ListOption) 
 }
 
 // ListSeeds indicates an expected call of ListSeeds.
-func (mr *MockClientMockRecorder) ListSeeds(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ListSeeds(ctx interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0}, arg1...)
+	varargs := append([]interface{}{ctx}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSeeds", reflect.TypeOf((*MockClient)(nil).ListSeeds), varargs...)
 }
 
 // ListShoots mocks base method.
-func (m *MockClient) ListShoots(arg0 context.Context, arg1 ...client.ListOption) (*v1beta1.ShootList, error) {
+func (m *MockClient) ListShoots(ctx context.Context, opts ...client.ListOption) (*v1beta1.ShootList, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0}
-	for _, a := range arg1 {
+	varargs := []interface{}{ctx}
+	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ListShoots", varargs...)
@@ -277,9 +296,9 @@ func (m *MockClient) ListShoots(arg0 context.Context, arg1 ...client.ListOption)
 }
 
 // ListShoots indicates an expected call of ListShoots.
-func (mr *MockClientMockRecorder) ListShoots(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) ListShoots(ctx interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0}, arg1...)
+	varargs := append([]interface{}{ctx}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListShoots", reflect.TypeOf((*MockClient)(nil).ListShoots), varargs...)
 }
 
@@ -295,4 +314,90 @@ func (m *MockClient) RuntimeClient() client.Client {
 func (mr *MockClientMockRecorder) RuntimeClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RuntimeClient", reflect.TypeOf((*MockClient)(nil).RuntimeClient))
+}
+
+// Mockresolver is a mock of resolver interface.
+type Mockresolver struct {
+	ctrl     *gomock.Controller
+	recorder *MockresolverMockRecorder
+}
+
+// MockresolverMockRecorder is the mock recorder for Mockresolver.
+type MockresolverMockRecorder struct {
+	mock *Mockresolver
+}
+
+// NewMockresolver creates a new mock instance.
+func NewMockresolver(ctrl *gomock.Controller) *Mockresolver {
+	mock := &Mockresolver{ctrl: ctrl}
+	mock.recorder = &MockresolverMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *Mockresolver) EXPECT() *MockresolverMockRecorder {
+	return m.recorder
+}
+
+// resolve mocks base method.
+func (m *Mockresolver) resolve(arg0 context.Context, arg1 gardenclient.Client) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "resolve", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// resolve indicates an expected call of resolve.
+func (mr *MockresolverMockRecorder) resolve(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "resolve", reflect.TypeOf((*Mockresolver)(nil).resolve), arg0, arg1)
+}
+
+// MocklistOptionResolver is a mock of listOptionResolver interface.
+type MocklistOptionResolver struct {
+	ctrl     *gomock.Controller
+	recorder *MocklistOptionResolverMockRecorder
+}
+
+// MocklistOptionResolverMockRecorder is the mock recorder for MocklistOptionResolver.
+type MocklistOptionResolverMockRecorder struct {
+	mock *MocklistOptionResolver
+}
+
+// NewMocklistOptionResolver creates a new mock instance.
+func NewMocklistOptionResolver(ctrl *gomock.Controller) *MocklistOptionResolver {
+	mock := &MocklistOptionResolver{ctrl: ctrl}
+	mock.recorder = &MocklistOptionResolverMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MocklistOptionResolver) EXPECT() *MocklistOptionResolverMockRecorder {
+	return m.recorder
+}
+
+// ApplyToList mocks base method.
+func (m *MocklistOptionResolver) ApplyToList(arg0 *client.ListOptions) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ApplyToList", arg0)
+}
+
+// ApplyToList indicates an expected call of ApplyToList.
+func (mr *MocklistOptionResolverMockRecorder) ApplyToList(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyToList", reflect.TypeOf((*MocklistOptionResolver)(nil).ApplyToList), arg0)
+}
+
+// resolve mocks base method.
+func (m *MocklistOptionResolver) resolve(arg0 context.Context, arg1 gardenclient.Client) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "resolve", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// resolve indicates an expected call of resolve.
+func (mr *MocklistOptionResolverMockRecorder) resolve(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "resolve", reflect.TypeOf((*MocklistOptionResolver)(nil).resolve), arg0, arg1)
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ package main
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -17,6 +18,7 @@ import (
 func main() {
 	utilruntime.Must(gardencorev1beta1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(operationsv1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(seedmanagementv1alpha1.AddToScheme(scheme.Scheme))
 
 	cmd.Execute()
 }

--- a/pkg/cmd/env/options.go
+++ b/pkg/cmd/env/options.go
@@ -18,7 +18,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
@@ -139,13 +138,10 @@ func (o *options) Run(f util.Factory) error {
 
 		if t.ShootName() == "" {
 			if t.SeedName() != "" {
-				managedSeed, err := client.GetManagedSeed(f.Context(), t.SeedName())
-				if err != nil && !apierrors.IsNotFound(err) {
+				if shoot, err := client.GetShootOfManagedSeed(f.Context(), t.SeedName()); err != nil {
 					return err
-				}
-
-				if managedSeed != nil {
-					o.Target = o.Target.WithProjectName("garden").WithShootName(managedSeed.Spec.Shoot.Name)
+				} else if shoot != nil {
+					o.Target = o.Target.WithProjectName("garden").WithShootName(shoot.Name)
 				} else {
 					return target.ErrNoShootTargeted
 				}

--- a/pkg/cmd/env/options.go
+++ b/pkg/cmd/env/options.go
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
@@ -146,7 +145,6 @@ func (o *options) Run(f util.Factory) error {
 				}
 
 				if managedSeed != nil {
-					fmt.Fprintf(o.IOStreams.Out, "%s The targted seed is a managed seed. Providing cloud provider CLI configuration script for referred shoot %q\n", color.BlueString("INFO"), managedSeed.Name)
 					o.CurrentTarget = o.CurrentTarget.WithProjectName("garden").WithShootName(managedSeed.Name)
 				} else {
 					return target.ErrNoShootTargeted

--- a/pkg/cmd/env/options_test.go
+++ b/pkg/cmd/env/options_test.go
@@ -401,6 +401,11 @@ var _ = Describe("Env Commands - Options", func() {
 								Name:      "seed",
 								Namespace: "garden",
 							},
+							Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+								Shoot: &seedmanagementv1alpha1.Shoot{
+									Name: "seed",
+								},
+							},
 						}
 
 						factory.EXPECT().Context().Return(ctx)

--- a/pkg/cmd/env/options_test.go
+++ b/pkg/cmd/env/options_test.go
@@ -526,7 +526,7 @@ var _ = Describe("Env Commands - Options", func() {
 				providerConfig = nil
 				serviceaccountJSON = readTestFile("gcp/serviceaccount.json")
 				token = "token"
-				options.CurrentTarget = target.NewTarget("test", "project", "", shootName)
+				options.Target = target.NewTarget("test", "project", "", shootName)
 			})
 
 			JustBeforeEach(func() {
@@ -744,7 +744,7 @@ var _ = Describe("Env Commands - Options", func() {
 				providerType = "alicloud"
 				shell = "bash"
 				unset = false
-				options.CurrentTarget = t.WithSeedName("")
+				options.Target = t.WithSeedName("")
 			})
 
 			JustBeforeEach(func() {

--- a/pkg/cmd/env/options_test.go
+++ b/pkg/cmd/env/options_test.go
@@ -396,21 +396,13 @@ var _ = Describe("Env Commands - Options", func() {
 
 				Context("and the seed is a managed seed", func() {
 					JustBeforeEach(func() {
-						managedSeed := &seedmanagementv1alpha1.ManagedSeed{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "seed",
-								Namespace: "garden",
-							},
-							Spec: seedmanagementv1alpha1.ManagedSeedSpec{
-								Shoot: &seedmanagementv1alpha1.Shoot{
-									Name: "seed",
-								},
-							},
+						seedShoot := &seedmanagementv1alpha1.Shoot{
+							Name: "seed",
 						}
 
 						factory.EXPECT().Context().Return(ctx)
 						manager.EXPECT().CurrentTarget().Return(t.WithProjectName("").WithShootName(""), nil)
-						client.EXPECT().GetManagedSeed(ctx, "seed").Return(managedSeed, nil)
+						client.EXPECT().GetShootOfManagedSeed(ctx, "seed").Return(seedShoot, nil)
 						currentTarget := t.WithShootName("seed").WithProjectName("garden")
 						client.EXPECT().FindShoot(ctx, currentTarget.AsListOption()).Return(shoot, nil)
 					})
@@ -441,7 +433,7 @@ var _ = Describe("Env Commands - Options", func() {
 					manager.EXPECT().GardenClient(t.GardenName()).Return(client, nil)
 					factory.EXPECT().Context().Return(ctx)
 					manager.EXPECT().CurrentTarget().Return(t.WithShootName(""), nil)
-					client.EXPECT().GetManagedSeed(ctx, "seed").Return(nil, nil)
+					client.EXPECT().GetShootOfManagedSeed(ctx, "seed").Return(nil, nil)
 					Expect(options.Run(factory)).To(BeIdenticalTo(target.ErrNoShootTargeted))
 				})
 

--- a/pkg/cmd/env/testdata/gcp/export.managedseed.bash
+++ b/pkg/cmd/env/testdata/gcp/export.managedseed.bash
@@ -1,0 +1,10 @@
+export GOOGLE_CREDENTIALS='{"client_email":"test@example.org","project_id":"test"}';
+export GOOGLE_CREDENTIALS_ACCOUNT='test@example.org';
+export CLOUDSDK_CORE_PROJECT='test';
+export CLOUDSDK_COMPUTE_REGION='europe';
+export CLOUDSDK_CONFIG='%[1]s/.config/gcloud';
+gcloud auth activate-service-account $GOOGLE_CREDENTIALS_ACCOUNT --key-file <(printf "%%s" "$GOOGLE_CREDENTIALS");
+printf 'Run the following command to revoke access credentials:\n$ eval $(gardenctl provider-env --garden test --project garden --shoot seed -u bash)\n';
+
+# Run this command to configure gcloud for your shell:
+# eval $(gardenctl provider-env bash)

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
 	cryptossh "golang.org/x/crypto/ssh"
@@ -436,7 +435,6 @@ func (o *SSHOptions) Run(f util.Factory) error {
 			}
 
 			if managedSeed != nil {
-				fmt.Fprintf(o.IOStreams.Out, "%s The targted seed is a managed seed. Preparing access to referred shoot %q\n", color.BlueString("INFO"), managedSeed.Name)
 				currentTarget = currentTarget.WithProjectName("garden").WithShootName(managedSeed.Name)
 			} else {
 				return target.ErrNoShootTargeted

--- a/pkg/target/target_suite_test.go
+++ b/pkg/target/target_suite_test.go
@@ -12,7 +12,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -20,10 +21,13 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
 func init() {
 	utilruntime.Must(gardencorev1beta1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(seedmanagementv1alpha1.AddToScheme(scheme.Scheme))
 }
 
 func TestTarget(t *testing.T) {

--- a/pkg/target/target_suite_test.go
+++ b/pkg/target/target_suite_test.go
@@ -12,8 +12,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -21,8 +21,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
 func init() {


### PR DESCRIPTION
**What this PR does / why we need it**:
If seed is a managed seed, GetSeedClientConfig returns GetShootClientConfig for respective shoot

**Which issue(s) this PR fixes**:
Fixes #129 Fixes #104

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Managed seeds no longer require `<seedname>.login` secret. The `gardenlogin` kubeconfig is used instead for the shoot that is registered as seed
```

```feature user
Gardenctl now uses referred shoot of managed seeds for targeting, provider-env and ssh commands.
```
