### PR TITLE
Enable additional linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,6 +10,8 @@ linters:
     - wsl
     - goimports
     - nolintlint
+    - predeclared
+    - unconvert
 linters-settings:
   goimports:
     local-prefixes: github.com/gardener/gardenctl-v2


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables two additional linters ([ref](https://golangci-lint.run/usage/linters/))
- predeclared - find code that shadows one of Go's predeclared identifiers
- unconvert - Remove unnecessary type conversions

related PR https://github.com/gardener/gardenctl-v2/issues/45

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
