### PR TITLE
Add additional linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,7 @@ linters:
     - predeclared
     - unconvert
     - gocritic
+    - godot
 linters-settings:
   goimports:
     local-prefixes: github.com/gardener/gardenctl-v2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,6 +15,7 @@ linters:
     - gocritic
     - godot
     - gofumpt
+    - misspell
 linters-settings:
   goimports:
     local-prefixes: github.com/gardener/gardenctl-v2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,7 @@ linters:
     - unconvert
     - gocritic
     - godot
+    - gofumpt
 linters-settings:
   goimports:
     local-prefixes: github.com/gardener/gardenctl-v2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,7 @@ linters:
     - godot
     - gofumpt
     - misspell
+    - stylecheck
 linters-settings:
   goimports:
     local-prefixes: github.com/gardener/gardenctl-v2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,7 @@ linters:
     - nolintlint
     - predeclared
     - unconvert
+    - gocritic
 linters-settings:
   goimports:
     local-prefixes: github.com/gardener/gardenctl-v2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,19 +5,19 @@ run:
     - "zz_generated.*"
 linters:
   enable:
-    - revive
-    - whitespace
-    - wsl
-    - goimports
-    - nolintlint
-    - predeclared
-    - unconvert
     - gocritic
     - godot
     - gofumpt
+    - goimports
     - misspell
+    - nolintlint
+    - predeclared
+    - revive
     - stylecheck
+    - unconvert
     - wastedassign
+    - whitespace
+    - wsl
 linters-settings:
   goimports:
     local-prefixes: github.com/gardener/gardenctl-v2

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,6 +17,7 @@ linters:
     - gofumpt
     - misspell
     - stylecheck
+    - wastedassign
 linters-settings:
   goimports:
     local-prefixes: github.com/gardener/gardenctl-v2

--- a/internal/fake/factory.go
+++ b/internal/fake/factory.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/target"
 )
 
