### PR TITLE
Get seed client: fail on any other error than not found

### DIFF
--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -265,7 +265,12 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string) (clie
 	key := types.NamespacedName{Name: name}
 
 	secret, err := g.GetSecret(ctx, "garden", name+".login")
-	if apierrors.IsNotFound(err) { // fallback to deprecated .oidc secret
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil, err
+		}
+
+		// fallback to deprecated .oidc secret
 		var oidcErr error
 
 		secret, oidcErr = g.GetSecret(ctx, "garden", name+".oidc")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a nil pointer dereference when targeting a seed cluster. This happens e.g. in case you are not authorized to read the `<seed>.login` secret in the `garden` namespace.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixes a nil pointer dereference when targeting a seed cluster. This happens e.g. in case you are not authorized to read the `<seed>.login` secret in the `garden` namespace.
```
