### PR TITLE
Initialize KUBECONFIG environment variable in startup script

### DIFF
--- a/docs/help/gardenctl_rc_bash.md
+++ b/docs/help/gardenctl_rc_bash.md
@@ -23,6 +23,7 @@ gardenctl rc bash [flags]
 ```
   -h, --help            help for bash
       --no-completion   The startup script should not setup completion
+      --no-kubeconfig   The startup script should not modify the KUBECONFIG environment variable
   -p, --prefix string   The prefix used for aliases and functions (default "g")
 ```
 

--- a/docs/help/gardenctl_rc_fish.md
+++ b/docs/help/gardenctl_rc_fish.md
@@ -23,6 +23,7 @@ gardenctl rc fish [flags]
 ```
   -h, --help            help for fish
       --no-completion   The startup script should not setup completion
+      --no-kubeconfig   The startup script should not modify the KUBECONFIG environment variable
   -p, --prefix string   The prefix used for aliases and functions (default "g")
 ```
 

--- a/docs/help/gardenctl_rc_powershell.md
+++ b/docs/help/gardenctl_rc_powershell.md
@@ -23,6 +23,7 @@ gardenctl rc powershell [flags]
 ```
   -h, --help            help for powershell
       --no-completion   The startup script should not setup completion
+      --no-kubeconfig   The startup script should not modify the KUBECONFIG environment variable
   -p, --prefix string   The prefix used for aliases and functions (default "g")
 ```
 

--- a/docs/help/gardenctl_rc_zsh.md
+++ b/docs/help/gardenctl_rc_zsh.md
@@ -58,6 +58,7 @@ gardenctl rc zsh [flags]
 ```
   -h, --help            help for zsh
       --no-completion   The startup script should not setup completion
+      --no-kubeconfig   The startup script should not modify the KUBECONFIG environment variable
   -p, --prefix string   The prefix used for aliases and functions (default "g")
 ```
 

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -180,6 +180,8 @@ type rcOptions struct {
 	Prefix string
 	// NoCompletion if the value is true tab completion is not part of the startup script
 	NoCompletion bool
+	// NoKubeconfig if the value is true the KUBECONFIG environment variable is not modified in the startup script
+	NoKubeconfig bool
 	// Template is the script template
 	Template Template
 }
@@ -217,6 +219,7 @@ func (o *rcOptions) Run(f util.Factory) error {
 		"shell":        o.Shell,
 		"prefix":       o.Prefix,
 		"noCompletion": o.NoCompletion,
+		"noKubeconfig": o.NoKubeconfig,
 	}
 
 	return o.Template.ExecuteTemplate(o.IOStreams.Out, o.Shell, data)
@@ -226,4 +229,5 @@ func (o *rcOptions) Run(f util.Factory) error {
 func (o *rcOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.Prefix, "prefix", "p", "g", "The prefix used for aliases and functions")
 	flags.BoolVar(&o.NoCompletion, "no-completion", false, "The startup script should not setup completion")
+	flags.BoolVar(&o.NoKubeconfig, "no-kubeconfig", false, "The startup script should not modify the KUBECONFIG environment variable")
 }

--- a/pkg/cmd/env/rc_test.go
+++ b/pkg/cmd/env/rc_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -73,6 +74,7 @@ alias gtc-='gardenctl target unset control-plane'
 alias gk='eval $(gardenctl kubectl-env bash)'
 alias gp='eval $(gardenctl provider-env bash)'
 alias gcv='gardenctl config view -o yaml'
+gk
 `))
 		})
 
@@ -103,6 +105,7 @@ alias gtc-='gardenctl target unset control-plane'
 alias gk='eval $(gardenctl kubectl-env zsh)'
 alias gp='eval $(gardenctl provider-env zsh)'
 alias gcv='gardenctl config view -o yaml'
+gk
 `))
 		})
 
@@ -121,6 +124,7 @@ alias gtc-='gardenctl target unset control-plane'
 alias gk='eval (gardenctl kubectl-env fish)'
 alias gp='eval (gardenctl provider-env fish)'
 alias gcv='gardenctl config view -o yaml'