-// Factory implements util.Factory interface
+// Factory implements util.Factory interface.
 type Factory struct {
 	// ContextImpl is the root context any command should use.
 	ContextImpl context.Context

--- a/internal/gardenclient/client.go
+++ b/internal/gardenclient/client.go
@@ -39,7 +39,7 @@ func init() {
 
 //go:generate mockgen -destination=./mocks/mock_client.go -package=mocks github.com/gardener/gardenctl-v2/internal/gardenclient Client
 
-// Client returns a new client with functions to get Gardener and Kubernetes resources
+// Client returns a new client with functions to get Gardener and Kubernetes resources.
 type Client interface {
 	// GetProject returns a Gardener project resource by name
 	GetProject(ctx context.Context, name string) (*gardencorev1beta1.Project, error)
@@ -92,7 +92,7 @@ type clientImpl struct {
 	name string
 }
 
-// NewGardenClient returns a new gardenclient
+// NewGardenClient returns a new gardenclient.
 func NewGardenClient(client client.Client, name string) Client {
 	return &clientImpl{
 		c:    client,
@@ -217,7 +217,7 @@ func (g *clientImpl) ListShoots(ctx context.Context, opts ...client.ListOption) 
 	return shootList, nil
 }
 
-// GetNamespace returns a Kubernetes namespace resource
+// GetNamespace returns a Kubernetes namespace resource.
 func (g *clientImpl) GetNamespace(ctx context.Context, name string) (*corev1.Namespace, error) {
 	namespace := &corev1.Namespace{}
 	key := types.NamespacedName{Name: name}
@@ -229,7 +229,7 @@ func (g *clientImpl) GetNamespace(ctx context.Context, name string) (*corev1.Nam
 	return namespace, nil
 }
 
-// GetSecretBinding returns a Gardener secretbinding resource
+// GetSecretBinding returns a Gardener secretbinding resource.
 func (g *clientImpl) GetSecretBinding(ctx context.Context, namespace, name string) (*gardencorev1beta1.SecretBinding, error) {
 	secretBinding := &gardencorev1beta1.SecretBinding{}
 	key := types.NamespacedName{Namespace: namespace, Name: name}
@@ -241,7 +241,7 @@ func (g *clientImpl) GetSecretBinding(ctx context.Context, namespace, name strin
 	return secretBinding, nil
 }
 
-// GetSecret returns a Kubernetes secret resource
+// GetSecret returns a Kubernetes secret resource.
 func (g *clientImpl) GetSecret(ctx context.Context, namespace, name string) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	key := types.NamespacedName{Namespace: namespace, Name: name}
@@ -253,7 +253,7 @@ func (g *clientImpl) GetSecret(ctx context.Context, namespace, name string) (*co
 	return secret, nil
 }
 
-// GetConfigMap returns a Gardener configmap resource
+// GetConfigMap returns a Gardener configmap resource.
 func (g *clientImpl) GetConfigMap(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error) {
 	cm := &corev1.ConfigMap{}
 	key := types.NamespacedName{Name: name, Namespace: namespace}
@@ -330,7 +330,7 @@ func (g *clientImpl) GetCloudProfile(ctx context.Context, name string) (*gardenc
 	return cloudProfile, nil
 }
 
-// RuntimeClient returns the underlying Kubernetes runtime client
+// RuntimeClient returns the underlying Kubernetes runtime client.
 func (g *clientImpl) RuntimeClient() client.Client {
 	return g.c
 }

--- a/internal/gardenclient/client_test.go
+++ b/internal/gardenclient/client_test.go
@@ -269,7 +269,7 @@ var _ = Describe("Client", func() {
 	})
 })
 
-// TODO copied from target_suite_test. Move into a test helper package for better reuse
+// TODO copied from target_suite_test. Move into a test helper package for better reuse.
 func createTestKubeconfig(name string) []byte {
 	config := clientcmdapi.NewConfig()
 	config.Clusters["cluster"] = &clientcmdapi.Cluster{

--- a/internal/gardenclient/shoot_client.go
+++ b/internal/gardenclient/shoot_client.go
@@ -49,7 +49,7 @@ type shootKubeconfigRequest struct {
 	gardenClusterIdentity string
 }
 
-// cluster holds the data to describe and connect to a kubernetes cluster
+// cluster holds the data to describe and connect to a kubernetes cluster.
 type cluster struct {
 	// name is the name of the shoot advertised address, usually "external", "internal" or "unmanaged"
 	name string
@@ -61,7 +61,7 @@ type cluster struct {
 	caCert []byte
 }
 
-// execPluginConfig contains a reference to the garden and shoot cluster
+// execPluginConfig contains a reference to the garden and shoot cluster.
 type execPluginConfig struct {
 	// ShootRef references the shoot cluster
 	ShootRef shootRef `json:"shootRef"`
@@ -70,7 +70,7 @@ type execPluginConfig struct {
 	GardenClusterIdentity string `json:"gardenClusterIdentity"`
 }
 
-// shootRef references the shoot cluster by namespace and name
+// shootRef references the shoot cluster by namespace and name.
 type shootRef struct {
 	// Namespace is the namespace of the shoot cluster
 	Namespace string `json:"namespace"`
@@ -92,7 +92,7 @@ func (e *execPluginConfig) DeepCopyObject() runtime.Object {
 	}
 }
 
-// validate validates the kubeconfig request by ensuring that all required fields are set
+// validate validates the kubeconfig request by ensuring that all required fields are set.
 func (k *shootKubeconfigRequest) validate() error {
 	if len(k.clusters) == 0 {
 		return errors.New("missing clusters")
@@ -127,7 +127,7 @@ func (k *shootKubeconfigRequest) validate() error {
 // by exec'ing the gardenlogin plugin, which fetches a client certificate.
 // If legacy is false, the shoot reference and garden cluster identity is passed via the cluster extensions,
 // which is supported starting with kubectl version v1.20.0.
-// If legacy is true, the shoot reference and garden cluster identity are passed as command line flags to the plugin
+// If legacy is true, the shoot reference and garden cluster identity are passed as command line flags to the plugin.
 func (k *shootKubeconfigRequest) generate(legacy bool) (*clientcmdapi.Config, error) {
 	var extension *execPluginConfig
 

--- a/internal/util/clock.go
+++ b/internal/util/clock.go
@@ -8,13 +8,13 @@ package util
 
 import "time"
 
-// Clock provides the current time
+// Clock provides the current time.
 type Clock interface {
 	// Now returns the current time
 	Now() time.Time
 }
 
-// RealClock implements Clock interface
+// RealClock implements Clock interface.
 type RealClock struct{}
 
 var _ Clock = &RealClock{}

--- a/internal/util/factory.go
+++ b/internal/util/factory.go
@@ -59,7 +59,7 @@ type FactoryImpl struct {
 	GardenHomeDirectory string
 
 	// ConfigFile is the location of the gardenctlv2 configuration file.
-	// This can be overriden via a CLI flag and defaults to ~/.garden/gardenctlv2.yaml
+	// This can be overridden via a CLI flag and defaults to ~/.garden/gardenctlv2.yaml
 	// if empty.
 	ConfigFile string
 

--- a/internal/util/factory.go
+++ b/internal/util/factory.go
@@ -160,7 +160,7 @@ func getSessionID() (string, error) {
 			return value, nil
 		}
 
-		return "", fmt.Errorf("Environment variable %s must only contain alphanumeric characters, underscore and dash and have a minimum length of 1 and a maximum length of 128", envSessionID)
+		return "", fmt.Errorf("environment variable %s must only contain alphanumeric characters, underscore and dash and have a minimum length of 1 and a maximum length of 128", envSessionID)
 	}
 
 	if value, ok := os.LookupEnv(envTermSessionID); ok {
@@ -170,5 +170,5 @@ func getSessionID() (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("Environment variable %s is required. Use \"gardenctl help\" for more information about the requirements of gardenctl", envSessionID)
+	return "", fmt.Errorf("environment variable %s is required. Use \"gardenctl help\" for more information about the requirements of gardenctl", envSessionID)
 }

--- a/internal/util/factory.go
+++ b/internal/util/factory.go
@@ -87,7 +87,7 @@ func (f *FactoryImpl) Manager() (target.Manager, error) {
 
 	sessionDirectory := filepath.Join(os.TempDir(), "garden", sid)
 
-	err = os.MkdirAll(sessionDirectory, 0700)
+	err = os.MkdirAll(sessionDirectory, 0o700)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create session directory: %w", err)
 	}

--- a/internal/util/factory.go
+++ b/internal/util/factory.go
@@ -50,7 +50,7 @@ type Factory interface {
 	PublicIPs(context.Context) ([]string, error)
 }
 
-// FactoryImpl implements util.Factory interface
+// FactoryImpl implements util.Factory interface.
 type FactoryImpl struct {
 	// GardenHomeDirectory is the home directory for all gardenctl
 	// related files. While some files can be explicitly loaded from

--- a/internal/util/io_streams.go
+++ b/internal/util/io_streams.go
@@ -14,7 +14,7 @@ import (
 )
 
 // IOStreams provides the standard names for iostreams. This is useful for embedding and for unit testing.
-// Inconsistent and different names make it hard to read and review code
+// Inconsistent and different names make it hard to read and review code.
 type IOStreams struct {
 	// In think, os.Stdin
 	In io.Reader
@@ -33,7 +33,7 @@ func NewIOStreams() IOStreams {
 	}
 }
 
-// NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests
+// NewTestIOStreams returns a valid IOStreams and in, out, errout buffers for unit tests.
 func NewTestIOStreams() (IOStreams, *SafeBytesBuffer, *SafeBytesBuffer, *SafeBytesBuffer) {
 	in := &SafeBytesBuffer{}
 	out := &SafeBytesBuffer{}

--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -45,7 +45,7 @@ func ShellEscape(values ...interface{}) string {
 	return strings.Join(out, " ")
 }
 
-// StripUnsafe remove non-printable characters from the string
+// StripUnsafe remove non-printable characters from the string.
 func StripUnsafe(s string) string {
 	return strings.Map(func(r rune) rune {
 		if unicode.IsPrint(r) {

--- a/internal/util/target.go
+++ b/internal/util/target.go
@@ -120,7 +120,7 @@ func ProjectNamesForTarget(ctx context.Context, manager target.Manager) ([]strin
 	return names.List(), nil
 }
 
-// GardenNames returns all names of configured Gardens
+// GardenNames returns all names of configured Gardens.
 func GardenNames(manager target.Manager) ([]string, error) {
 	config := manager.Configuration()
 	if config == nil {

--- a/pkg/ac/access_restriction.go
+++ b/pkg/ac/access_restriction.go
@@ -43,8 +43,10 @@ type AccessRestrictionOption struct {
 // The typical implementation of this function looks like this:
 //
 //	func(messages AccessRestrictionMessages) { message.Render(os.Stdout) }
-type AccessRestrictionHandler func(AccessRestrictionMessages) bool
-type accessRestrictionHandlerContextKey struct{}
+type (
+	AccessRestrictionHandler           func(AccessRestrictionMessages) bool
+	accessRestrictionHandlerContextKey struct{}
+)
 
 // WithAccessRestrictionHandler returns a copy of parent context to which the given AccessRestrictionHandler function has been added.
 func WithAccessRestrictionHandler(ctx context.Context, fn AccessRestrictionHandler) context.Context {
@@ -106,7 +108,7 @@ func (m *AccessRestrictionMessage) messageWidth() int {
 }
 
 func (accessRestriction *AccessRestriction) checkAccessRestriction(matchLabels, annotations map[string]string) *AccessRestrictionMessage {
-	var matches = func(m map[string]string, key string, val bool) bool {
+	matches := func(m map[string]string, key string, val bool) bool {
 		if strVal, ok := m[key]; ok {
 			if boolVal, err := strconv.ParseBool(strVal); err == nil {
 				return boolVal == val

--- a/pkg/ac/access_restriction.go
+++ b/pkg/ac/access_restriction.go
@@ -17,7 +17,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
-// AccessRestriction is used to define an access restriction
+// AccessRestriction is used to define an access restriction.
 type AccessRestriction struct {
 	// Key is the identifier of an access restriction
 	Key string `yaml:"key,omitempty" json:"key,omitempty"`
@@ -29,7 +29,7 @@ type AccessRestriction struct {
 	Options []AccessRestrictionOption `yaml:"options,omitempty" json:"options,omitempty"`
 }
 
-// AccessRestrictionOption is used to define an access restriction option
+// AccessRestrictionOption is used to define an access restriction option.
 type AccessRestrictionOption struct {
 	// Key is the identifier of an access restriction option
 	Key string `yaml:"key,omitempty" json:"key,omitempty"`
@@ -62,7 +62,7 @@ func AccessRestrictionHandlerFromContext(ctx context.Context) AccessRestrictionH
 	return nil
 }
 
-// NewAccessRestrictionHandler create an access restriction handler function
+// NewAccessRestrictionHandler create an access restriction handler function.
 func NewAccessRestrictionHandler(r io.Reader, w io.Writer, askForConfirmation bool) AccessRestrictionHandler {
 	return func(messages AccessRestrictionMessages) bool {
 		if len(messages) == 0 {
@@ -158,7 +158,7 @@ type AccessRestrictionMessage struct {
 	Items  []string
 }
 
-// AccessRestrictionMessages is a list of access restriction messages
+// AccessRestrictionMessages is a list of access restriction messages.
 type AccessRestrictionMessages []*AccessRestrictionMessage
 
 type pos int
@@ -215,7 +215,7 @@ func (p pos) print(text string, width int) string {
 	return strings.Join(results, "\n")
 }
 
-// Render displays the access restriction messages
+// Render displays the access restriction messages.
 func (messages AccessRestrictionMessages) Render(w io.Writer) {
 	title := " Access Restriction"
 	if len(messages) > 1 {
@@ -245,7 +245,7 @@ func (messages AccessRestrictionMessages) Render(w io.Writer) {
 	fmt.Fprintln(w, footer.print("", width))
 }
 
-// Confirm  asks for confirmation to continue
+// Confirm  asks for confirmation to continue.
 func (messages AccessRestrictionMessages) Confirm(r io.Reader, w io.Writer) bool {
 	reader := bufio.NewReader(r)
 

--- a/pkg/ac/access_restriction_test.go
+++ b/pkg/ac/access_restriction_test.go
@@ -123,7 +123,6 @@ var _ = Describe("AccessRestriction", func() {
 
 	Describe("Handling an access restriction message", func() {
 		It("should add and get a handler function from the context", func() {
-
 			message := &ac.AccessRestrictionMessage{}
 			messages := ac.AccessRestrictionMessages{message}
 			ctx := ac.WithAccessRestrictionHandler(context.Background(), func(messages ac.AccessRestrictionMessages) bool {

--- a/pkg/cmd/base/options.go
+++ b/pkg/cmd/base/options.go
@@ -43,7 +43,7 @@ type Options struct {
 
 var _ CommandOptions = &Options{}
 
-// WrapRunE creates a cobra RunE function that has access to the factory
+// WrapRunE creates a cobra RunE function that has access to the factory.
 func WrapRunE(o CommandOptions, f util.Factory) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if err := o.Complete(f, cmd, args); err != nil {
@@ -58,19 +58,19 @@ func WrapRunE(o CommandOptions, f util.Factory) func(cmd *cobra.Command, args []
 	}
 }
 
-// NewOptions returns initialized Options
+// NewOptions returns initialized Options.
 func NewOptions(ioStreams util.IOStreams) *Options {
 	return &Options{
 		IOStreams: ioStreams,
 	}
 }
 
-// AddFlags adds flags to adjust the output to a cobra command
+// AddFlags adds flags to adjust the output to a cobra command.
 func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.Output, "output", "o", o.Output, "One of 'yaml' or 'json'.")
 }
 
-// PrintObject prints an object to IOStreams.out, using o.Output to print in the selected output format
+// PrintObject prints an object to IOStreams.out, using o.Output to print in the selected output format.
 func (o *Options) PrintObject(obj interface{}) error {
 	switch o.Output {
 	case "":

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -51,7 +51,7 @@ func Execute() {
 	}
 }
 
-// NewDefaultGardenctlCommand creates the `gardenctl` command with defaults
+// NewDefaultGardenctlCommand creates the `gardenctl` command with defaults.
 func NewDefaultGardenctlCommand() *cobra.Command {
 	factory := util.FactoryImpl{
 		TargetFlags: target.NewTargetFlags("", "", "", "", false),
@@ -61,7 +61,7 @@ func NewDefaultGardenctlCommand() *cobra.Command {
 	return NewGardenctlCommand(&factory, ioStreams)
 }
 
-// NewGardenctlCommand creates the `gardenctl` command
+// NewGardenctlCommand creates the `gardenctl` command.
 func NewGardenctlCommand(f *util.FactoryImpl, ioStreams util.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gardenctl",
@@ -241,7 +241,7 @@ func shootFlagCompletionFunc(ctx context.Context, manager target.Manager) ([]str
 	return util.ShootNamesForTarget(ctx, manager)
 }
 
-// addKlogFlags adds flags from k8s.io/klog
+// addKlogFlags adds flags from k8s.io/klog.
 func addKlogFlags(fs *pflag.FlagSet) {
 	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	klog.InitFlags(local)

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -203,13 +203,14 @@ func registerCompletionFuncForGlobalFlags(cmd *cobra.Command, f *util.FactoryImp
 	utilruntime.Must(cmd.RegisterFlagCompletionFunc("shoot", completionWrapper(f, ioStreams, shootFlagCompletionFunc)))
 }
 
-type cobraCompletionFunc func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
-type cobraCompletionFuncWithError func(ctx context.Context, manager target.Manager) ([]string, error)
+type (
+	cobraCompletionFunc          func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+	cobraCompletionFuncWithError func(ctx context.Context, manager target.Manager) ([]string, error)
+)
 
 func completionWrapper(f *util.FactoryImpl, ioStreams util.IOStreams, completer cobraCompletionFuncWithError) cobraCompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		manager, err := f.Manager()
-
 		if err != nil {
 			fmt.Fprintf(ioStreams.ErrOut, "%v\n", err)
 			return nil, cobra.ShellCompDirectiveNoFileComp

--- a/pkg/cmd/config/config_suite_test.go
+++ b/pkg/cmd/config/config_suite_test.go
@@ -77,7 +77,8 @@ var _ = BeforeEach(func() {
 				Name:       gardenIdentity2,
 				Kubeconfig: kubeconfig,
 				Patterns:   patterns,
-			}},
+			},
+		},
 	}
 
 	streams, _, out, errOut = util.NewTestIOStreams()

--- a/pkg/cmd/config/delete_garden.go
+++ b/pkg/cmd/config/delete_garden.go
@@ -61,7 +61,7 @@ func (o *deleteGardenOptions) Complete(f util.Factory, cmd *cobra.Command, args 
 	return nil
 }
 
-// Validate validates the provided options
+// Validate validates the provided options.
 func (o *deleteGardenOptions) Validate() error {
 	if o.Name == "" {
 		return errors.New("garden identity is required")
@@ -70,7 +70,7 @@ func (o *deleteGardenOptions) Validate() error {
 	return nil
 }
 
-// Run executes the command
+// Run executes the command.
 func (o *deleteGardenOptions) Run(_ util.Factory) error {
 	i, ok := o.Configuration.IndexOfGarden(o.Name)
 	if !ok {

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -87,7 +87,7 @@ func (o *setGardenOptions) Complete(f util.Factory, cmd *cobra.Command, args []s
 	return nil
 }
 
-// Validate validates the provided options
+// Validate validates the provided options.
 func (o *setGardenOptions) Validate() error {
 	if o.Name == "" {
 		return errors.New("garden identity is required")
@@ -100,7 +100,7 @@ func (o *setGardenOptions) Validate() error {
 	return nil
 }
 
-// AddFlags adds flags to adjust the output to a cobra command
+// AddFlags adds flags to adjust the output to a cobra command.
 func (o *setGardenOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.Var(&o.KubeconfigFlag, "kubeconfig", "path to kubeconfig file for this Garden cluster")
 	flags.Var(&o.ContextFlag, "context", "override the current-context of the garden cluster kubeconfig")
@@ -111,7 +111,7 @@ Note that if you set this flag it will overwrite the pattern list in the config 
 You may specify any number of extra patterns.`)
 }
 
-// Run executes the command
+// Run executes the command.
 func (o *setGardenOptions) Run(_ util.Factory) error {
 	garden, err := o.Configuration.Garden(o.Name)
 	if err == nil {

--- a/pkg/cmd/config/view.go
+++ b/pkg/cmd/config/view.go
@@ -56,7 +56,7 @@ func (o *viewOptions) Complete(f util.Factory, cmd *cobra.Command, args []string
 	return nil
 }
 
-// Run executes the command
+// Run executes the command.
 func (o *viewOptions) Run(_ util.Factory) error {
 	return o.PrintObject(o.Configuration)
 }

--- a/pkg/cmd/env/env_suite_test.go
+++ b/pkg/cmd/env/env_suite_test.go
@@ -48,7 +48,7 @@ var _ = AfterSuite(func() {
 func makeTempGardenHomeDir() string {
 	dir, err := os.MkdirTemp("", "garden-*")
 	Expect(err).NotTo(HaveOccurred())
-	Expect(os.Mkdir(filepath.Join(dir, "templates"), 0777)).NotTo(HaveOccurred())
+	Expect(os.Mkdir(filepath.Join(dir, "templates"), 0o777)).NotTo(HaveOccurred())
 
 	return dir
 }
@@ -63,7 +63,7 @@ func readTestFile(filename string) string {
 }
 
 func writeTempFile(filename string, content string) {
-	err := os.WriteFile(filepath.Join(gardenHomeDir, filename), []byte(content), 0777)
+	err := os.WriteFile(filepath.Join(gardenHomeDir, filename), []byte(content), 0o777)
 	Expect(err).NotTo(HaveOccurred())
 }
 

--- a/pkg/cmd/env/env_test.go
+++ b/pkg/cmd/env/env_test.go
@@ -36,7 +36,6 @@ var _ = Describe("Env Commands", func() {
 	})
 
 	Describe("given a ProviderEnv instance", func() {
-
 		BeforeEach(func() {
 			cmd = env.NewCmdProviderEnv(factory, streams)
 		})
@@ -57,7 +56,6 @@ var _ = Describe("Env Commands", func() {
 				Expect(s).To(BeElementOf(env.ValidShells))
 			}
 		})
-
 	})
 
 	Describe("given a KubectlEnv instance", func() {

--- a/pkg/cmd/env/options.go
+++ b/pkg/cmd/env/options.go
@@ -64,6 +64,7 @@ func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) er
 	o.GardenDir = f.GardenHomeDir()
 	o.Template = newTemplate("helpers")
 
+	//nolint:gocritic // accept singleCaseSwitch to be consistent with rest of the file. Will be resolved once we refactor to have own options for each provider type
 	switch o.ProviderType {
 	case "kubernetes":
 		filename := filepath.Join(o.GardenDir, "templates", "kubernetes.tmpl")

--- a/pkg/cmd/env/options.go
+++ b/pkg/cmd/env/options.go
@@ -384,7 +384,7 @@ func createProviderConfigDir(sessionDir string, providerType string) (string, er
 	cli := getProviderCLI(providerType)
 	configDir := filepath.Join(sessionDir, ".config", cli)
 
-	err := os.MkdirAll(configDir, 0700)
+	err := os.MkdirAll(configDir, 0o700)
 	if err != nil {
 		return "", fmt.Errorf("failed to create %s configuration directory: %w", cli, err)
 	}

--- a/pkg/cmd/env/options.go
+++ b/pkg/cmd/env/options.go
@@ -394,7 +394,7 @@ func createProviderConfigDir(sessionDir string, providerType string) (string, er
 
 func (o *options) checkAccessRestrictions(cfg *config.Config, gardenName string, shoot *gardencorev1beta1.Shoot) (ac.AccessRestrictionMessages, error) {
 	if cfg == nil {
-		return nil, errors.New("Garden configuration is required")
+		return nil, errors.New("garden configuration is required")
 	}
 
 	garden, err := cfg.Garden(gardenName)

--- a/pkg/cmd/env/options_test.go
+++ b/pkg/cmd/env/options_test.go
@@ -82,11 +82,9 @@ var _ = Describe("Env Commands - Options", func() {
 		})
 
 		Describe("completing the command options", func() {
-			var (
-				root,
+			var root,
 				parent,
 				child *cobra.Command
-			)
 
 			BeforeEach(func() {
 				root = &cobra.Command{Use: "root"}
@@ -242,7 +240,7 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				Context("because reading kubeconfig fails", func() {
-					var err = errors.New("error")
+					err := errors.New("error")
 
 					BeforeEach(func() {
 						currentTarget = t.WithGardenName("test")
@@ -865,5 +863,4 @@ var _ = Describe("Env Commands - Options", func() {
 		Entry("when provider is gcp", "gcp", "gcloud"),
 		Entry("when provider is kubernetes", "kubernetes", "kubectl"),
 	)
-
 })

--- a/pkg/cmd/env/shell.go
+++ b/pkg/cmd/env/shell.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 )
 
-// Shell represents the type of shell
+// Shell represents the type of shell.
 type Shell string
 
 const (
@@ -22,7 +22,7 @@ const (
 
 var validShells = []Shell{bash, zsh, fish, powershell}
 
-// EvalCommand returns the script that evaluates the given command
+// EvalCommand returns the script that evaluates the given command.
 func (s Shell) EvalCommand(cmd string) string {
 	var format string
 
@@ -39,7 +39,7 @@ func (s Shell) EvalCommand(cmd string) string {
 	return fmt.Sprintf(format, cmd)
 }
 
-// Prompt returns the typical prompt for a given os
+// Prompt returns the typical prompt for a given os.
 func (s Shell) Prompt(goos string) string {
 	switch s {
 	case powershell:
@@ -53,7 +53,7 @@ func (s Shell) Prompt(goos string) string {
 	}
 }
 
-// Validate checks if the shell is valid
+// Validate checks if the shell is valid.
 func (s Shell) Validate() error {
 	for _, shell := range validShells {
 		if s == shell {

--- a/pkg/cmd/env/template.go
+++ b/pkg/cmd/env/template.go
@@ -28,7 +28,7 @@ var fsys embed.FS
 
 //go:generate mockgen -destination=./mocks/mock_template.go -package=mocks github.com/gardener/gardenctl-v2/pkg/cmd/env Template
 
-// Template provides an abstraction for go templates
+// Template provides an abstraction for go templates.
 type Template interface {
 	// ParseFiles parses the named files and associates the resulting templates with t.
 	ParseFiles(filenames ...string) error
@@ -79,7 +79,7 @@ func (t *templateImpl) ExecuteTemplate(wr io.Writer, shell string, data interfac
 	return t.delegate.ExecuteTemplate(wr, shell, data)
 }
 
-// Delegate returns the wrapped go template
+// Delegate returns the wrapped go template.
 func (t *templateImpl) Delegate() *template.Template {
 	return t.delegate
 }

--- a/pkg/cmd/env/template_test.go
+++ b/pkg/cmd/env/template_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Env Commands - Template", func() {
 # Run this command to reset the kubectl configuration for your shell:
 # eval $(gardenctl kubectl-env -u %[1]s)
 `
-		var pathToKubeconfig = "/path/to/.kube/config"
+		pathToKubeconfig := "/path/to/.kube/config"
 
 		BeforeEach(func() {
 			providerType = "kubernetes"
@@ -312,5 +312,4 @@ Remove-Item -ErrorAction SilentlyContinue Env:\AZURE_CONFIG_DIR;
 			Expect(t.ParseFiles("invalid")).To(MatchError("embedded template \"invalid\" does not exist"))
 		})
 	})
-
 })

--- a/pkg/cmd/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kubeconfig/kubeconfig.go
@@ -53,7 +53,7 @@ gardenctl kubeconfig --garden my-garden --project my-project`,
 	return cmd
 }
 
-// options is a struct to support kubeconfig command
+// options is a struct to support kubeconfig command.
 type options struct {
 	base.Options
 
@@ -76,7 +76,7 @@ type options struct {
 	RawConfig *clientcmdapi.Config
 }
 
-// newOptions returns initialized options
+// newOptions returns initialized options.
 func newOptions(ioStreams util.IOStreams) *options {
 	return &options{
 		Options: base.Options{

--- a/pkg/cmd/kubeconfig/kubeconfig_test.go
+++ b/pkg/cmd/kubeconfig/kubeconfig_test.go
@@ -211,7 +211,7 @@ users:
 				})
 
 				Context("when an error occurs during PrintObject", func() {
-					var err = errors.New("error")
+					err := errors.New("error")
 
 					It("should fail with an error", func() {
 						options.PrintObject = func(_ runtime.Object, _ io.Writer) error {

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -490,7 +490,7 @@ func (o *SSHOptions) Run(f util.Factory) error {
 
 	if o.NodeName != "" {
 		node, err := getShootNode(ctx, o, shootClient)
-		if err == nil {
+		if err == nil { //nolint:gocritic // rewrite if-else to switch statement does not make sense as anonymous switch statements should never be cuddled
 			nodeHostname, err = getNodeHostname(node)
 			if err != nil {
 				return err
@@ -579,11 +579,12 @@ func (o *SSHOptions) Run(f util.Factory) error {
 	ingress := bastion.Status.Ingress
 	printAddr := ""
 
-	if ingress.Hostname != "" && ingress.IP != "" {
+	switch {
+	case ingress.Hostname != "" && ingress.IP != "":
 		printAddr = fmt.Sprintf("%s (%s)", ingress.IP, ingress.Hostname)
-	} else if ingress.Hostname != "" {
+	case ingress.Hostname != "":
 		printAddr = ingress.Hostname
-	} else {
+	default:
 		printAddr = ingress.IP
 	}
 

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -63,7 +63,7 @@ const (
 	SSHPort = 22
 )
 
-// wrappers used for unit tests only
+// wrappers used for unit tests only.
 var (
 	// keepAliveInterval is the interval in which bastions should be given the
 	// keep-alive annotation to prolong their lifetime.
@@ -73,7 +73,7 @@ var (
 	// pollBastionStatusInterval is the time in-between status checks on the bastion object.
 	pollBastionStatusInterval = 5 * time.Second
 
-	// tempFileCreator creates and opens a temporary file
+	// tempFileCreator creates and opens a temporary file.
 	tempFileCreator = func() (*os.File, error) {
 		return os.CreateTemp(os.TempDir(), "gctlv2*")
 	}
@@ -201,7 +201,7 @@ type SSHOptions struct {
 	KeepBastion bool
 }
 
-// NewSSHOptions returns initialized SSHOptions
+// NewSSHOptions returns initialized SSHOptions.
 func NewSSHOptions(ioStreams util.IOStreams) *SSHOptions {
 	return &SSHOptions{
 		Options: base.Options{
@@ -290,7 +290,7 @@ func ipToCIDR(address string) string {
 	return ipnet.String()
 }
 
-// Validate validates the provided SSHOptions
+// Validate validates the provided SSHOptions.
 func (o *SSHOptions) Validate() error {
 	if o.WaitTimeout == 0 {
 		return errors.New("the maximum wait duration must be non-zero")

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
-	cryptossh "golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -311,7 +310,7 @@ func (o *SSHOptions) Validate() error {
 		return fmt.Errorf("invalid SSH public key file: %w", err)
 	}
 
-	if _, _, _, _, err := cryptossh.ParseAuthorizedKey(content); err != nil {
+	if _, _, _, _, err := ssh.ParseAuthorizedKey(content); err != nil {
 		return fmt.Errorf("invalid SSH public key file: %w", err)
 	}
 
@@ -1081,11 +1080,11 @@ func getNodes(ctx context.Context, c client.Client) ([]corev1.Node, error) {
 
 func (o *SSHOptions) checkAccessRestrictions(cfg *config.Config, gardenName string, tf target.TargetFlags, shoot *gardencorev1beta1.Shoot) (bool, error) {
 	if cfg == nil {
-		return false, errors.New("Garden configuration is required")
+		return false, errors.New("garden configuration is required")
 	}
 
 	if tf == nil {
-		return false, errors.New("Target flags are required")
+		return false, errors.New("target flags are required")
 	}
 
 	// handle access restrictions

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -383,7 +383,7 @@ func encodePublicKey(publicKey ssh.PublicKey) []byte {
 }
 
 func writeKeyFile(filename string, content []byte) error {
-	if err := os.WriteFile(filename, content, 0600); err != nil {
+	if err := os.WriteFile(filename, content, 0o600); err != nil {
 		return fmt.Errorf("failed to write %q: %w", filename, err)
 	}
 

--- a/pkg/cmd/ssh/ssh.go
+++ b/pkg/cmd/ssh/ssh.go
@@ -54,8 +54,10 @@ func registerCompletionFuncForFlags(cmd *cobra.Command, f util.Factory, ioStream
 	utilruntime.Must(cmd.RegisterFlagCompletionFunc("cidr", completionWrapper(f, ioStreams, cidrFlagCompletionFunc)))
 }
 
-type cobraCompletionFunc func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
-type cobraCompletionFuncWithError func(f util.Factory) ([]string, error)
+type (
+	cobraCompletionFunc          func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+	cobraCompletionFuncWithError func(f util.Factory) ([]string, error)
+)
 
 func completionWrapper(f util.Factory, ioStreams util.IOStreams, completer cobraCompletionFuncWithError) cobraCompletionFunc {
 	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -546,7 +546,7 @@ var _ = Describe("SSH Options", func() {
 	})
 
 	It("should require a valid public SSH key file", func() {
-		Expect(os.WriteFile(publicSSHKeyFile, []byte("not a key"), 0644)).To(Succeed())
+		Expect(os.WriteFile(publicSSHKeyFile, []byte("not a key"), 0o644)).To(Succeed())
 
 		o := ssh.NewSSHOptions(streams)
 		o.CIDRs = []string{"8.8.8.8/32"}

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -144,16 +144,18 @@ func (o *TargetOptions) Complete(f util.Factory, cmd *cobra.Command, args []stri
 	}
 
 	tf := manager.TargetFlags()
+
 	if o.Kind == "" {
-		if tf.ControlPlane() {
+		switch {
+		case tf.ControlPlane():
 			o.Kind = TargetKindControlPlane
-		} else if tf.ShootName() != "" {
+		case tf.ShootName() != "":
 			o.Kind = TargetKindShoot
-		} else if tf.ProjectName() != "" {
+		case tf.ProjectName() != "":
 			o.Kind = TargetKindProject
-		} else if tf.SeedName() != "" {
+		case tf.SeedName() != "":
 			o.Kind = TargetKindSeed
-		} else if tf.GardenName() != "" {
+		case tf.GardenName() != "":
 			o.Kind = TargetKindGarden
 		}
 	}

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -119,7 +119,7 @@ type TargetOptions struct {
 	TargetName string
 }
 
-// NewTargetOptions returns initialized TargetOptions
+// NewTargetOptions returns initialized TargetOptions.
 func NewTargetOptions(ioStreams util.IOStreams) *TargetOptions {
 	return &TargetOptions{
 		Options: base.Options{
@@ -176,7 +176,7 @@ func (o *TargetOptions) Complete(f util.Factory, cmd *cobra.Command, args []stri
 	return nil
 }
 
-// Validate validates the provided options
+// Validate validates the provided options.
 func (o *TargetOptions) Validate() error {
 	switch o.Kind {
 	case TargetKindControlPlane:
@@ -190,7 +190,7 @@ func (o *TargetOptions) Validate() error {
 	return nil
 }
 
-// Run executes the command
+// Run executes the command.
 func (o *TargetOptions) Run(f util.Factory) error {
 	manager, err := f.Manager()
 	if err != nil {

--- a/pkg/cmd/target/unset.go
+++ b/pkg/cmd/target/unset.go
@@ -62,9 +62,7 @@ func (o *UnsetOptions) Complete(_ util.Factory, cmd *cobra.Command, args []strin
 	return nil
 }
 
-var (
-	AllTargetKinds = []TargetKind{TargetKindGarden, TargetKindProject, TargetKindSeed, TargetKindShoot, TargetKindPattern, TargetKindControlPlane}
-)
+var AllTargetKinds = []TargetKind{TargetKindGarden, TargetKindProject, TargetKindSeed, TargetKindShoot, TargetKindPattern, TargetKindControlPlane}
 
 func ValidateKind(kind TargetKind) error {
 	for _, k := range AllTargetKinds {

--- a/pkg/cmd/target/unset.go
+++ b/pkg/cmd/target/unset.go
@@ -45,7 +45,7 @@ gardenctl target unset garden`,
 	return cmd
 }
 
-// UnsetOptions is a struct to support unset command
+// UnsetOptions is a struct to support unset command.
 type UnsetOptions struct {
 	base.Options
 
@@ -76,7 +76,7 @@ func ValidateKind(kind TargetKind) error {
 	return fmt.Errorf("invalid target kind given, must be one of %v", AllTargetKinds)
 }
 
-// Validate validates the provided options
+// Validate validates the provided options.
 func (o *UnsetOptions) Validate() error {
 	if err := ValidateKind(o.Kind); err != nil {
 		return err
@@ -85,7 +85,7 @@ func (o *UnsetOptions) Validate() error {
 	return nil
 }
 
-// Run executes the command
+// Run executes the command.
 func (o *UnsetOptions) Run(f util.Factory) error {
 	manager, err := f.Manager()
 	if err != nil {

--- a/pkg/cmd/target/view.go
+++ b/pkg/cmd/target/view.go
@@ -57,7 +57,7 @@ func runViewCommand(f util.Factory, opt *ViewOptions) error {
 	return opt.PrintObject(currentTarget)
 }
 
-// ViewOptions is a struct to support view command
+// ViewOptions is a struct to support view command.
 type ViewOptions struct {
 	base.Options
 }

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -66,7 +66,7 @@ type VersionOptions struct {
 	Short bool
 }
 
-// NewVersionOptions returns initialized VersionOptions
+// NewVersionOptions returns initialized VersionOptions.
 func NewVersionOptions(ioStreams util.IOStreams) *VersionOptions {
 	return &VersionOptions{
 		Options: base.Options{
@@ -75,7 +75,7 @@ func NewVersionOptions(ioStreams util.IOStreams) *VersionOptions {
 	}
 }
 
-// AddFlags adds flags to adjust the output to a cobra command
+// AddFlags adds flags to adjust the output to a cobra command.
 func (o *VersionOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.Short, "short", o.Short, "If true, print just the version number.")
 	o.Options.AddFlags(flags)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,12 +108,12 @@ func (config *Config) SymlinkTargetKubeconfig() bool {
 func (config *Config) Save() error {
 	dir := filepath.Dir(config.Filename)
 
-	err := os.MkdirAll(dir, 0700)
+	err := os.MkdirAll(dir, 0o700)
 	if err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	f, err := os.OpenFile(config.Filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	f, err := os.OpenFile(config.Filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/ac"
 )
 
-// Config holds the gardenctl configuration
+// Config holds the gardenctl configuration.
 type Config struct {
 	// Filename is the name of the gardenctl configuration file
 	Filename string `yaml:"-" json:"-"`
@@ -32,7 +32,7 @@ type Config struct {
 	Gardens []Garden `yaml:"gardens" json:"gardens"`
 }
 
-// Garden represents one garden cluster
+// Garden represents one garden cluster.
 type Garden struct {
 	// Name is a unique identifier of this Garden that can be used to target this Garden
 	Name string `yaml:"identity" json:"identity"`
@@ -50,7 +50,7 @@ type Garden struct {
 	AccessRestrictions []ac.AccessRestriction `yaml:"accessRestrictions,omitempty" json:"accessRestrictions,omitempty"`
 }
 
-// LoadFromFile parses a gardenctl config file and returns a Config struct
+// LoadFromFile parses a gardenctl config file and returns a Config struct.
 func LoadFromFile(filename string) (*Config, error) {
 	config := &Config{Filename: filename}
 
@@ -99,12 +99,12 @@ func LoadFromFile(filename string) (*Config, error) {
 	return config, nil
 }
 
-// SymlinkTargetKubeconfig indicates if the kubeconfig of the current target should be always symlinked
+// SymlinkTargetKubeconfig indicates if the kubeconfig of the current target should be always symlinked.
 func (config *Config) SymlinkTargetKubeconfig() bool {
 	return config.LinkKubeconfig == nil || *config.LinkKubeconfig
 }
 
-// Save updates a gardenctl config file with the values passed via Config struct
+// Save updates a gardenctl config file with the values passed via Config struct.
 func (config *Config) Save() error {
 	dir := filepath.Dir(config.Filename)
 
@@ -126,8 +126,8 @@ func (config *Config) Save() error {
 	return nil
 }
 
-// IndexOfGarden returns the index of the Garden with the given name in the configured Gardens slice
-// If no Garden with this name is found it returns -1
+// IndexOfGarden returns the index of the Garden with the given name in the configured Gardens slice.
+// If no Garden with this name is found it returns -1.
 func (config *Config) IndexOfGarden(name string) (int, bool) {
 	for i, g := range config.Gardens {
 		if g.Name == name {
@@ -138,7 +138,7 @@ func (config *Config) IndexOfGarden(name string) (int, bool) {
 	return -1, false
 }
 
-// GardenNames returns a slice containing the names of the configured Gardens
+// GardenNames returns a slice containing the names of the configured Gardens.
 func (config *Config) GardenNames() []string {
 	names := []string{}
 	for _, g := range config.Gardens {
@@ -148,7 +148,7 @@ func (config *Config) GardenNames() []string {
 	return names
 }
 
-// Garden returns a Garden cluster from the list of configured Gardens
+// Garden returns a Garden cluster from the list of configured Gardens.
 func (config *Config) Garden(name string) (*Garden, error) {
 	i, ok := config.IndexOfGarden(name)
 	if !ok {
@@ -158,7 +158,7 @@ func (config *Config) Garden(name string) (*Garden, error) {
 	return &config.Gardens[i], nil
 }
 
-// ClientConfig returns a deferred loading client config for a configured garden cluster
+// ClientConfig returns a deferred loading client config for a configured garden cluster.
 func (config *Config) ClientConfig(name string) (clientcmd.ClientConfig, error) {
 	garden, err := config.Garden(name)
 	if err != nil {
@@ -175,7 +175,7 @@ func (config *Config) ClientConfig(name string) (clientcmd.ClientConfig, error) 
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, overrides), nil
 }
 
-// DirectClientConfig returns a directly loaded client config for a configured garden cluster
+// DirectClientConfig returns a directly loaded client config for a configured garden cluster.
 func (config *Config) DirectClientConfig(name string) (clientcmd.ClientConfig, error) {
 	garden, err := config.Garden(name)
 	if err != nil {
@@ -190,7 +190,7 @@ func (config *Config) DirectClientConfig(name string) (clientcmd.ClientConfig, e
 	return clientcmd.NewDefaultClientConfig(*rawConfig, nil), nil
 }
 
-// LoadRawConfig directly loads the raw config from file, validates the content and removes all the irrelevant pieces
+// LoadRawConfig directly loads the raw config from file, validates the content and removes all the irrelevant pieces.
 func (g *Garden) LoadRawConfig() (*clientcmdapi.Config, error) {
 	rawConfig, err := clientcmd.LoadFromFile(g.Kubeconfig)
 	if err != nil {
@@ -215,7 +215,7 @@ func (g *Garden) LoadRawConfig() (*clientcmdapi.Config, error) {
 	return rawConfig, nil
 }
 
-// PatternMatch holds (target) values extracted from a provided string
+// PatternMatch holds (target) values extracted from a provided string.
 type PatternMatch struct {
 	// Garden is the matched Garden
 	Garden string
@@ -227,20 +227,20 @@ type PatternMatch struct {
 	Shoot string
 }
 
-// PatternKey is a key that can be used to identify a value in a pattern
+// PatternKey is a key that can be used to identify a value in a pattern.
 type PatternKey string
 
 const (
-	// PatternKeyProject is used to identify a Project
+	// PatternKeyProject is used to identify a Project.
 	PatternKeyProject = PatternKey("project")
-	// PatternKeyNamespace is used to identify a Project by the namespace it refers to
+	// PatternKeyNamespace is used to identify a Project by the namespace it refers to.
 	PatternKeyNamespace = PatternKey("namespace")
-	// PatternKeyShoot is used to identify a Shoot
+	// PatternKeyShoot is used to identify a Shoot.
 	PatternKeyShoot = PatternKey("shoot")
 )
 
-// MatchPattern matches a string against patterns defined in gardenctl config
-// If matched, the function creates and returns a PatternMatch from the provided target string
+// MatchPattern matches a string against patterns defined in gardenctl config.
+// If matched, the function creates and returns a PatternMatch from the provided target string.
 func (config *Config) MatchPattern(preferredGardenName string, value string) (*PatternMatch, error) {
 	if preferredGardenName != "" {
 		g, err := config.Garden(preferredGardenName)
@@ -285,8 +285,8 @@ func (config *Config) MatchPattern(preferredGardenName string, value string) (*P
 	return patternMatch, nil
 }
 
-// matchPattern matches pattern with provided list of patterns
-// If none of the provided patterns matches the given value no error is returned
+// matchPattern matches pattern with provided list of patterns.
+// If none of the provided patterns matches the given value no error is returned.
 func matchPattern(patterns []string, value string) (*PatternMatch, error) {
 	for _, p := range patterns {
 		r, err := regexp.Compile(p)

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -19,9 +19,7 @@ func TestConfiguration(t *testing.T) {
 	RunSpecs(t, "Config Test Suite")
 }
 
-var (
-	gardenHomeDir string
-)
+var gardenHomeDir string
 
 var _ = BeforeSuite(func() {
 	dir, err := os.MkdirTemp("", "garden-*")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,11 +45,12 @@ var _ = Describe("Config", func() {
 					Patterns: []string{
 						fmt.Sprintf("^(%s/)?shoot--(?P<project>.+)--(?P<shoot>.+)$", clusterIdentity2),
 					},
-				}},
+				},
+			},
 		}
 	})
 
-	var patternValue = func(prefix string) string {
+	patternValue := func(prefix string) string {
 		value := fmt.Sprintf("shoot--%s--%s", project, shoot)
 
 		if prefix != "" {
@@ -125,7 +126,6 @@ var _ = Describe("Config", func() {
 		garden, err := cfg.Garden(clusterIdentity1)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(garden.Name).Should(Equal(clusterIdentity1))
-
 	})
 
 	It("should throw an error if garden not found", func() {

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -507,7 +507,7 @@ func (m *managerImpl) WriteClientConfig(config clientcmd.ClientConfig) (string, 
 
 	filename := filepath.Join(m.sessionDirectory, fmt.Sprintf("kubeconfig.%x.yaml", md5.Sum(data)))
 
-	err = os.WriteFile(filename, data, 0600)
+	err = os.WriteFile(filename, data, 0o600)
 	if err != nil {
 		return "", fmt.Errorf("failed to write temporary kubeconfig file to %s: %w", filename, err)
 	}

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -33,7 +33,7 @@ var (
 
 //go:generate mockgen -destination=./mocks/mock_manager.go -package=mocks github.com/gardener/gardenctl-v2/pkg/target Manager
 
-// Manager sets and gets the current target configuration
+// Manager sets and gets the current target configuration.
 type Manager interface {
 	// CurrentTarget contains the current target configuration
 	CurrentTarget() (Target, error)
@@ -116,7 +116,7 @@ func newGardenClient(name string, config *config.Config, provider ClientProvider
 	return gardenclient.NewGardenClient(client, name), nil
 }
 
-// NewManager returns a new manager
+// NewManager returns a new manager.
 func NewManager(config *config.Config, targetProvider TargetProvider, clientProvider ClientProvider, sessionDirectory string) (Manager, error) {
 	return &managerImpl{
 		config:           config,

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -74,7 +74,7 @@ type Manager interface {
 	// of a pattern
 	TargetMatchPattern(ctx context.Context, value string) error
 
-	//ClientConfig returns the client config for a target
+	// ClientConfig returns the client config for a target
 	ClientConfig(ctx context.Context, t Target) (clientcmd.ClientConfig, error)
 	// WriteClientConfig creates a kubeconfig file in the session directory of the operating system
 	WriteClientConfig(config clientcmd.ClientConfig) (string, error)

--- a/pkg/target/target_builder.go
+++ b/pkg/target/target_builder.go
@@ -55,7 +55,7 @@ type targetBuilderImpl struct {
 
 var _ TargetBuilder = &targetBuilderImpl{}
 
-// NewTargetBuilder returns a new target builder
+// NewTargetBuilder returns a new target builder.
 func NewTargetBuilder(config *config.Config, clientProvider ClientProvider) (TargetBuilder, error) {
 	if config == nil {
 		return nil, errors.New("config must not be nil")
@@ -276,7 +276,7 @@ func (b *targetBuilderImpl) validateProject(ctx context.Context, gardenName stri
 	return project, nil
 }
 
-// getProjectNameByNamespace  returns the project name for the given namespace name
+// getProjectNameByNamespace returns the project name for the given namespace name.
 func (b *targetBuilderImpl) getProjectNameByNamespace(ctx context.Context, gardenName string, name string) (string, error) {
 	gardenClient, err := b.getGardenClient(gardenName)
 	if err != nil {

--- a/pkg/target/target_provider.go
+++ b/pkg/target/target_provider.go
@@ -80,7 +80,7 @@ func (p *fsTargetProvider) Read() (Target, error) {
 
 // Write takes a target and saves it permanently.
 func (p *fsTargetProvider) Write(t Target) error {
-	f, err := os.OpenFile(p.targetFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+	f, err := os.OpenFile(p.targetFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to create file: %w", err)
 	}

--- a/pkg/target/target_provider_test.go
+++ b/pkg/target/target_provider_test.go
@@ -77,7 +77,6 @@ var _ = Describe("Target Provider", func() {
 		Expect(target.SeedName()).To(Equal(t.SeedName()))
 		Expect(target.ShootName()).To(Equal(t.ShootName()))
 		Expect(target.ControlPlane()).To(Equal(t.ControlPlane()))
-
 	})
 })
 

--- a/pkg/target/target_suite_test.go
+++ b/pkg/target/target_suite_test.go
@@ -47,11 +47,11 @@ var _ = BeforeSuite(func() {
 	dir, err := os.MkdirTemp("", "garden-*")
 	Expect(err).NotTo(HaveOccurred())
 	sessionDir = filepath.Join(dir, uuid.New().String())
-	Expect(os.MkdirAll(sessionDir, 0700)).To(Succeed())
+	Expect(os.MkdirAll(sessionDir, 0o700)).To(Succeed())
 	gardenHomeDir = dir
 	gardenKubeconfig = filepath.Join(gardenHomeDir, "kubeconfig.yaml")
 	data := createTestKubeconfig(gardenName)
-	Expect(os.WriteFile(gardenKubeconfig, data, 0600)).To(Succeed())
+	Expect(os.WriteFile(gardenKubeconfig, data, 0o600)).To(Succeed())
 }, 60)
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the following linters. In addition the findings were fixed
- `gocritic` - Provides diagnostics that check for bugs, performance and style issues.
- `godot` - Check if comments end in a period
- [`gofumpt`](https://github.com/mvdan/gofumpt) - Gofumpt checks whether code was gofumpt-ed. This linter enforces a stricter format than gofmt, while being backwards compatible. Run `gofumpt -l -w .` to fix findings
- `misspell` - Finds commonly misspelled English words in comments
- `wastedassign` - wastedassign finds wasted assignment statements.

**Which issue(s) this PR fixes**:
Fixes #45

**Special notes for your reviewer**:
- Use the commit view for easier review as with one commit one linter was enabled and all findings fixed.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
