### PR TITLE
bugfix - config file creation fails when directory does not exist

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 
@@ -105,6 +106,13 @@ func (config *Config) SymlinkTargetKubeconfig() bool {
 
 // Save updates a gardenctl config file with the values passed via Config struct
 func (config *Config) Save() error {
+	dir := filepath.Dir(config.Filename)
+
+	err := os.MkdirAll(dir, 0700)
+	if err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
 	f, err := os.OpenFile(config.Filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -164,11 +164,12 @@ var _ = Describe("Config", func() {
 	)
 
 	It("should create configuration directories and file", func() {
-		dir, err := os.MkdirTemp("", "garden-*")
+		dir, err := os.MkdirTemp("", "home-*")
 		Expect(err).NotTo(HaveOccurred())
 		defer os.RemoveAll(dir)
 
-		filename := filepath.Join(dir, "./.nonexisting-sub-folder/", "gardenctl-v2.yaml")
+		filename := filepath.Join(dir, ".garden", "gardenctl-v2.yaml")
+
 		cfg = &config.Config{
 			Filename: filename,
 		}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -162,4 +162,16 @@ var _ = Describe("Config", func() {
 		Entry("when LinkKubeconfig is false and envVar is True", pointer.Bool(false), "True", pointer.Bool(true)),
 		Entry("when LinkKubeconfig is false and envVar is False", pointer.Bool(false), "False", pointer.Bool(false)),
 	)
+
+	It("should create configuration directories and file", func() {
+		dir, err := os.MkdirTemp("", "garden-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer os.RemoveAll(dir)
+
+		filename := filepath.Join(dir, "./.nonexisting-sub-folder/", "gardenctl-v2.yaml")
+		cfg = &config.Config{
+			Filename: filename,
+		}
+		Expect(cfg.Save()).NotTo(HaveOccurred())
+	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Especially when first installing gardenctl it will try to create the config file `~/.garden/gardenctl-v2.yaml`. If the parent directory `.garden` does not already exist it will fail.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```bugfix user
Fixed error when trying to create `~/.garden/gardenctl-v2.yaml` and the directory did not yet exist
```
