### PR TITLE
Doc/gardenctl config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ export KUBECONFIG=~/relative/path/to/kubeconfig.yaml
 # Method 1 : Fetch cluster-identity of garden cluster from the configmap
 export CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
 # OR
-# Method 2 : If you don't have access to the kube-system namespace in the garden, the garden cluster-identity is also available in every shoot's yaml
+# Method 2 : If you don't have access to the kube-system namespace in the garden cluster, the garden cluster-identity can also be extracted from every shoot's yaml
 export PROJECT="your-project-name" # Change to your project name
 export SHOOT="your-shoot-name" # Change to any shoot's name in your project
 export PREFIX="shoot--$PROJECT--$SHOOT-"$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.metadata.uid})"-"

--- a/README.md
+++ b/README.md
@@ -59,13 +59,19 @@ You can modify this file directly using the `gardenctl config` command. It allow
 Example `config` command:
 ``` bash
 # Adapt the path to your kubeconfig file for the garden cluster
-export KUBECONFIG=~/relative/path/to/kubeconfig.yaml
+❯ export KUBECONFIG=~/relative/path/to/kubeconfig.yaml
 
-# Fetch cluster-identity of garden cluster
-CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
+# Method 1 : Fetch cluster-identity of garden cluster from the configmap
+❯ export CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
+# OR
+# Method 2 : If you don't have access to the kube-system namespace in the garden, the garden cluster-identity is also available in every shoot's 
+❯ export SHOOT_UID=$(kubectl get shoot -n garden-my-project my-shoot -ojsonpath={.metadata.uid})
+❯ export PREFIX="shoot--my-project--my-shoot-$SHOOT_UID-"
+❯ kubectl -n garden-my-project get shoot my-shoot -ojsonpath={.status.clusterIdentity}
+❯ export CLUSTER_IDENTITY="landscape-dev" # difference between both
 
 # Configure garden cluster
-gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
+❯ gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
 ```
 This command will create or update a garden with the provided identity and kubeconfig path of your garden cluster.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ export CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity 
 # OR
 # Method 2 : If you don't have access to the kube-system namespace in the garden, the garden cluster-identity is also available in every shoot's 
 export PROJECT="your-project-name" # Change to your project name
-export SHOOT="your-shoot-name" # Change to any shoot in your project
+export SHOOT="your-shoot-name" # Change to any shoot's name in your project
 export PREFIX="shoot--$PROJECT--$SHOOT-"$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.metadata.uid})"-"
 export STATUS=$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.status.clusterIdentity})
 export CLUSTER_IDENTITY=$(echo ${STATUS#$PREFIX}) # difference between both

--- a/README.md
+++ b/README.md
@@ -59,19 +59,20 @@ You can modify this file directly using the `gardenctl config` command. It allow
 Example `config` command:
 ``` bash
 # Adapt the path to your kubeconfig file for the garden cluster
-❯ export KUBECONFIG=~/relative/path/to/kubeconfig.yaml
+export KUBECONFIG=~/relative/path/to/kubeconfig.yaml
 
 # Method 1 : Fetch cluster-identity of garden cluster from the configmap
-❯ export CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
+export CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
 # OR
 # Method 2 : If you don't have access to the kube-system namespace in the garden, the garden cluster-identity is also available in every shoot's 
-❯ export SHOOT_UID=$(kubectl get shoot -n garden-my-project my-shoot -ojsonpath={.metadata.uid})
-❯ export PREFIX="shoot--my-project--my-shoot-$SHOOT_UID-"
-❯ kubectl -n garden-my-project get shoot my-shoot -ojsonpath={.status.clusterIdentity}
-❯ export CLUSTER_IDENTITY="landscape-dev" # difference between both
+export PROJECT="your-project-name" # Change to your project name
+export SHOOT="your-shoot-name" # Change to any shoot in your project
+export PREFIX="shoot--$PROJECT--$SHOOT-"$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.metadata.uid})"-"
+export STATUS=$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.status.clusterIdentity})
+export CLUSTER_IDENTITY=$(echo ${STATUS#$PREFIX}) # difference between both
 
 # Configure garden cluster
-❯ gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
+gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
 ```
 This command will create or update a garden with the provided identity and kubeconfig path of your garden cluster.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ export KUBECONFIG=~/relative/path/to/kubeconfig.yaml
 # Method 1 : Fetch cluster-identity of garden cluster from the configmap
 export CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
 # OR
-# Method 2 : If you don't have access to the kube-system namespace in the garden, the garden cluster-identity is also available in every shoot's 
+# Method 2 : If you don't have access to the kube-system namespace in the garden, the garden cluster-identity is also available in every shoot's yaml
 export PROJECT="your-project-name" # Change to your project name
 export SHOOT="your-shoot-name" # Change to any shoot's name in your project
 export PREFIX="shoot--$PROJECT--$SHOOT-"$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.metadata.uid})"-"

