### PR TITLE
[hotfix-2.1] Consider control-plane flag on kubeconfig command

### DIFF
--- a/pkg/target/target_flags.go
+++ b/pkg/target/target_flags.go
@@ -87,7 +87,7 @@ func (tf *targetFlagsImpl) AddFlags(flags *pflag.FlagSet) {
 }
 
 func (tf *targetFlagsImpl) ToTarget() Target {
-	return NewTarget(tf.gardenName, tf.projectName, tf.seedName, tf.shootName)
+	return NewTarget(tf.gardenName, tf.projectName, tf.seedName, tf.shootName).WithControlPlane(tf.controlPlane)
 }
 
 func (tf *targetFlagsImpl) isEmpty() bool {

--- a/pkg/target/target_flags_test.go
+++ b/pkg/target/target_flags_test.go
@@ -77,6 +77,15 @@ var _ = Describe("Target Flags", func() {
 		Expect(t.ControlPlane()).To(BeTrue())
 	})
 
+	It("should convert to target", func() {
+		t := target.NewTargetFlags("garden", "project", "", "shoot", true).ToTarget()
+		Expect(t.GardenName()).To(Equal("garden"))
+		Expect(t.ProjectName()).To(Equal("project"))
+		Expect(t.SeedName()).To(BeEmpty())
+		Expect(t.ShootName()).To(Equal("shoot"))
+		Expect(t.ControlPlane()).To(BeTrue())
+	})
+
 	It("should fail to override a target", func() {
 		tf := target.NewTargetFlags("", "", "", "shoot", false)
 		_, err := tf.OverrideTarget(target.NewTarget("", "b", "c", "d"))


### PR DESCRIPTION
**What this PR does / why we need it**:
Consider control-plane flag on kubeconfig command

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed an issue where the `--control-plane` flag was not considered on the `kubeconfig` command
```