### PR TITLE
Bump golang from 1.19.2 to 1.19.4

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,11 +9,11 @@ gardenctl-v2:
         inject_effective_version: true
     steps:
       check:
-        image: 'golang:1.19.2'
+        image: 'golang:1.19.4'
       test:
-        image: 'golang:1.19.2'
+        image: 'golang:1.19.4'
       build:
-        image: 'golang:1.19.2'
+        image: 'golang:1.19.4'
         output_dir: 'binary'
         timeout: '5m'
 

--- a/.github/workflows/update-gardenctl-v2.yaml
+++ b/.github/workflows/update-gardenctl-v2.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # pin@v3.1.0
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
         with:
-          go-version: '1.19.2'
+          go-version: '1.19.4'
       - name: Build the binary-files
         id: build_binary_files
         run: |


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps golang from 1.19.2 to 1.19.4.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
