### PR TITLE
Print target kubeconfig

### DIFF
--- a/docs/help/gardenctl_target_kubeconfig.md
+++ b/docs/help/gardenctl_target_kubeconfig.md
@@ -1,28 +1,15 @@
-## gardenctl target
+## gardenctl target kubeconfig
 
-Set scope for next operations, using subcommands or pattern
-
-```
-gardenctl target [flags]
-```
-
-### Examples
+Print the kubeconfig for the current target
 
 ```
-# target project "my-project" of garden "my-garden"
-gardenctl target --garden my-garden --project my-project
-
-# target shoot "my-shoot" of currently selected project
-gardenctl target shoot my-shoot
-
-# Target shoot control-plane using values that match a pattern defined for a specific garden
-gardenctl target value/that/matches/pattern --control-plane
+gardenctl target kubeconfig [flags]
 ```
 
 ### Options
 
 ```
-  -h, --help            help for target
+  -h, --help            help for kubeconfig
   -o, --output string   One of 'yaml' or 'json'.
 ```
 
@@ -52,13 +39,5 @@ gardenctl target value/that/matches/pattern --control-plane
 
 ### SEE ALSO
 
-* [gardenctl](gardenctl.md)	 - Gardenctl is a utility to interact with Gardener installations
-* [gardenctl target control-plane](gardenctl_target_control-plane.md)	 - Target the control plane of the shoot
-* [gardenctl target garden](gardenctl_target_garden.md)	 - Target a garden
-* [gardenctl target kubeconfig](gardenctl_target_kubeconfig.md)	 - Print the kubeconfig for the current target
-* [gardenctl target project](gardenctl_target_project.md)	 - Target a project
-* [gardenctl target seed](gardenctl_target_seed.md)	 - Target a seed
-* [gardenctl target shoot](gardenctl_target_shoot.md)	 - Target a shoot
-* [gardenctl target unset](gardenctl_target_unset.md)	 - Unset target
-* [gardenctl target view](gardenctl_target_view.md)	 - Print the current target
+* [gardenctl target](gardenctl_target.md)	 - Set scope for next operations, using subcommands or pattern
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gardener/gardenctl-v2
 go 1.17
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/fatih/color v1.13.0
 	github.com/gardener/gardener v1.40.0
