### PR TITLE
Print target kubeconfig

### DIFF
--- a/docs/help/gardenctl.md
+++ b/docs/help/gardenctl.md
@@ -57,6 +57,7 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 ### SEE ALSO
 
 * [gardenctl config](gardenctl_config.md)	 - Modify gardenctl configuration file using subcommands
+* [gardenctl kubeconfig](gardenctl_kubeconfig.md)	 - Print the kubeconfig for the current target
 * [gardenctl kubectl-env](gardenctl_kubectl-env.md)	 - Generate a script that points KUBECONFIG to the targeted cluster for the specified shell
 * [gardenctl provider-env](gardenctl_provider-env.md)	 - Generate the cloud provider CLI configuration script for the specified shell
 * [gardenctl rc](gardenctl_rc.md)	 - Generate a gardenctl startup script for the specified shell

--- a/docs/help/gardenctl_kubeconfig.md
+++ b/docs/help/gardenctl_kubeconfig.md
@@ -1,0 +1,59 @@
+## gardenctl kubeconfig
+
+Print the kubeconfig for the current target
+
+```
+gardenctl kubeconfig [flags]
+```
+
+### Examples
+
+```
+# Print the kubeconfig for the current target 
+gardenctl kubeconfig
+
+# Print the kubeconfig for the current target in json format
+gardenctl kubeconfig --output json
+
+# Print the Shoot cluster kubeconfig for my-shoot
+gardenctl kubeconfig --garden my-garden --project my-project --shoot my-shoot
+
+# Print the Garden cluster kubeconfig of my-garden. The namespace of the project my-project is set as default
+gardenctl kubeconfig --garden my-garden --project my-project
+```
+
+### Options
+
+```
+  -h, --help            help for kubeconfig
+  -o, --output string   One of 'yaml' or 'json'.
+```
+
+### Options inherited from parent commands
+
+```
+      --add-dir-header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files
+      --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+      --control-plane                    target control plane of shoot, use together with shoot argument
+      --garden string                    target the given garden cluster
+      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log-dir string                   If non-empty, write log files in this directory
+      --log-file string                  If non-empty, use this log file
+      --log-file-max-size uint           Defines the maximum size a log file can grow to. Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files (default true)
+      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level)
+      --project string                   target the given project
+      --seed string                      target the given seed cluster
+      --shoot string                     target the given shoot cluster
+      --skip-headers                     If true, avoid header prefixes in the log messages
+      --skip-log-headers                 If true, avoid headers when opening log files
+      --stderrthreshold severity         logs at or above this threshold go to stderr (default 2)
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+
+* [gardenctl](gardenctl.md)	 - Gardenctl is a utility to interact with Gardener installations
+

--- a/docs/help/gardenctl_kubeconfig.md
+++ b/docs/help/gardenctl_kubeconfig.md
@@ -25,8 +25,15 @@ gardenctl kubeconfig --garden my-garden --project my-project
 ### Options
 
 ```