--- a/README.md
+++ b/README.md
@@ -62,17 +62,19 @@ Example `config` command:
 export KUBECONFIG=~/relative/path/to/kubeconfig.yaml
 
 # Method 1 : Fetch cluster-identity of garden cluster from the configmap
-CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
+cluster_identity=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
 # OR
 # Method 2 : If you don't have access to the kube-system namespace in the garden cluster, the garden cluster-identity can also be extracted from every shoot's yaml
-PROJECT="your-project-name" # Change to your project name
-SHOOT="your-shoot-name" # Change to any shoot's name in your project
-PREFIX="shoot--$PROJECT--$SHOOT-"$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.metadata.uid})"-"
-STATUS=$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.status.clusterIdentity})
-CLUSTER_IDENTITY=$(echo ${STATUS#$PREFIX}) # difference between both
+project="your-project-name" # Change to your project name
+shoot="your-shoot-name" # Change to any shoot's name in your project
+# Simply copy/paste the following lines
+ns=$(kubectl get project $project -ojsonpath={.spec.namespace})
+prefix="shoot--$project--$shoot-"$(kubectl get shoot -n $ns $shoot -ojsonpath={.metadata.uid})"-"
+identity_status=$(kubectl get shoot -n $ns $shoot -ojsonpath={.status.clusterIdentity})
+cluster_identity=$(echo ${identity_status#"$prefix"})
 
 # Configure garden cluster
-gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
+gardenctl config set-garden $cluster_identity --kubeconfig $KUBECONFIG
 ```
 This command will create or update a garden with the provided identity and kubeconfig path of your garden cluster.
 

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ Example `config` command:
 export KUBECONFIG=~/relative/path/to/kubeconfig.yaml
 
 # Method 1 : Fetch cluster-identity of garden cluster from the configmap
-export CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
+CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
 # OR
 # Method 2 : If you don't have access to the kube-system namespace in the garden cluster, the garden cluster-identity can also be extracted from every shoot's yaml
 PROJECT="your-project-name" # Change to your project name
 SHOOT="your-shoot-name" # Change to any shoot's name in your project
 PREFIX="shoot--$PROJECT--$SHOOT-"$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.metadata.uid})"-"
 STATUS=$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.status.clusterIdentity})
-export CLUSTER_IDENTITY=$(echo ${STATUS#$PREFIX}) # difference between both
+CLUSTER_IDENTITY=$(echo ${STATUS#$PREFIX}) # difference between both
 
 # Configure garden cluster
 gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG

--- a/README.md
+++ b/README.md
@@ -65,10 +65,10 @@ export KUBECONFIG=~/relative/path/to/kubeconfig.yaml
 export CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
 # OR
 # Method 2 : If you don't have access to the kube-system namespace in the garden cluster, the garden cluster-identity can also be extracted from every shoot's yaml
-export PROJECT="your-project-name" # Change to your project name
-export SHOOT="your-shoot-name" # Change to any shoot's name in your project
-export PREFIX="shoot--$PROJECT--$SHOOT-"$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.metadata.uid})"-"
-export STATUS=$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.status.clusterIdentity})
+PROJECT="your-project-name" # Change to your project name
+SHOOT="your-shoot-name" # Change to any shoot's name in your project
+PREFIX="shoot--$PROJECT--$SHOOT-"$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.metadata.uid})"-"
+STATUS=$(kubectl get shoot -n garden-$PROJECT $SHOOT -ojsonpath={.status.clusterIdentity})
 export CLUSTER_IDENTITY=$(echo ${STATUS#$PREFIX}) # difference between both
 
 # Configure garden cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
There was missing documentation on how to configure gardenctl if the kube-system namespace is blocked for a user.

So added a 2nd method to do that over CLI. I get and know that this is not an ideal solution, but it works well in the meantime

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Added a second method to configure gardenctl which requres less premissions
```
