### PR TITLE
SSH to node that did not join the cluster

### DIFF
--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -803,9 +803,6 @@ func remoteShell(ctx context.Context, o *SSHOptions, bastion *operationsv1alpha1
 // waitForSignal informs the user about their SSHOptions and keeps the
 // bastion alive until gardenctl exits.
 func waitForSignal(ctx context.Context, o *SSHOptions, shootClient client.Client, bastion *operationsv1alpha1.Bastion, nodeHostname string, nodePrivateKeyFiles []string, signalChan <-chan struct{}) error {
-	bastionAddr := preferredBastionAddress(bastion)
-	connectCmd := sshCommandLine(o, bastionAddr, nodePrivateKeyFiles, nodeHostname)
-
 	if nodeHostname == "" {
 		nodeHostname = "IP_OR_HOSTNAME"
 
@@ -885,6 +882,9 @@ func waitForSignal(ctx context.Context, o *SSHOptions, shootClient client.Client
 
 		fmt.Fprintln(o.IOStreams.Out, "")
 	}
+
+	bastionAddr := preferredBastionAddress(bastion)
+	connectCmd := sshCommandLine(o, bastionAddr, nodePrivateKeyFiles, nodeHostname)
 
 	fmt.Fprintln(o.IOStreams.Out, "Connect to shoot nodes by using the bastion as a proxy/jump host, for example:")
 	fmt.Fprintln(o.IOStreams.Out, "")

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -72,6 +72,20 @@ func waitForBastionThenPatchStatus(ctx context.Context, gardenClient client.Clie
 	}
 }
 
+func waitForBastionThenSetBastionReady(ctx context.Context, gardenClient client.Client, bastionName string, namespace string, bastionHostname string, bastionIP string) {
+	waitForBastionThenPatchStatus(ctx, gardenClient, bastionName, namespace, func(status *operationsv1alpha1.BastionStatus) {
+		status.Ingress = &corev1.LoadBalancerIngress{
+			Hostname: bastionHostname,
+			IP:       bastionIP,
+		}
+		status.Conditions = []gardencorev1alpha1.Condition{{
+			Type:   "BastionReady",
+			Status: gardencorev1alpha1.ConditionTrue,
+			Reason: "Testing",
+		}}
+	})
+}
+
 var _ = Describe("SSH Command", func() {
 	const (
 		gardenName           = "mygarden"
@@ -279,17 +293,7 @@ var _ = Describe("SSH Command", func() {
 			cmd := ssh.NewCmdSSH(factory, options)
 
 			// simulate an external controller processing the bastion and proving a successful status
-			go waitForBastionThenPatchStatus(ctx, gardenClient, bastionName, *testProject.Spec.Namespace, func(status *operationsv1alpha1.BastionStatus) {
-				status.Ingress = &corev1.LoadBalancerIngress{
-					Hostname: bastionHostname,
-					IP:       bastionIP,
-				}
-				status.Conditions = []gardencorev1alpha1.Condition{{
-					Type:   "BastionReady",
-					Status: gardencorev1alpha1.ConditionTrue,
-					Reason: "Testing",
-				}}
-			})
+			go waitForBastionThenSetBastionReady(ctx, gardenClient, bastionName, *testProject.Spec.Namespace, bastionHostname, bastionIP)
 
 			// let the magic happen
 			Expect(cmd.RunE(cmd, nil)).To(Succeed())
@@ -318,17 +322,7 @@ var _ = Describe("SSH Command", func() {
 			cmd := ssh.NewCmdSSH(factory, options)
 
 			// simulate an external controller processing the bastion and proving a successful status
-			go waitForBastionThenPatchStatus(ctx, gardenClient, bastionName, *testProject.Spec.Namespace, func(status *operationsv1alpha1.BastionStatus) {
-				status.Ingress = &corev1.LoadBalancerIngress{
-					Hostname: bastionHostname,
-					IP:       bastionIP,
-				}
-				status.Conditions = []gardencorev1alpha1.Condition{{
-					Type:   "BastionReady",
-					Status: gardencorev1alpha1.ConditionTrue,
-					Reason: "Testing",
-				}}
-			})
+			go waitForBastionThenSetBastionReady(ctx, gardenClient, bastionName, *testProject.Spec.Namespace, bastionHostname, bastionIP)
 
 			// do not actually execute any commands
 			executedCommands := 0
@@ -382,17 +376,7 @@ var _ = Describe("SSH Command", func() {
 			cmd := ssh.NewCmdSSH(factory, options)
 
 			// simulate an external controller processing the bastion and proving a successful status
-			go waitForBastionThenPatchStatus(ctx, gardenClient, bastionName, *testProject.Spec.Namespace, func(status *operationsv1alpha1.BastionStatus) {
-				status.Ingress = &corev1.LoadBalancerIngress{
-					Hostname: bastionHostname,
-					IP:       bastionIP,
-				}
-				status.Conditions = []gardencorev1alpha1.Condition{{
-					Type:   "BastionReady",
-					Status: gardencorev1alpha1.ConditionTrue,
-					Reason: "Testing",
-				}}
-			})
+			go waitForBastionThenSetBastionReady(ctx, gardenClient, bastionName, *testProject.Spec.Namespace, bastionHostname, bastionIP)
 
 			// end the test after a couple of seconds (enough seconds for the keep-alive
 			// goroutine to do its thing)


### PR DESCRIPTION
**What this PR does / why we need it**:
gardenctl continues with the SSH operation in case the node was not found (e.g. node failed to joined the cluster)

**Which issue(s) this PR fixes**:
Fixes #146

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue where it was not possible to SSH to a node that has not yet joined the cluster
```
