### PR TITLE
use referred shoot of managed seeds for targeting, provider-env and ssh command #2

### DIFF
--- a/internal/gardenclient/mocks/mock_client.go
+++ b/internal/gardenclient/mocks/mock_client.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
@@ -221,6 +222,21 @@ func (m *MockClient) GetShootClientConfig(arg0 context.Context, arg1, arg2 strin
 func (mr *MockClientMockRecorder) GetShootClientConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShootClientConfig", reflect.TypeOf((*MockClient)(nil).GetShootClientConfig), arg0, arg1, arg2)
+}
+
+// GetShootOfManagedSeed mocks base method.
+func (m *MockClient) GetShootOfManagedSeed(arg0 context.Context, arg1 string) (*v1alpha1.Shoot, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetShootOfManagedSeed", arg0, arg1)
+	ret0, _ := ret[0].(*v1alpha1.Shoot)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetShootOfManagedSeed indicates an expected call of GetShootOfManagedSeed.
+func (mr *MockClientMockRecorder) GetShootOfManagedSeed(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShootOfManagedSeed", reflect.TypeOf((*MockClient)(nil).GetShootOfManagedSeed), arg0, arg1)
 }
 
 // ListProjects mocks base method.

--- a/internal/gardenclient/shoot_client.go
+++ b/internal/gardenclient/shoot_client.go
@@ -14,14 +14,21 @@ import (
 
 	"github.com/Masterminds/semver"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
+
+func init() {
+	utilruntime.Must(seedmanagementv1alpha1.AddToScheme(scheme.Scheme))
+}
 
 const (
 	// ShootProjectSecretSuffixCACluster is a constant for a shoot project secret with suffix 'ca-cluster'.

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ package main
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -17,6 +18,7 @@ import (
 func main() {
 	utilruntime.Must(gardencorev1beta1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(operationsv1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(seedmanagementv1alpha1.AddToScheme(scheme.Scheme))
 
 	cmd.Execute()
 }

--- a/pkg/cmd/env/env_suite_test.go
+++ b/pkg/cmd/env/env_suite_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -27,6 +28,7 @@ var (
 
 func init() {
 	utilruntime.Must(gardencorev1beta1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(seedmanagementv1alpha1.AddToScheme(scheme.Scheme))
 }
 
 func TestCloudEnvCommand(t *testing.T) {

--- a/pkg/cmd/env/export_test.go
+++ b/pkg/cmd/env/export_test.go
@@ -9,12 +9,11 @@ package env
 import (
 	"text/template"
 
-	"github.com/gardener/gardenctl-v2/pkg/ac"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/ac"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 )
 

--- a/pkg/cmd/env/options_test.go
+++ b/pkg/cmd/env/options_test.go
@@ -409,7 +409,8 @@ var _ = Describe("Env Commands - Options", func() {
 
 				It("should fail with ErrNoShootTargeted", func() {
 					factory.EXPECT().Manager().Return(manager, nil)
-					manager.EXPECT().CurrentTarget().Return(t.WithShootName(""), nil)
+					manager.EXPECT().CurrentTarget().Return(t.WithShootName("").WithSeedName(""), nil)
+					manager.EXPECT().GardenClient(t.GardenName()).Return(client, nil)
 					Expect(options.Run(factory)).To(BeIdenticalTo(target.ErrNoShootTargeted))
 				})
 
@@ -498,7 +499,7 @@ var _ = Describe("Env Commands - Options", func() {
 				providerConfig = nil
 				serviceaccountJSON = readTestFile("gcp/serviceaccount.json")
 				token = "token"
-				options.CurrentTarget = target.NewTarget("test", "project", "", shootName)
+				options.Target = target.NewTarget("test", "project", "", shootName)
 			})
 
 			JustBeforeEach(func() {
@@ -716,7 +717,7 @@ var _ = Describe("Env Commands - Options", func() {
 				providerType = "alicloud"
 				shell = "bash"
 				unset = false
-				options.CurrentTarget = t.WithSeedName("")
+				options.Target = t.WithSeedName("")
 			})
 
 			JustBeforeEach(func() {

--- a/pkg/target/target_flags_test.go
+++ b/pkg/target/target_flags_test.go
@@ -7,12 +7,19 @@ SPDX-License-Identifier: Apache-2.0
 package target_test
 
 import (
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/pflag"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/gardener/gardenctl-v2/pkg/target"
 )
+
+func init() {
+	utilruntime.Must(seedmanagementv1alpha1.AddToScheme(scheme.Scheme))
+}
 
 var _ = Describe("Target Flags", func() {
 	It("should return an empty set of target flags", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
If seed is a managed seed, GetSeedClientConfig returns GetShootClientConfig for respective shoot

**Which issue(s) this PR fixes**:
Fixes #129 Fixes #104

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Managed seeds no longer require `<seedname>.login` secret. The `gardenlogin` kubeconfig is used instead for the shoot that is registered as seed
```

```feature user
Gardenctl now uses referred shoot of managed seeds for targeting, provider-env and ssh commands.
```