-  -h, --help            help for kubeconfig
-  -o, --output string   One of 'yaml' or 'json'.
+      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+      --context string                The name of the kubeconfig context to use
+      --flatten                       Flatten the resulting kubeconfig file into self-contained output (useful for creating portable kubeconfig files)
+  -h, --help                          help for kubeconfig
+      --minify                        Remove all information not used by current-context from the output
+  -o, --output string                 Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file. (default "yaml")
+      --raw                           Display raw byte data
+      --show-managed-fields           If true, keep the managedFields when printing objects in JSON or YAML format.
+      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
@@ -44,25 +46,34 @@ require (
 	github.com/gardener/external-dns-management v0.7.18 // indirect
 	github.com/gardener/hvpa-controller v0.3.1 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
+	github.com/go-errors/errors v1.0.1 // indirect
 	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/go-logr/zapr v0.4.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/btree v1.0.1 // indirect
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kubernetes-csi/external-snapshotter/v2 v2.1.4 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
@@ -72,9 +83,12 @@ require (
 	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
@@ -85,7 +99,10 @@ require (
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca // indirect
+	go.starlark.net v0.0.0-20200306205701-8dd3e2ee1dd5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	go.uber.org/zap v1.19.0 // indirect
@@ -113,6 +130,8 @@ require (
 	k8s.io/kube-aggregator v0.22.2 // indirect
 	k8s.io/kube-openapi v0.0.0-20210421082810-95288971da7e // indirect
 	k8s.io/metrics v0.22.2 // indirect
+	sigs.k8s.io/kustomize/api v0.8.11 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.11.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.1.2 // indirect
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/internal/fake/client.go
+++ b/internal/fake/client.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package fake
 
 import (

--- a/internal/fake/target_provider.go
+++ b/internal/fake/target_provider.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package fake
 
 import (

--- a/internal/util/io_streams.go
+++ b/internal/util/io_streams.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package util
 
 import (

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/gardenctl-v2/internal/util"
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
 	cmdenv "github.com/gardener/gardenctl-v2/pkg/cmd/env"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/kubeconfig"
 	cmdssh "github.com/gardener/gardenctl-v2/pkg/cmd/ssh"
 	cmdtarget "github.com/gardener/gardenctl-v2/pkg/cmd/target"
 	cmdversion "github.com/gardener/gardenctl-v2/pkg/cmd/version"
@@ -127,6 +128,7 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 	cmd.AddCommand(cmdenv.NewCmdProviderEnv(f, ioStreams))
 	cmd.AddCommand(cmdenv.NewCmdKubectlEnv(f, ioStreams))
 	cmd.AddCommand(cmdenv.NewCmdRC(f, ioStreams))
+	cmd.AddCommand(kubeconfig.NewCmdKubeconfig(f, ioStreams))
 
 	return cmd
 }

--- a/pkg/cmd/kubeconfig/export_test.go
+++ b/pkg/cmd/kubeconfig/export_test.go
@@ -1,0 +1,29 @@
+/*
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kubeconfig
+
+import (
+	"github.com/gardener/gardenctl-v2/internal/util"
+)
+
+type TestOptions struct {
+	options
+	out *util.SafeBytesBuffer
+}
+
+func NewOptions() *TestOptions {
+	streams, _, out, _ := util.NewTestIOStreams()
+
+	return &TestOptions{
+		options: *newOptions(streams),
+		out:     out,
+	}
+}
+
+func (o *TestOptions) String() string {
+	return o.out.String()
+}

--- a/pkg/cmd/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kubeconfig/kubeconfig.go
@@ -1,0 +1,110 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kubeconfig
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/target"
+)
+
+// NewCmdKubeconfig returns a new target kubeconfig command.
+func NewCmdKubeconfig(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	o := &kubeconfigOptions{
+		Options: base.Options{
+			IOStreams: ioStreams,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "kubeconfig",
+		Short: "Print the kubeconfig for the current target",
+		Example: `# Print the kubeconfig for the current target 
+gardenctl kubeconfig
+
+# Print the kubeconfig for the current target in json format
+gardenctl kubeconfig --output json
+
+# Print the Shoot cluster kubeconfig for my-shoot
+gardenctl kubeconfig --garden my-garden --project my-project --shoot my-shoot
+
+# Print the Garden cluster kubeconfig of my-garden. The namespace of the project my-project is set as default
+gardenctl kubeconfig --garden my-garden --project my-project`,
+		RunE: base.WrapRunE(o, f),
+	}
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// kubeconfigOptions is a struct to support kubeconfig command
+type kubeconfigOptions struct {
+	base.Options
+
+	// CurrentTarget is the current target
+	CurrentTarget target.Target
+}
+
+// Complete adapts from the command line args to the data required.
+func (o *kubeconfigOptions) Complete(f util.Factory, _ *cobra.Command, _ []string) error {
+	manager, err := f.Manager()
+	if err != nil {
+		return err
+	}
+
+	o.CurrentTarget, err = manager.CurrentTarget()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Validate validates the provided command options.
+func (o *kubeconfigOptions) Validate() error {
+	if o.CurrentTarget.GardenName() == "" {
+		return target.ErrNoGardenTargeted
+	}
+
+	return nil
+}
+
+func (o *kubeconfigOptions) Run(f util.Factory) error {
+	ctx := f.Context()
+
+	manager, err := f.Manager()
+	if err != nil {
+		return err
+	}
+
+	config, err := manager.ClientConfig(ctx, o.CurrentTarget)
+	if err != nil {
+		return err
+	}
+
+	b, err := writeRawConfig(config)
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(o.IOStreams.Out, "%s", b)
+
+	return err
+}
+
+func writeRawConfig(config clientcmd.ClientConfig) ([]byte, error) {
+	rawConfig, err := config.RawConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return clientcmd.Write(rawConfig)
+}

--- a/pkg/cmd/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kubeconfig/kubeconfig.go
@@ -54,8 +54,8 @@ gardenctl kubeconfig --garden my-garden --project my-project`,
 	return cmd
 }
 
-// kubeconfigOptions is a struct to support kubeconfig command
-type kubeconfigOptions struct {
+// options is a struct to support kubeconfig command
+type options struct {
 	base.Options
 
 	// CurrentTarget is the current target
@@ -77,9 +77,9 @@ type kubeconfigOptions struct {
 	Context string
 }
 
-// newOptions returns initialized kubeconfigOptions
-func newOptions(ioStreams util.IOStreams) *kubeconfigOptions {
-	return &kubeconfigOptions{
+// newOptions returns initialized options
+func newOptions(ioStreams util.IOStreams) *options {
+	return &options{
 		Options: base.Options{
 			IOStreams: ioStreams,
 		},
@@ -88,7 +88,7 @@ func newOptions(ioStreams util.IOStreams) *kubeconfigOptions {
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *kubeconfigOptions) Complete(f util.Factory, _ *cobra.Command, _ []string) error {
+func (o *options) Complete(f util.Factory, _ *cobra.Command, _ []string) error {
 	manager, err := f.Manager()
 	if err != nil {
 		return err
@@ -109,8 +109,8 @@ func (o *kubeconfigOptions) Complete(f util.Factory, _ *cobra.Command, _ []strin
 	return nil
 }
 
-// Validate validates the provided command kubeconfigOptions.
-func (o *kubeconfigOptions) Validate() error {
+// Validate validates the provided command options.
+func (o *options) Validate() error {
 	if o.CurrentTarget.GardenName() == "" {
 		return target.ErrNoGardenTargeted
 	}
@@ -119,7 +119,7 @@ func (o *kubeconfigOptions) Validate() error {
 }
 
 // Run does the actual work of the command.
-func (o *kubeconfigOptions) Run(f util.Factory) error {
+func (o *options) Run(f util.Factory) error {
 	ctx := f.Context()
 
 	manager, err := f.Manager()

--- a/pkg/cmd/kubeconfig/kubeconfig_suite_test.go
+++ b/pkg/cmd/kubeconfig/kubeconfig_suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestCommand(t *testing.T) {
+func TestKubeconfigCommand(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Kubeconfig Command Test Suite")
 }

--- a/pkg/cmd/kubeconfig/kubeconfig_suite_test.go
+++ b/pkg/cmd/kubeconfig/kubeconfig_suite_test.go
@@ -1,0 +1,19 @@
+/*
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kubeconfig_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kubeconfig Command Test Suite")
+}

--- a/pkg/cmd/kubeconfig/kubeconfig_test.go
+++ b/pkg/cmd/kubeconfig/kubeconfig_test.go
@@ -1,0 +1,245 @@
+/*
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package kubeconfig_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/utils/pointer"
+
+	utilmocks "github.com/gardener/gardenctl-v2/internal/util/mocks"
+	cmdkubeconfig "github.com/gardener/gardenctl-v2/pkg/cmd/kubeconfig"
+	"github.com/gardener/gardenctl-v2/pkg/target"
+	targetmocks "github.com/gardener/gardenctl-v2/pkg/target/mocks"
+)
+
+var _ = Describe("Target Commands - Options", func() {
+	Describe("having an Options instance", func() {
+		var (
+			ctrl    *gomock.Controller
+			factory *utilmocks.MockFactory
+			manager *targetmocks.MockManager
+			options *cmdkubeconfig.TestOptions
+			t       target.Target
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			factory = utilmocks.NewMockFactory(ctrl)
+			manager = targetmocks.NewMockManager(ctrl)
+			options = cmdkubeconfig.NewOptions()
+			t = target.NewTarget("test", "project", "seed", "shoot")
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		Describe("completing the command options", func() {
+			var (
+				root,
+				parent *cobra.Command
+			)
+
+			BeforeEach(func() {
+				root = &cobra.Command{Use: "root"}
+				parent = &cobra.Command{Use: "parent", Aliases: []string{"alias"}}
+				root.AddCommand(parent)
+				root.SetArgs([]string{"alias", "child"})
+				Expect(root.Execute()).To(Succeed())
+			})
+
+			It("should complete options with current target and print object", func() {
+				factory.EXPECT().Manager().Return(manager, nil)
+				manager.EXPECT().CurrentTarget().Return(t, nil)
+				Expect(options.Complete(factory, parent, nil)).To(Succeed())
+				Expect(options.CurrentTarget).To(Equal(t))
+				Expect(options.PrintObject).NotTo(BeNil())
+			})
+
+			It("should fail to complete options", func() {
+				err := errors.New("error")
+				factory.EXPECT().Manager().Return(nil, err)
+				Expect(options.Complete(factory, parent, nil)).To(MatchError(err))
+			})
+		})
+
+		Describe("validating the command options", func() {
+			It("should successfully validate the options", func() {
+				options.CurrentTarget = target.NewTarget("my-garden", "", "", "")
+				Expect(options.Validate()).To(Succeed())
+			})
+
+			It("should return an error when the target is empty", func() {
+				options.CurrentTarget = target.NewTarget("", "", "", "")
+				Expect(options.Validate()).To(MatchError(target.ErrNoGardenTargeted))
+			})
+		})
+
+		Describe("running the kubeconfig command with the given options", func() {
+			var (
+				ctx    context.Context
+				config clientcmd.ClientConfig
+			)
+
+			BeforeEach(func() {
+				ctx = context.Background()
+				config = &clientcmd.DirectClientConfig{}
+			})
+
+			Context("when the command runs successfully", func() {
+				BeforeEach(func() {
+					factory.EXPECT().Manager().Return(manager, nil).AnyTimes()
+					factory.EXPECT().Context().Return(ctx)
+				})
+
+				It("should return the kubeconfig in yaml format", func() {
+					manager.EXPECT().CurrentTarget().Return(t, nil)
+					manager.EXPECT().ClientConfig(ctx, t).Return(config, nil)
+					Expect(options.Complete(factory, nil, nil)).To(Succeed())
+					Expect(options.Run(factory)).To(Succeed())
+					Expect(options.String()).To(Equal(`apiVersion: v1
+clusters: null
+contexts: null
+current-context: ""
+kind: Config
+preferences: {}
+users: null
+`))
+				})
+
+				It("should return the kubeconfig in json format", func() {
+					options.PrintFlags.OutputFormat = pointer.StringPtr("json")
+
+					manager.EXPECT().CurrentTarget().Return(t, nil)
+					manager.EXPECT().ClientConfig(ctx, t).Return(config, nil)
+
+					Expect(options.Complete(factory, nil, nil)).To(Succeed())
+					Expect(options.Run(factory)).To(Succeed())
+					Expect(options.String()).To(Equal(`{
+    "kind": "Config",
+    "apiVersion": "v1",
+    "preferences": {},
+    "clusters": null,
+    "users": null,
+    "contexts": null,
+    "current-context": ""
+}
+`))
+				})
+
+				It("should return the kubeconfig minified", func() {
+					options.Minify = true
+					options.RawByteData = true
+					config = clientcmd.NewDefaultClientConfig(*createTestKubeconfig("context-a"), nil)
+
+					manager.EXPECT().CurrentTarget().Return(t, nil)
+					manager.EXPECT().ClientConfig(ctx, t).Return(config, nil)
+
+					Expect(options.Complete(factory, nil, nil)).To(Succeed())
+					Expect(options.Run(factory)).To(Succeed())
+					Expect(options.String()).To(Equal(`apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://kubernetes:6443/
+  name: cluster
+contexts:
+- context:
+    cluster: cluster
+    namespace: default
+    user: user
+  name: context-a
+current-context: context-a
+kind: Config
+preferences: {}
+users:
+- name: user
+  user:
+    token: token
+`))
+				})
+
+				Context("when an error occurs", func() {
+					var currentTarget target.Target
+
+					BeforeEach(func() {
+						factory.EXPECT().Manager().Return(manager, nil).AnyTimes()
+					})
+
+					JustBeforeEach(func() {
+						manager.EXPECT().CurrentTarget().Return(currentTarget, nil)
+					})
+
+					Context("because fetching kubeconfig fails", func() {
+						var err = errors.New("error")
+
+						BeforeEach(func() {
+							currentTarget = t.WithGardenName("test")
+						})
+
+						It("should fail with a read error", func() {
+							manager.EXPECT().ClientConfig(ctx, currentTarget).Return(nil, err)
+							Expect(options.Complete(factory, nil, nil)).To(Succeed())
+							Expect(options.Run(factory)).To(BeIdenticalTo(err))
+						})
+					})
+				})
+			})
+		})
+	})
+})
+
+var _ = Describe("Kubeconfig Options", func() {
+	It("should validate", func() {
+		o := cmdkubeconfig.NewOptions()
+		o.CurrentTarget = target.NewTarget("my-garden", "", "", "")
+
+		Expect(o.Validate()).To(Succeed())
+	})
+
+	It("should reject empty target", func() {
+		o := cmdkubeconfig.NewOptions()
+		o.CurrentTarget = target.NewTarget("", "", "", "")
+
+		Expect(o.Validate()).ToNot(Succeed())
+	})
+})
+
+func createTestKubeconfig(name string) *clientcmdapi.Config {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["cluster"] = &clientcmdapi.Cluster{
+		Server:                "https://kubernetes:6443/",
+		InsecureSkipTLSVerify: true,
+	}
+	config.AuthInfos["user"] = &clientcmdapi.AuthInfo{
+		Token: "token",
+	}
+	config.AuthInfos["user2"] = &clientcmdapi.AuthInfo{
+		Token: "token2",
+	}
+	config.Contexts[name] = &clientcmdapi.Context{
+		Namespace: "default",
+		AuthInfo:  "user",
+		Cluster:   "cluster",
+	}
+	config.Contexts["context2"] = &clientcmdapi.Context{
+		Namespace: "default2",
+		AuthInfo:  "user2",
+		Cluster:   "cluster",
+	}
+	config.CurrentContext = name
+
+	return config
+}

--- a/pkg/cmd/kubeconfig/kubeconfig_test.go
+++ b/pkg/cmd/kubeconfig/kubeconfig_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Kubeconfig Command - Options", func() {
 			ctx = context.Background()
 			config = &clientcmd.DirectClientConfig{}
 
-			factory.EXPECT().Manager().Return(manager, nil).AnyTimes()
+			factory.EXPECT().Manager().Return(manager, nil)
 			factory.EXPECT().Context().Return(ctx)
 
 			manager.EXPECT().CurrentTarget().Return(t, nil)
@@ -110,7 +110,7 @@ users: null
 
 				Expect(options.Complete(factory, nil, nil)).To(Succeed())
 				Expect(options.PrintObject).NotTo(BeNil())
-				Expect(options.RawConfig).To(Equal(rawConfig))
+				Expect(options.RawConfig).To(Equal(&rawConfig))
 			})
 
 			It("should fail to complete options when the target is empty", func() {
@@ -125,7 +125,13 @@ users: null
 
 		Describe("validating the command options", func() {
 			It("should successfully validate the options", func() {
+				options.RawConfig = &rawConfig
 				Expect(options.Validate()).To(Succeed())
+			})
+
+			It("should return an error when raw config is not set", func() {
+				options.RawConfig = nil
+				Expect(options.Validate()).To(MatchError("raw Config is required"))
 			})
 		})
 
@@ -134,6 +140,7 @@ users: null
 				printer, err := options.PrintFlags.ToPrinter()
 				Expect(err).To(Succeed())
 
+				options.RawConfig = &rawConfig
 				options.PrintObject = printer.PrintObj
 			})
 
@@ -178,7 +185,7 @@ users: null
 					config = clientcmd.NewDefaultClientConfig(*createTestKubeconfig(), nil)
 					rawConfig, err = config.RawConfig()
 					Expect(err).To(Succeed())
-					options.RawConfig = rawConfig
+					options.RawConfig = &rawConfig
 
 					Expect(options.Run(nil)).To(Succeed())
 					Expect(options.String()).To(Equal(`apiVersion: v1

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -21,11 +21,7 @@ import (
 
 // NewCmdTarget returns a new target command.
 func NewCmdTarget(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
-	o := &TargetOptions{
-		Options: base.Options{
-			IOStreams: ioStreams,
-		},
-	}
+	o := NewTargetOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:   "target",
 		Short: "Set scope for next operations, using subcommands or pattern",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package config
 
 import (

--- a/pkg/target/client_provider.go
+++ b/pkg/target/client_provider.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package target
 
 import (

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package target
 
 import (

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package target
 
 import (

--- a/pkg/target/target_builder.go
+++ b/pkg/target/target_builder.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package target
 
 import (

--- a/pkg/target/target_flags.go
+++ b/pkg/target/target_flags.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package target
 
 import (

--- a/pkg/target/target_provider.go
+++ b/pkg/target/target_provider.go
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener con
 
 SPDX-License-Identifier: Apache-2.0
 */
+
 package target
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the command `kubeconfig` to print the kubeconfig for the current target.

This is especially useful to retrieve the gardenlogin kubeconfig for `Shoot` clusters, as these kubeconfigs will not be written anymore to the garden cluster as ConfigMaps, as the `gardenlogin-controller-manager` will be deprecated (ref #149)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
You can now print the kubeconfig for the current target using `gardenctl kubeconfig --raw` command
```