+gk
 `))
 		})
 
@@ -164,6 +168,7 @@ function Gardenctl-Config-View {
   gardenctl config view -o yaml
 }
 Set-Alias -Name gcv -Value Gardenctl-Config-View -Option AllScope -Force
+gk
 `))
 		})
 
@@ -172,6 +177,17 @@ Set-Alias -Name gcv -Value Gardenctl-Config-View -Option AllScope -Force
 			Expect(cmd.Execute()).To(Succeed())
 			Expect(out.String()).To(MatchRegexp(`(?m)^alias gctl=gardenctl$`))
 		})
+
+		DescribeTable("Execute the shell subcommand with no-kubeconfig flag", func(shell string) {
+			cmd.SetArgs([]string{shell, "--no-kubeconfig"})
+			Expect(cmd.Execute()).To(Succeed())
+			Expect(out.String()).NotTo(MatchRegexp(`(?m)^gk$`))
+		},
+			Entry("when subcommand is bash", "bash"),
+			Entry("when subcommand is zsh", "zsh"),
+			Entry("when subcommand is fish", "fish"),
+			Entry("when subcommand is powershell", "powershell"),
+		)
 	})
 
 	Describe("Validating the RC command options", func() {

--- a/pkg/cmd/env/rc_test.go
+++ b/pkg/cmd/env/rc_test.go
@@ -65,8 +65,8 @@ var _ = Describe("Env Commands", func() {
 			Expect(out.String()).To(Equal(`if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
-source <(gardenctl completion bash)
 alias g=gardenctl
+source <(gardenctl completion bash)
 complete -o default -F __start_gardenctl g
 alias gtv='gardenctl target view -o yaml'
 alias gtc='gardenctl target control-plane'
@@ -115,8 +115,8 @@ gk
 			Expect(out.String()).To(Equal(`if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ];
   set -gx GCTL_SESSION_ID (uuidgen)
 end
-gardenctl completion fish | source
 alias g=gardenctl
+gardenctl completion fish | source
 complete -c g -w gardenctl
 alias gtv='gardenctl target view -o yaml'
 alias gtc='gardenctl target control-plane'

--- a/pkg/cmd/env/rc_test.go
+++ b/pkg/cmd/env/rc_test.go
@@ -66,14 +66,14 @@ var _ = Describe("Env Commands", func() {
   export GCTL_SESSION_ID=$(uuidgen)
 fi
 alias g=gardenctl
-source <(gardenctl completion bash)
-complete -o default -F __start_gardenctl g
 alias gtv='gardenctl target view -o yaml'
 alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
 alias gk='eval $(gardenctl kubectl-env bash)'
 alias gp='eval $(gardenctl provider-env bash)'
 alias gcv='gardenctl config view -o yaml'
+source <(gardenctl completion bash)
+complete -o default -F __start_gardenctl g
 gk
 `))
 		})
@@ -84,6 +84,13 @@ gk
 			Expect(out.String()).To(Equal(`if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
+alias g=gardenctl
+alias gtv='gardenctl target view -o yaml'
+alias gtc='gardenctl target control-plane'
+alias gtc-='gardenctl target unset control-plane'
+alias gk='eval $(gardenctl kubectl-env zsh)'
+alias gp='eval $(gardenctl provider-env zsh)'
+alias gcv='gardenctl config view -o yaml'
 if (( $+commands[gardenctl] )); then
   if [ -d "$ZSH_CACHE_DIR/completions" ] && (($fpath[(Ie)$ZSH_CACHE_DIR/completions])); then
     GCTL_COMPLETION_FILE="$ZSH_CACHE_DIR/completions/_gardenctl"
@@ -98,13 +105,6 @@ if (( $+commands[gardenctl] )); then
   gardenctl completion zsh >| "$GCTL_COMPLETION_FILE" &|
   unset GCTL_COMPLETION_FILE
 fi
-alias g=gardenctl
-alias gtv='gardenctl target view -o yaml'
-alias gtc='gardenctl target control-plane'
-alias gtc-='gardenctl target unset control-plane'
-alias gk='eval $(gardenctl kubectl-env zsh)'
-alias gp='eval $(gardenctl provider-env zsh)'
-alias gcv='gardenctl config view -o yaml'
 gk
 `))
 		})
@@ -116,14 +116,14 @@ gk
   set -gx GCTL_SESSION_ID (uuidgen)
 end
 alias g=gardenctl
-gardenctl completion fish | source
-complete -c g -w gardenctl
 alias gtv='gardenctl target view -o yaml'
 alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
 alias gk='eval (gardenctl kubectl-env fish)'
 alias gp='eval (gardenctl provider-env fish)'
 alias gcv='gardenctl config view -o yaml'
+gardenctl completion fish | source
+complete -c g -w gardenctl
 gk
 `))
 		})
@@ -135,15 +135,6 @@ gk
   $Env:GCTL_SESSION_ID = [guid]::NewGuid().ToString()
 }
 Set-Alias -Name g -Value (get-command gardenctl).Path -Option AllScope -Force
-function Gardenctl-Completion-Powershell {
-  $s = (gardenctl completion powershell)
-  @(
-    ($s -replace "(?ms)^Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock", "` + "`" + `$scriptBlock =")
-    "Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock ` + "`" + `$scriptBlock"
-    "Register-ArgumentCompleter -CommandName 'g' -ScriptBlock ` + "`" + `$scriptBlock"
-  )
-}
-Gardenctl-Completion-Powershell | Out-String | Invoke-Expression
 function Gardenctl-Target-View {
   gardenctl target view -o yaml
 }
@@ -168,6 +159,15 @@ function Gardenctl-Config-View {
   gardenctl config view -o yaml
 }
 Set-Alias -Name gcv -Value Gardenctl-Config-View -Option AllScope -Force
+function Gardenctl-Completion-Powershell {
+  $s = (gardenctl completion powershell)
+  @(
+    ($s -replace "(?ms)^Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock", "` + "`" + `$scriptBlock =")
+    "Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock ` + "`" + `$scriptBlock"
+    "Register-ArgumentCompleter -CommandName 'g' -ScriptBlock ` + "`" + `$scriptBlock"
+  )
+}
+Gardenctl-Completion-Powershell | Out-String | Invoke-Expression
 gk
 `))
 		})

--- a/pkg/cmd/env/rc_test.go
+++ b/pkg/cmd/env/rc_test.go
@@ -178,6 +178,18 @@ gk
 			Expect(out.String()).To(MatchRegexp(`(?m)^alias gctl=gardenctl$`))
 		})
 
+		DescribeTable("Execute the shell subcommand with no-completion flag", func(shell, aliasRegexp string) {
+			cmd.SetArgs([]string{shell, "--no-completion"})
+			Expect(cmd.Execute()).To(Succeed())
+			Expect(out.String()).NotTo(MatchRegexp(fmt.Sprintf("(?m)gardenctl completion %s", shell)))
+			Expect(out.String()).To(MatchRegexp(aliasRegexp))
+		},
+			Entry("when subcommand is bash", "bash", `(?m)^alias g=`),
+			Entry("when subcommand is zsh", "zsh", `(?m)^alias g=`),
+			Entry("when subcommand is fish", "fish", `(?m)^alias g=`),
+			Entry("when subcommand is powershell", "powershell", `(?m)^Set-Alias -Name g -Value`),
+		)
+
 		DescribeTable("Execute the shell subcommand with no-kubeconfig flag", func(shell string) {
 			cmd.SetArgs([]string{shell, "--no-kubeconfig"})
 			Expect(cmd.Execute()).To(Succeed())

--- a/pkg/cmd/env/rc_test.go
+++ b/pkg/cmd/env/rc_test.go
@@ -173,7 +173,7 @@ gk
 		})
 
 		It("should execute the bash subcommand with prefix flag", func() {
-			cmd.SetArgs([]string{"--prefix=gctl", "bash"})
+			cmd.SetArgs([]string{"bash", "--prefix=gctl"})
 			Expect(cmd.Execute()).To(Succeed())
 			Expect(out.String()).To(MatchRegexp(`(?m)^alias gctl=gardenctl$`))
 		})

--- a/pkg/cmd/env/templates/rc.tmpl
+++ b/pkg/cmd/env/templates/rc.tmpl
@@ -3,16 +3,16 @@ if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
 alias {{.prefix}}=gardenctl
-{{if not .noCompletion -}}
-source <(gardenctl completion {{.shell}})
-complete -o default -F __start_gardenctl {{.prefix}}
-{{end -}}
 alias {{.prefix}}tv='gardenctl target view -o yaml'
 alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval $(gardenctl kubectl-env {{.shell}})'
 alias {{.prefix}}p='eval $(gardenctl provider-env {{.shell}})'
 alias {{.prefix}}cv='gardenctl config view -o yaml'
+{{if not .noCompletion -}}
+source <(gardenctl completion {{.shell}})
+complete -o default -F __start_gardenctl {{.prefix}}
+{{end -}}
 {{if not .noKubeconfig -}}
 {{.prefix}}k
 {{end -}}
@@ -22,6 +22,13 @@ alias {{.prefix}}cv='gardenctl config view -o yaml'
 if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
+alias {{.prefix}}=gardenctl
+alias {{.prefix}}tv='gardenctl target view -o yaml'
+alias {{.prefix}}tc='gardenctl target control-plane'
+alias {{.prefix}}tc-='gardenctl target unset control-plane'
+alias {{.prefix}}k='eval $(gardenctl kubectl-env {{.shell}})'
+alias {{.prefix}}p='eval $(gardenctl provider-env {{.shell}})'
+alias {{.prefix}}cv='gardenctl config view -o yaml'
 {{if not .noCompletion -}}
 if (( $+commands[gardenctl] )); then
   if [ -d "$ZSH_CACHE_DIR/completions" ] && (($fpath[(Ie)$ZSH_CACHE_DIR/completions])); then
@@ -38,13 +45,6 @@ if (( $+commands[gardenctl] )); then
   unset GCTL_COMPLETION_FILE
 fi
 {{end -}}
-alias {{.prefix}}=gardenctl
-alias {{.prefix}}tv='gardenctl target view -o yaml'
-alias {{.prefix}}tc='gardenctl target control-plane'
-alias {{.prefix}}tc-='gardenctl target unset control-plane'
-alias {{.prefix}}k='eval $(gardenctl kubectl-env {{.shell}})'
-alias {{.prefix}}p='eval $(gardenctl provider-env {{.shell}})'
-alias {{.prefix}}cv='gardenctl config view -o yaml'
 {{if not .noKubeconfig -}}
 {{.prefix}}k
 {{end -}}
@@ -55,16 +55,16 @@ if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ];
   set -gx GCTL_SESSION_ID (uuidgen)
 end
 alias {{.prefix}}=gardenctl
-{{if not .noCompletion -}}
-gardenctl completion {{.shell}} | source
-complete -c {{.prefix}} -w gardenctl
-{{end -}}
 alias {{.prefix}}tv='gardenctl target view -o yaml'
 alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval (gardenctl kubectl-env {{.shell}})'
 alias {{.prefix}}p='eval (gardenctl provider-env {{.shell}})'
 alias {{.prefix}}cv='gardenctl config view -o yaml'
+{{if not .noCompletion -}}
+gardenctl completion {{.shell}} | source
+complete -c {{.prefix}} -w gardenctl
+{{end -}}
 {{if not .noKubeconfig -}}
 {{.prefix}}k
 {{end -}}
@@ -75,17 +75,6 @@ if ( !(Test-Path Env:GCTL_SESSION_ID) -and !(Test-Path Env:TERM_SESSION_ID) ) {
   $Env:GCTL_SESSION_ID = [guid]::NewGuid().ToString()
 }
 Set-Alias -Name {{.prefix}} -Value (get-command gardenctl).Path -Option AllScope -Force
-{{if not .noCompletion -}}
-function Gardenctl-Completion-Powershell {
-  $s = (gardenctl completion {{.shell}})
-  @(
-    ($s -replace "(?ms)^Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock", "`$scriptBlock =")
-    "Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock `$scriptBlock"
-    "Register-ArgumentCompleter -CommandName '{{.prefix}}' -ScriptBlock `$scriptBlock"
-  )
-}
-Gardenctl-Completion-Powershell | Out-String | Invoke-Expression
-{{end -}}
 function Gardenctl-Target-View {
   gardenctl target view -o yaml
 }
@@ -110,6 +99,17 @@ function Gardenctl-Config-View {
   gardenctl config view -o yaml
 }
 Set-Alias -Name {{.prefix}}cv -Value Gardenctl-Config-View -Option AllScope -Force
+{{if not .noCompletion -}}
+function Gardenctl-Completion-Powershell {
+  $s = (gardenctl completion {{.shell}})
+  @(
+    ($s -replace "(?ms)^Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock", "`$scriptBlock =")
+    "Register-ArgumentCompleter -CommandName 'gardenctl' -ScriptBlock `$scriptBlock"
+    "Register-ArgumentCompleter -CommandName '{{.prefix}}' -ScriptBlock `$scriptBlock"
+  )
+}
+Gardenctl-Completion-Powershell | Out-String | Invoke-Expression
+{{end -}}
 {{if not .noKubeconfig -}}
 {{.prefix}}k
 {{end -}}

--- a/pkg/cmd/env/templates/rc.tmpl
+++ b/pkg/cmd/env/templates/rc.tmpl
@@ -2,9 +2,9 @@
 if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
+alias {{.prefix}}=gardenctl
 {{if not .noCompletion -}}
 source <(gardenctl completion {{.shell}})
-alias {{.prefix}}=gardenctl
 complete -o default -F __start_gardenctl {{.prefix}}
 {{end -}}
 alias {{.prefix}}tv='gardenctl target view -o yaml'
@@ -54,9 +54,9 @@ alias {{.prefix}}cv='gardenctl config view -o yaml'
 if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ];
   set -gx GCTL_SESSION_ID (uuidgen)
 end
+alias {{.prefix}}=gardenctl
 {{if not .noCompletion -}}
 gardenctl completion {{.shell}} | source
-alias {{.prefix}}=gardenctl
 complete -c {{.prefix}} -w gardenctl
 {{end -}}
 alias {{.prefix}}tv='gardenctl target view -o yaml'

--- a/pkg/cmd/env/templates/rc.tmpl
+++ b/pkg/cmd/env/templates/rc.tmpl
@@ -13,6 +13,9 @@ alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval $(gardenctl kubectl-env {{.shell}})'
 alias {{.prefix}}p='eval $(gardenctl provider-env {{.shell}})'
 alias {{.prefix}}cv='gardenctl config view -o yaml'
+{{if not .noKubeconfig -}}
+{{.prefix}}k
+{{end -}}
 {{end}}
 
 {{define "zsh" -}}
@@ -42,6 +45,9 @@ alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval $(gardenctl kubectl-env {{.shell}})'
 alias {{.prefix}}p='eval $(gardenctl provider-env {{.shell}})'
 alias {{.prefix}}cv='gardenctl config view -o yaml'
+{{if not .noKubeconfig -}}
+{{.prefix}}k
+{{end -}}
 {{end}}
 
 {{define "fish" -}}
@@ -59,6 +65,9 @@ alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval (gardenctl kubectl-env {{.shell}})'
 alias {{.prefix}}p='eval (gardenctl provider-env {{.shell}})'
 alias {{.prefix}}cv='gardenctl config view -o yaml'
+{{if not .noKubeconfig -}}
+{{.prefix}}k
+{{end -}}
 {{end}}
 
 {{define "powershell" -}}
@@ -101,4 +110,7 @@ function Gardenctl-Config-View {
   gardenctl config view -o yaml
 }
 Set-Alias -Name {{.prefix}}cv -Value Gardenctl-Config-View -Option AllScope -Force
+{{if not .noKubeconfig -}}
+{{.prefix}}k
+{{end -}}
 {{end}}


### PR DESCRIPTION
**What this PR does / why we need it**:
At the end of the startup script the KUBECONFIG environment variable is set to `kubeconfig.yaml` symlink in the current session directory. This behavior can be disabled by using the `--no-kubeconfig` flag. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Initialize KUBECONFIG environment variable in startup script using `rc` command. You can disable this bahavior by using the `--no-kubeconfig` flag
```