@@ -30,7 +31,6 @@ require (
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/internal/fake/client.go
+++ b/internal/fake/client.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package fake
 
 import (

--- a/internal/fake/target_provider.go
+++ b/internal/fake/target_provider.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package fake
 
 import (

--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -61,7 +61,7 @@ type Client interface {
 	// ListShoots returns all Gardener shoot resources, filtered by a list option
 	ListShoots(ctx context.Context, opts ...client.ListOption) (*gardencorev1beta1.ShootList, error)
 	// GetShootClientConfig returns the client config for a shoot
-	GetShootClientConfig(ctx context.Context, clusterIdentity, namespace, name string) (clientcmd.ClientConfig, error)
+	GetShootClientConfig(ctx context.Context, namespace, name string) (clientcmd.ClientConfig, error)
 
 	// GetSecretBinding returns a Gardener secretbinding resource
 	GetSecretBinding(ctx context.Context, namespace, name string) (*gardencorev1beta1.SecretBinding, error)
@@ -83,12 +83,16 @@ type Client interface {
 
 type clientImpl struct {
 	c client.Client
+
+	// name is a unique identifier of this Garden client
+	name string
 }
 
 // NewGardenClient returns a new gardenclient
-func NewGardenClient(client client.Client) Client {
+func NewGardenClient(client client.Client, name string) Client {
 	return &clientImpl{
-		c: client,
+		c:    client,
+		name: name,
 	}
 }
 

--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -61,7 +61,7 @@ type Client interface {
 	// ListShoots returns all Gardener shoot resources, filtered by a list option
 	ListShoots(ctx context.Context, opts ...client.ListOption) (*gardencorev1beta1.ShootList, error)
 	// GetShootClientConfig returns the client config for a shoot
-	GetShootClientConfig(ctx context.Context, namespace, name string) (clientcmd.ClientConfig, error)
+	GetShootClientConfig(ctx context.Context, clusterIdentity, namespace, name string) (clientcmd.ClientConfig, error)
 
 	// GetSecretBinding returns a Gardener secretbinding resource
 	GetSecretBinding(ctx context.Context, namespace, name string) (*gardencorev1beta1.SecretBinding, error)
@@ -278,27 +278,6 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string) (clie
 	config, err := clientcmd.NewClientConfigFromBytes(value)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deserialize kubeconfig for seed %v: %w", key, err)
-	}
-
-	return config, nil
-}
-
-func (g *clientImpl) GetShootClientConfig(ctx context.Context, namespace, name string) (clientcmd.ClientConfig, error) {
-	key := types.NamespacedName{Namespace: namespace, Name: name}
-
-	cm, err := g.GetConfigMap(ctx, namespace, name+".kubeconfig")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get kubeconfig for shoot %v: %w", key, err)
-	}
-
-	value, ok := cm.Data["kubeconfig"]
-	if !ok {
-		return nil, fmt.Errorf("invalid kubeconfig configmap for shoot %v", key)
-	}
-
-	config, err := clientcmd.NewClientConfigFromBytes([]byte(value))
-	if err != nil {
-		return nil, fmt.Errorf("failed to deserialize kubeconfig for shoot %v: %w", key, err)
 	}
 
 	return config, nil

--- a/internal/gardenclient/client_test.go
+++ b/internal/gardenclient/client_test.go
@@ -169,13 +169,12 @@ var _ = Describe("Client", func() {
 				Expect(cluster.Server).To(Equal("https://api." + domain))
 				Expect(cluster.CertificateAuthorityData).To(Equal(ca.CertificatePEM))
 
-				Expect(cluster.Extensions["client.authentication.k8s.io/exec"]).To(Equal(&gardenclient.ExecPluginConfig{
-					GardenClusterIdentity: gardenName,
-					ShootRef: gardenclient.ShootRef{
-						Namespace: namespace,
-						Name:      shootName,
-					},
-				}))
+				extension := &gardenclient.ExecPluginConfig{}
+				extension.GardenClusterIdentity = gardenName
+				extension.ShootRef.Namespace = namespace
+				extension.ShootRef.Name = shootName
+
+				Expect(cluster.Extensions["client.authentication.k8s.io/exec"]).To(Equal(extension.ToRuntimeObject()))
 
 				Expect(rawConfig.Contexts).To(HaveLen(2))
 

--- a/internal/gardenclient/client_test.go
+++ b/internal/gardenclient/client_test.go
@@ -8,13 +8,18 @@ package gardenclient_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/utils/secrets"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
@@ -23,12 +28,12 @@ import (
 )
 
 var _ = Describe("Client", func() {
-	Describe("GetSeedClientConfig", func() {
-		var (
-			ctx          context.Context
-			gardenClient gardenclient.Client
-		)
+	var (
+		ctx          context.Context
+		gardenClient gardenclient.Client
+	)
 
+	Describe("GetSeedClientConfig", func() {
 		BeforeEach(func() {
 			ctx = context.Background()
 			oidcSecret := &corev1.Secret{
@@ -71,6 +76,166 @@ var _ = Describe("Client", func() {
 				_, err := gardenClient.GetSeedClientConfig(ctx, "seed-3")
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("GetShootClientConfig", func() {
+		const (
+			shootName       = "test-shoot1"
+			namespace       = "garden-prod1"
+			domain          = "foo.bar.baz"
+			clusterIdentity = "my-garden"
+
+			k8sVersion       = "1.20.0"
+			k8sVersionLegacy = "1.19.0" // legacy kubeconfig should be rendered
+		)
+		var (
+			testShoot1 *gardencorev1beta1.Shoot
+			caSecret   *corev1.Secret
+			ca         *secrets.Certificate
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			testShoot1 = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      shootName,
+					Namespace: namespace,
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						Version: k8sVersion,
+					},
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
+						{
+							Name: "shoot-address1",
+							URL:  "https://api." + domain,
+						},
+						{
+							Name: "shoot-address2",
+							URL:  "https://api2." + domain,
+						},
+					},
+				},
+			}
+
+			csc := &secrets.CertificateSecretConfig{
+				Name:       "ca-test",
+				CommonName: "ca-test",
+				CertType:   secrets.CACert,
+			}
+			var err error
+			ca, err = csc.GenerateCertificate()
+			Expect(err).NotTo(HaveOccurred())
+
+			caSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testShoot1.Name + ".ca-cluster",
+					Namespace: testShoot1.Namespace,
+				},
+				Data: map[string][]byte{
+					"ca.crt": ca.CertificatePEM,
+				},
+			}
+		})
+
+		Context("good case", func() {
+			JustBeforeEach(func() {
+				gardenClient = gardenclient.NewGardenClient(
+					fake.NewClientWithObjects(testShoot1, caSecret),
+				)
+			})
+
+			It("it should return the client config", func() {
+				gardenClient = gardenclient.NewGardenClient(
+					fake.NewClientWithObjects(testShoot1, caSecret),
+				)
+
+				clientConfig, err := gardenClient.GetShootClientConfig(ctx, clusterIdentity, namespace, shootName)
+				Expect(err).NotTo(HaveOccurred())
+
+				rawConfig, err := clientConfig.RawConfig()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rawConfig.Clusters).To(HaveLen(2))
+				currentCluster := rawConfig.Contexts[rawConfig.CurrentContext].Cluster
+				Expect(rawConfig.Clusters[currentCluster].Server).To(Equal("https://api." + domain))
+				Expect(rawConfig.Clusters[currentCluster].CertificateAuthorityData).To(Equal(ca.CertificatePEM))
+				Expect(rawConfig.Clusters[currentCluster].Extensions).ToNot(BeEmpty())
+
+				execConfig := rawConfig.Clusters[currentCluster].Extensions["client.authentication.k8s.io/exec"].(*runtime.Unknown)
+				Expect(execConfig.Raw).ToNot(BeNil())
+
+				var extension gardenclient.ExecPluginConfig
+				Expect(json.Unmarshal(execConfig.Raw, &extension)).To(Succeed())
+				Expect(extension).To(Equal(gardenclient.ExecPluginConfig{
+					ShootRef: gardenclient.ShootRef{
+						Namespace: namespace,
+						Name:      shootName,
+					},
+					GardenClusterIdentity: clusterIdentity,
+				}))
+
+				Expect(rawConfig.Contexts).To(HaveLen(2))
+
+				Expect(rawConfig.AuthInfos).To(HaveLen(1))
+				currentAuthInfo := rawConfig.Contexts[rawConfig.CurrentContext].AuthInfo
+				Expect(rawConfig.AuthInfos[currentAuthInfo].Exec.Command).To(Equal("kubectl"))
+				Expect(rawConfig.AuthInfos[currentAuthInfo].Exec.Args).To(Equal([]string{
+					"gardenlogin",
+					"get-client-certificate",
+				}))
+			})
+
+			Context("legacy kubeconfig", func() {
+				BeforeEach(func() {
+					By("having shoot kubernetes version < v1.20.0")
+					testShoot1.Spec.Kubernetes.Version = k8sVersionLegacy
+				})
+
+				It("should create legacy kubeconfig configMap", func() {
+					clientConfig, err := gardenClient.GetShootClientConfig(ctx, clusterIdentity, namespace, shootName)
+					Expect(err).NotTo(HaveOccurred())
+
+					rawConfig, err := clientConfig.RawConfig()
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(rawConfig.Clusters).To(HaveLen(2))
+					currentCluster := rawConfig.Contexts[rawConfig.CurrentContext].Cluster
+					Expect(rawConfig.Clusters[currentCluster].Server).To(Equal("https://api." + domain))
+					Expect(rawConfig.Clusters[currentCluster].CertificateAuthorityData).To(Equal(ca.CertificatePEM))
+					Expect(rawConfig.Clusters[currentCluster].Extensions).To(BeEmpty())
+
+					Expect(rawConfig.Contexts).To(HaveLen(2))
+
+					Expect(rawConfig.AuthInfos).To(HaveLen(1))
+					currentAuthInfo := rawConfig.Contexts[rawConfig.CurrentContext].AuthInfo
+					Expect(rawConfig.AuthInfos[currentAuthInfo].Exec.Command).To(Equal("kubectl"))
+					Expect(rawConfig.AuthInfos[currentAuthInfo].Exec.Args).To(Equal([]string{
+						"gardenlogin",
+						"get-client-certificate",
+						fmt.Sprintf("--name=%s", shootName),
+						fmt.Sprintf("--namespace=%s", namespace),
+						fmt.Sprintf("--garden-cluster-identity=%s", clusterIdentity),
+					}))
+				})
+			})
+		})
+
+		Context("when the ca-cluster secret does not exist", func() {
+			BeforeEach(func() {
+				gardenClient = gardenclient.NewGardenClient(
+					fake.NewClientWithObjects(testShoot1),
+				)
+			})
+
+			It("it should fail with not found error", func() {
+				_, err := gardenClient.GetShootClientConfig(ctx, clusterIdentity, namespace, shootName)
+				Expect(err).To(HaveOccurred())
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				Expect(err.Error()).To(ContainSubstring(shootName + ".ca-cluster"))
 			})
 		})
 	})

--- a/internal/gardenclient/export_test.go
+++ b/internal/gardenclient/export_test.go
@@ -1,0 +1,17 @@
+/*
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package gardenclient
+
+import "k8s.io/apimachinery/pkg/runtime"
+
+type ExecPluginConfig struct {
+	execPluginConfig
+}
+
+func (e *ExecPluginConfig) ToRuntimeObject() runtime.Object {
+	return &e.execPluginConfig
+}

--- a/internal/gardenclient/gardenclient_suite_test.go
+++ b/internal/gardenclient/gardenclient_suite_test.go
@@ -9,9 +9,16 @@ package gardenclient_test
 import (
 	"testing"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 )
+
+func init() {
+	utilruntime.Must(gardencorev1beta1.AddToScheme(scheme.Scheme))
+}
 
 func TestCloudEnvCommand(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/internal/gardenclient/mocks/mock_client.go
+++ b/internal/gardenclient/mocks/mock_client.go
@@ -209,18 +209,18 @@ func (mr *MockClientMockRecorder) GetShoot(arg0, arg1, arg2 interface{}) *gomock
 }
 
 // GetShootClientConfig mocks base method.
-func (m *MockClient) GetShootClientConfig(arg0 context.Context, arg1, arg2 string) (clientcmd.ClientConfig, error) {
+func (m *MockClient) GetShootClientConfig(arg0 context.Context, arg1, arg2, arg3 string) (clientcmd.ClientConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetShootClientConfig", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetShootClientConfig", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(clientcmd.ClientConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetShootClientConfig indicates an expected call of GetShootClientConfig.
-func (mr *MockClientMockRecorder) GetShootClientConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetShootClientConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShootClientConfig", reflect.TypeOf((*MockClient)(nil).GetShootClientConfig), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShootClientConfig", reflect.TypeOf((*MockClient)(nil).GetShootClientConfig), arg0, arg1, arg2, arg3)
 }
 
 // ListProjects mocks base method.

--- a/internal/gardenclient/mocks/mock_client.go
+++ b/internal/gardenclient/mocks/mock_client.go
@@ -209,18 +209,18 @@ func (mr *MockClientMockRecorder) GetShoot(arg0, arg1, arg2 interface{}) *gomock
 }
 
 // GetShootClientConfig mocks base method.
-func (m *MockClient) GetShootClientConfig(arg0 context.Context, arg1, arg2, arg3 string) (clientcmd.ClientConfig, error) {
+func (m *MockClient) GetShootClientConfig(arg0 context.Context, arg1, arg2 string) (clientcmd.ClientConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetShootClientConfig", arg0, arg1, arg2, arg3)
+	ret := m.ctrl.Call(m, "GetShootClientConfig", arg0, arg1, arg2)
 	ret0, _ := ret[0].(clientcmd.ClientConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetShootClientConfig indicates an expected call of GetShootClientConfig.
-func (mr *MockClientMockRecorder) GetShootClientConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetShootClientConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShootClientConfig", reflect.TypeOf((*MockClient)(nil).GetShootClientConfig), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShootClientConfig", reflect.TypeOf((*MockClient)(nil).GetShootClientConfig), arg0, arg1, arg2)
 }
 
 // ListProjects mocks base method.

--- a/internal/gardenclient/shoot_client.go
+++ b/internal/gardenclient/shoot_client.go
@@ -198,9 +198,9 @@ func (k *shootKubeconfigRequest) generate(legacy bool) ([]byte, error) {
 	return runtime.Encode(clientcmdlatest.Codec, config)
 }
 
-func (g *clientImpl) GetShootClientConfig(ctx context.Context, clusterIdentity, namespace, name string) (clientcmd.ClientConfig, error) {
-	if len(clusterIdentity) == 0 {
-		return nil, errors.New("cluster identity must not be empty")
+func (g *clientImpl) GetShootClientConfig(ctx context.Context, namespace, name string) (clientcmd.ClientConfig, error) {
+	if len(g.name) == 0 {
+		return nil, errors.New("garden name must not be empty")
 	}
 
 	// fetch Shoot
@@ -231,7 +231,7 @@ func (g *clientImpl) GetShootClientConfig(ctx context.Context, clusterIdentity, 
 	kubeconfigRequest := shootKubeconfigRequest{
 		namespace:             shoot.Namespace,
 		shootName:             shoot.Name,
-		gardenClusterIdentity: clusterIdentity,
+		gardenClusterIdentity: g.name,
 	}
 
 	for _, address := range shoot.Status.AdvertisedAddresses {

--- a/internal/gardenclient/shoot_client.go
+++ b/internal/gardenclient/shoot_client.go
@@ -1,0 +1,273 @@
+/*
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package gardenclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/Masterminds/semver"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
+	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+)
+
+const (
+	// ShootProjectSecretSuffixCACluster is a constant for a shoot project secret with suffix 'ca-cluster'.
+	ShootProjectSecretSuffixCACluster = "ca-cluster"
+	// DataKeyCertificateCA is the key in a secret data holding the CA certificate.
+	DataKeyCertificateCA = "ca.crt"
+)
+
+// shootKubeconfigRequest is a struct which holds information about a Kubeconfig to be generated.
+type shootKubeconfigRequest struct {
+	// cluster holds all the cluster on which the kube-apiserver can be reached
+	clusters []cluster
+	// namespace is the namespace where the shoot resides
+	namespace string
+	// shootName is the name of the shoot
+	shootName string
+	// gardenClusterIdentity is the cluster identifier of the garden cluster.
+	gardenClusterIdentity string
+}
+
+// cluster holds the data to describe and connect to a kubernetes cluster
+type cluster struct {
+	// name is the name of the shoot advertised address, usually "external", "internal" or "unmanaged"
+	name string
+	// apiServerHost is the host of the kube-apiserver
+	apiServerHost string
+
+	// caCert holds the ca certificate for the cluster
+	//+optional
+	caCert []byte
+}
+
+// ExecPluginConfig contains a reference to the garden and shoot cluster
+type ExecPluginConfig struct {
+	// ShootRef references the shoot cluster
+	ShootRef ShootRef `json:"shootRef"`
+	// GardenClusterIdentity is the cluster identifier of the garden cluster.
+	// See cluster-identity ConfigMap in kube-system namespace of the garden cluster
+	GardenClusterIdentity string `json:"gardenClusterIdentity"`
+}
+
+// ShootRef references the shoot cluster by namespace and name
+type ShootRef struct {
+	// Namespace is the namespace of the shoot cluster
+	Namespace string `json:"namespace"`
+	// Name is the name of the shoot cluster
+	Name string `json:"name"`
+}
+
+// validate validates the kubeconfig request by ensuring that all required fields are set
+func (k *shootKubeconfigRequest) validate() error {
+	if len(k.clusters) == 0 {
+		return errors.New("missing clusters")
+	}
+
+	for n, cluster := range k.clusters {
+		if cluster.name == "" {
+			return fmt.Errorf("no name defined for cluster[%d]", n)
+		}
+
+		if cluster.apiServerHost == "" {
+			return fmt.Errorf("no api server host defined for cluster[%d]", n)
+		}
+	}
+
+	if k.namespace == "" {
+		return errors.New("no namespace defined for kubeconfig request")
+	}
+
+	if k.shootName == "" {
+		return errors.New("no shoot name defined for kubeconfig request")
+	}
+
+	if k.gardenClusterIdentity == "" {
+		return errors.New("no garden cluster identity defined for kubeconfig request")
+	}
+
+	return nil
+}
+
+// generate generates a Kubernetes kubeconfig for communicating with the kube-apiserver
+// by exec'ing the gardenlogin plugin, which fetches a client certificate.
+// If legacy is false, the shoot reference and garden cluster identity is passed via the cluster extensions,
+// which is supported starting with kubectl version v1.20.0.
+// If legacy is true, the shoot reference and garden cluster identity are passed as command line flags to the plugin
+func (k *shootKubeconfigRequest) generate(legacy bool) ([]byte, error) {
+	authName := fmt.Sprintf("%s--%s", k.namespace, k.shootName) // TODO instead of namespace, use project? But this would require an additional call
+	name := fmt.Sprintf("%s-%s", authName, k.clusters[0].name)
+
+	var legacyArgs []string
+	if legacy {
+		legacyArgs = []string{
+			fmt.Sprintf("--name=%s", k.shootName),
+			fmt.Sprintf("--namespace=%s", k.namespace),
+			fmt.Sprintf("--garden-cluster-identity=%s", k.gardenClusterIdentity),
+		}
+	}
+
+	var authInfos []clientcmdv1.NamedAuthInfo
+	authInfos = append(authInfos, clientcmdv1.NamedAuthInfo{
+		Name: authName,
+		AuthInfo: clientcmdv1.AuthInfo{
+			Exec: &clientcmdv1.ExecConfig{
+				Command: "kubectl",
+				Args: append([]string{
+					"gardenlogin",
+					"get-client-certificate",
+				},
+					legacyArgs...,
+				),
+				Env:                nil,
+				APIVersion:         clientauthenticationv1beta1.SchemeGroupVersion.String(),
+				InstallHint:        "",
+				ProvideClusterInfo: true,
+			},
+		},
+	})
+
+	config := &clientcmdv1.Config{
+		CurrentContext: name,
+		Clusters:       []clientcmdv1.NamedCluster{},
+		Contexts:       []clientcmdv1.NamedContext{},
+		AuthInfos:      authInfos,
+	}
+
+	extension := ExecPluginConfig{
+		ShootRef: ShootRef{
+			Namespace: k.namespace,
+			Name:      k.shootName,
+		},
+		GardenClusterIdentity: k.gardenClusterIdentity,
+	}
+
+	var clusterExtensions []clientcmdv1.NamedExtension
+
+	if !legacy {
+		raw, err := json.Marshal(extension)
+		if err != nil {
+			return nil, fmt.Errorf("could not json marshal cluster extension: %w", err)
+		}
+
+		clusterExtensions = []clientcmdv1.NamedExtension{
+			{
+				Name: "client.authentication.k8s.io/exec",
+				Extension: runtime.RawExtension{
+					Raw: raw,
+				},
+			},
+		}
+	}
+
+	for _, cluster := range k.clusters {
+		name := fmt.Sprintf("%s-%s", authName, cluster.name)
+
+		config.Clusters = append(config.Clusters, clientcmdv1.NamedCluster{
+			Name: name,
+			Cluster: clientcmdv1.Cluster{
+				CertificateAuthorityData: cluster.caCert,
+				Server:                   fmt.Sprintf("https://%s", cluster.apiServerHost),
+				Extensions:               clusterExtensions,
+			},
+		})
+		config.Contexts = append(config.Contexts, clientcmdv1.NamedContext{
+			Name: name,
+			Context: clientcmdv1.Context{
+				Cluster:   name,
+				AuthInfo:  authName,
+				Namespace: "default", // TODO leave hardcoded? Or omit?
+			},
+		})
+	}
+
+	return runtime.Encode(clientcmdlatest.Codec, config)
+}
+
+func (g *clientImpl) GetShootClientConfig(ctx context.Context, clusterIdentity, namespace, name string) (clientcmd.ClientConfig, error) {
+	if len(clusterIdentity) == 0 {
+		return nil, errors.New("cluster identity must not be empty")
+	}
+
+	// fetch Shoot
+	shoot := &gardencorev1beta1.Shoot{}
+	key := types.NamespacedName{Namespace: namespace, Name: name}
+
+	if err := g.c.Get(ctx, key, shoot); err != nil {
+		return nil, err
+	}
+
+	if len(shoot.Status.AdvertisedAddresses) == 0 {
+		return nil, errors.New("no advertised addresses listed in the Shoot status for the Shoot Kube API server")
+	}
+
+	// fetch cluster ca
+	caClusterSecret := corev1.Secret{}
+	caClusterSecretName := fmt.Sprintf("%s.%s", name, ShootProjectSecretSuffixCACluster)
+
+	if err := g.c.Get(ctx, types.NamespacedName{Namespace: namespace, Name: caClusterSecretName}, &caClusterSecret); err != nil {
+		return nil, err
+	}
+
+	caCert, ok := caClusterSecret.Data[DataKeyCertificateCA]
+	if !ok || len(caCert) == 0 {
+		return nil, fmt.Errorf("%s of secret %s is empty", DataKeyCertificateCA, caClusterSecretName)
+	}
+
+	kubeconfigRequest := shootKubeconfigRequest{
+		namespace:             shoot.Namespace,
+		shootName:             shoot.Name,
+		gardenClusterIdentity: clusterIdentity,
+	}
+
+	for _, address := range shoot.Status.AdvertisedAddresses {
+		u, err := url.Parse(address.URL)
+		if err != nil {
+			return nil, fmt.Errorf("could not parse shoot server url: %w", err)
+		}
+
+		kubeconfigRequest.clusters = append(kubeconfigRequest.clusters, cluster{
+			name:          address.Name,
+			apiServerHost: u.Host,
+			caCert:        caCert,
+		})
+	}
+
+	if err := kubeconfigRequest.validate(); err != nil {
+		return nil, fmt.Errorf("validation failed for kubeconfig request: %w", err)
+	}
+
+	// parse kubernetes version to determine if a legacy kubeconfig should be created.
+	constraint, err := semver.NewConstraint("< v1.20.0")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse constraint: %w", err)
+	}
+
+	version, err := semver.NewVersion(shoot.Spec.Kubernetes.Version)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse kubernetes version %s of shoot cluster: %w", shoot.Spec.Kubernetes.Version, err)
+	}
+
+	legacy := constraint.Check(version)
+
+	kubeconfig, err := kubeconfigRequest.generate(legacy)
+	if err != nil {
+		return nil, fmt.Errorf("generation failed for kubeconfig request: %w", err)
+	}
+
+	return clientcmd.NewClientConfigFromBytes(kubeconfig)
+}

--- a/internal/gardenclient/shoot_client.go
+++ b/internal/gardenclient/shoot_client.go
@@ -156,6 +156,11 @@ func (k *shootKubeconfigRequest) generate(legacy bool) (*clientcmdapi.Config, er
 		APIVersion:         clientauthenticationv1beta1.SchemeGroupVersion.String(),
 		InstallHint:        "",
 		ProvideClusterInfo: true,
+
+		// gardenlogin kubectl auth plugin does not require stdin itself,
+		// but relies on the provided garden kubeconfig which could include auth plugins that require stdin.
+		// E.g. kubelogin with --grant-type=authcode-keyboard flag, which will then prompt for the code
+		InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
 	}
 	authName := fmt.Sprintf("%s--%s", k.namespace, k.shootName) // TODO instead of namespace, use project? But this would require an additional call
 	config.AuthInfos[authName] = authInfo

--- a/internal/gardenclient/shoot_client.go
+++ b/internal/gardenclient/shoot_client.go
@@ -54,30 +54,30 @@ type cluster struct {
 	caCert []byte
 }
 
-// ExecPluginConfig contains a reference to the garden and shoot cluster
-type ExecPluginConfig struct {
+// execPluginConfig contains a reference to the garden and shoot cluster
+type execPluginConfig struct {
 	// ShootRef references the shoot cluster
-	ShootRef ShootRef `json:"shootRef"`
+	ShootRef shootRef `json:"shootRef"`
 	// GardenClusterIdentity is the cluster identifier of the garden cluster.
 	// See cluster-identity ConfigMap in kube-system namespace of the garden cluster
 	GardenClusterIdentity string `json:"gardenClusterIdentity"`
 }
 
-// ShootRef references the shoot cluster by namespace and name
-type ShootRef struct {
+// shootRef references the shoot cluster by namespace and name
+type shootRef struct {
 	// Namespace is the namespace of the shoot cluster
 	Namespace string `json:"namespace"`
 	// Name is the name of the shoot cluster
 	Name string `json:"name"`
 }
 
-func (e *ExecPluginConfig) GetObjectKind() schema.ObjectKind {
+func (e *execPluginConfig) GetObjectKind() schema.ObjectKind {
 	return schema.EmptyObjectKind
 }
 
-func (e *ExecPluginConfig) DeepCopyObject() runtime.Object {
-	return &ExecPluginConfig{
-		ShootRef: ShootRef{
+func (e *execPluginConfig) DeepCopyObject() runtime.Object {
+	return &execPluginConfig{
+		ShootRef: shootRef{
 			Namespace: e.ShootRef.Namespace,
 			Name:      e.ShootRef.Name,
 		},
@@ -122,7 +122,7 @@ func (k *shootKubeconfigRequest) validate() error {
 // which is supported starting with kubectl version v1.20.0.
 // If legacy is true, the shoot reference and garden cluster identity are passed as command line flags to the plugin
 func (k *shootKubeconfigRequest) generate(legacy bool) (*clientcmdapi.Config, error) {
-	var extension *ExecPluginConfig
+	var extension *execPluginConfig
 
 	args := []string{
 		"gardenlogin",
@@ -137,8 +137,8 @@ func (k *shootKubeconfigRequest) generate(legacy bool) (*clientcmdapi.Config, er
 			fmt.Sprintf("--garden-cluster-identity=%s", k.gardenClusterIdentity),
 		)
 	} else {
-		extension = &ExecPluginConfig{
-			ShootRef: ShootRef{
+		extension = &execPluginConfig{
+			ShootRef: shootRef{
 				Namespace: k.namespace,
 				Name:      k.shootName,
 			},

--- a/internal/util/io_streams.go
+++ b/internal/util/io_streams.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package util
 
 import (

--- a/internal/util/target_test.go
+++ b/internal/util/target_test.go
@@ -8,12 +8,10 @@ package util_test
 
 import (
 	"context"
-	"fmt"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 
@@ -64,21 +62,10 @@ var _ = Describe("Target Utilities", func() {
 			},
 		}
 
-		testShootKubeconfig := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s.kubeconfig", testShoot.Name),
-				Namespace: *testReadyProject.Spec.Namespace,
-			},
-			Data: map[string][]byte{
-				"data": []byte("not-used"),
-			},
-		}
-
 		gardenClient = gardenclient.NewGardenClient(fake.NewClientWithObjects(
 			testReadyProject,
 			testUnreadyProject,
 			testSeed,
-			testShootKubeconfig,
 			testShoot,
 		))
 	})

--- a/internal/util/target_test.go
+++ b/internal/util/target_test.go
@@ -62,12 +62,15 @@ var _ = Describe("Target Utilities", func() {
 			},
 		}
 
-		gardenClient = gardenclient.NewGardenClient(fake.NewClientWithObjects(
-			testReadyProject,
-			testUnreadyProject,
-			testSeed,
-			testShoot,
-		))
+		gardenClient = gardenclient.NewGardenClient(
+			fake.NewClientWithObjects(
+				testReadyProject,
+				testUnreadyProject,
+				testSeed,
+				testShoot,
+			),
+			"my-garden",
+		)
 	})
 
 	Describe("SeedForTarget", func() {

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package main
 
 import (

--- a/pkg/cmd/ssh/ssh_suite_test.go
+++ b/pkg/cmd/ssh/ssh_suite_test.go
@@ -15,8 +15,6 @@ import (
 	. "github.com/onsi/gomega"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
 func init() {
@@ -27,13 +25,4 @@ func init() {
 func TestCommand(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "SSH Command Test Suite")
-}
-
-func createTestKubeconfig(name string) []byte {
-	config := clientcmdapi.NewConfig()
-	config.CurrentContext = name
-	data, err := clientcmd.Write(*config)
-	Expect(err).NotTo(HaveOccurred())
-
-	return data
 }

--- a/pkg/cmd/target/kubeconfig.go
+++ b/pkg/cmd/target/kubeconfig.go
@@ -1,0 +1,101 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package target
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/target"
+)
+
+// NewCmdKubeconfig returns a new target kubeconfig command.
+func NewCmdKubeconfig(f util.Factory, o *KubeconfigOptions) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kubeconfig",
+		Short: "Print the kubeconfig for the current target",
+		RunE:  base.WrapRunE(o, f),
+	}
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// KubeconfigOptions is a struct to support kubeconfig command
+type KubeconfigOptions struct {
+	base.Options
+
+	// CurrentTarget is the current target
+	CurrentTarget target.Target
+}
+
+// NewKubeconfigOptions returns initialized KubeconfigOptions
+func NewKubeconfigOptions(ioStreams util.IOStreams) *KubeconfigOptions {
+	return &KubeconfigOptions{
+		Options: base.Options{
+			IOStreams: ioStreams,
+		},
+	}
+}
+
+// Complete adapts from the command line args to the data required.
+func (o *KubeconfigOptions) Complete(f util.Factory, _ *cobra.Command, _ []string) error {
+	manager, err := f.Manager()
+	if err != nil {
+		return err
+	}
+
+	o.CurrentTarget, err = manager.CurrentTarget()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Validate validates the provided command options.
+func (o *KubeconfigOptions) Validate() error {
+	if o.CurrentTarget.GardenName() == "" {
+		return target.ErrNoGardenTargeted
+	}
+
+	return nil
+}
+
+func (o *KubeconfigOptions) Run(f util.Factory) error {
+	ctx := f.Context()
+
+	manager, err := f.Manager()
+	if err != nil {
+		return err
+	}
+
+	config, err := manager.ClientConfig(ctx, o.CurrentTarget)
+	if err != nil {
+		return err
+	}
+
+	b, err := writeRawConfig(config)
+	if err != nil {
+		return err
+	}
+
+	_, err = o.IOStreams.Out.Write(b)
+
+	return err
+}
+
+func writeRawConfig(config clientcmd.ClientConfig) ([]byte, error) {
+	rawConfig, err := config.RawConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return clientcmd.Write(rawConfig)
+}

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -48,6 +48,7 @@ gardenctl target value/that/matches/pattern --control-plane`,
 
 	cmd.AddCommand(NewCmdUnset(f, NewUnsetOptions(ioStreams)))
 	cmd.AddCommand(NewCmdView(f, NewViewOptions(ioStreams)))
+	cmd.AddCommand(NewCmdKubeconfig(f, NewKubeconfigOptions(ioStreams)))
 
 	o.AddFlags(cmd.Flags())
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package config
 
 import (

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,7 +30,7 @@ type Config struct {
 
 // Garden represents one garden cluster
 type Garden struct {
-	// Identity is a unique identifier of this Garden that can be used to target this Garden
+	// Name is a unique identifier of this Garden that can be used to target this Garden
 	Name string `yaml:"identity" json:"identity"`
 	// Kubeconfig holds the path for the kubeconfig of the garden cluster
 	Kubeconfig string `yaml:"kubeconfig" json:"kubeconfig"`

--- a/pkg/target/client_provider.go
+++ b/pkg/target/client_provider.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package target
 
 import (

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package target
 
 import (

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -465,7 +465,7 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 				namespace = shoot.Namespace
 			}
 
-			return client.GetShootClientConfig(ctx, namespace, t.ShootName())
+			return client.GetShootClientConfig(ctx, t.GardenName(), namespace, t.ShootName())
 		})
 	}
 

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -112,7 +112,7 @@ func newGardenClient(name string, config *config.Config, provider ClientProvider
 		return nil, err
 	}
 
-	return gardenclient.NewGardenClient(client), nil
+	return gardenclient.NewGardenClient(client, name), nil
 }
 
 // NewManager returns a new manager
@@ -465,7 +465,7 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 				namespace = shoot.Namespace
 			}
 
-			return client.GetShootClientConfig(ctx, t.GardenName(), namespace, t.ShootName())
+			return client.GetShootClientConfig(ctx, namespace, t.ShootName())
 		})
 	}
 

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package target
 
 import (

--- a/pkg/target/target_builder.go
+++ b/pkg/target/target_builder.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package target
 
 import (

--- a/pkg/target/target_flags.go
+++ b/pkg/target/target_flags.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package target
 
 import (

--- a/pkg/target/target_provider.go
+++ b/pkg/target/target_provider.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package target
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the command `target kubeconfig` to print the kubeconfig for the current target.

This is especially useful to retrieve the gardenlogin kubeconfig for `Shoot` clusters, as these kubeconfigs will not be written anymore to the garden cluster as ConfigMaps, as the `gardenlogin-controller-manager` will be deprecated (ref #149)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
You can now print the kubeconfig for the current target using `gardenctl target kubeconfig` command
```
