### PR TITLE
lasterror

### DIFF
--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -768,7 +768,7 @@ func waitForBastion(ctx context.Context, o *SSHOptions, gardenClient client.Clie
 
 		lastCheckErr = bastionAvailabilityChecker(preferredBastionAddress(bastion), privateKeyBytes)
 		if lastCheckErr != nil {
-			fmt.Fprintf(o.IOStreams.ErrOut, "Still waiting: Bastion is ready, waiting to establish an ssh connection with bastion: %v\n", lastCheckErr)
+			fmt.Fprintf(o.IOStreams.ErrOut, "Still waiting: Bastion is ready, however cannot connect to bastion yet: %v\n", lastCheckErr)
 			return false, nil
 		}
 

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -765,15 +765,12 @@ func waitForBastion(ctx context.Context, o *SSHOptions, gardenClient client.Clie
 			fmt.Fprintf(o.IOStreams.ErrOut, "Still waiting: %v\n", lastCheckErr)
 			return false, nil
 		case cond.Status == gardencorev1alpha1.ConditionTrue:
-		default:
-			lastCheckErr = errors.New("unknown issues")
-			fmt.Fprintf(o.IOStreams.ErrOut, "Still waiting: %v\n", lastCheckErr)
-			return false, nil
+			// leave switch
 		}
 
 		lastCheckErr = bastionAvailabilityChecker(preferredBastionAddress(bastion), privateKeyBytes)
 		if lastCheckErr != nil {
-			fmt.Fprintf(o.IOStreams.ErrOut, "Still waiting: %s, waiting to establish an ssh connection with bastion: %v\n", "Bastion is Ready condition", lastCheckErr)
+			fmt.Fprintf(o.IOStreams.ErrOut, "Still waiting: Bastion is ready, waiting to establish an ssh connection with bastion: %v\n", lastCheckErr)
 			return false, nil
 		}
 

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -764,8 +764,6 @@ func waitForBastion(ctx context.Context, o *SSHOptions, gardenClient client.Clie
 			lastCheckErr = errors.New(cond.Message)
 			fmt.Fprintf(o.IOStreams.ErrOut, "Still waiting: %v\n", lastCheckErr)
 			return false, nil
-		case cond.Status == gardencorev1alpha1.ConditionTrue:
-			// leave switch
 		}
 
 		lastCheckErr = bastionAvailabilityChecker(preferredBastionAddress(bastion), privateKeyBytes)


### PR DESCRIPTION
**What this PR does / why we need it**:
new output looks like below
```
Preparing SSH access to abc/os on dev…
Creating bastion cli-urta3zkr…
Waiting up to 10m0s for bastion to be ready…
Still waiting: Error while waiting for Bastion shoot--abc-os/cli-urta3zkr to become ready: error during reconciliation: Error reconciling Bastion: instance or public ip address not ready yet
Still waiting: Error while waiting for Bastion shoot--abc-os/cli-urta3zkr to become ready: error during reconciliation: Error reconciling Bastion: instance or public ip address not ready yet
Still waiting: Error while waiting for Bastion shoot--abc-os/cli-urta3zkr to become ready: error during reconciliation: Error reconciling Bastion: instance or public ip address not ready yet
Still waiting: Error while waiting for Bastion shoot--abc-os/cli-urta3zkr to become ready: error during reconciliation: Error reconciling Bastion: instance or public ip address not ready yet
Still waiting: Error while waiting for Bastion shoot--abc-os/cli-urta3zkr to become ready: error during reconciliation: Error reconciling Bastion: instance or public ip address not ready yet
Still waiting: Bastion is Ready condition, waiting to establish an ssh connection with bastion: dial tcp 1xxxx:22: connect: connection refused
Still waiting: Bastion is Ready condition, waiting to establish an ssh connection with bastion: dial tcp 1xxxx:22: connect: connection refused
Still waiting: Bastion is Ready condition, waiting to establish an ssh connection with bastion: dial tcp 1xxxx:22: connect: connection refused
...
```
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl-v2/issues/143

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
