### PR TITLE
reuse cidr flag completion from ssh cmd for ssh-patch

### DIFF
--- a/docs/help/gardenctl_ssh-patch.md
+++ b/docs/help/gardenctl_ssh-patch.md
@@ -20,7 +20,12 @@ gardenctl ssh-patch cli-xxxxxxxx
 
 ```
       --cidr stringArray   CIDRs to allow access to the bastion host; if not given, your system's public IPs (v4 and v6) are auto-detected.
+      --control-plane      target control plane of shoot, use together with shoot argument
+      --garden string      target the given garden cluster
   -h, --help               help for ssh-patch
+      --project string     target the given project
+      --seed string        target the given seed cluster
+      --shoot string       target the given shoot cluster
 ```
 
 ### Options inherited from parent commands

--- a/pkg/cmd/base/options.go
+++ b/pkg/cmd/base/options.go
@@ -20,16 +20,14 @@ import (
 
 //go:generate mockgen -destination=./mocks/mock_options.go -package=mocks github.com/gardener/gardenctl-v2/pkg/cmd/base CommandOptions
 
-// CommandOptions is the base interface for command options.
-type CommandOptions interface {
+// Runnable is the base interface for command options.
+type Runnable interface {
 	// Complete adapts from the command line args to the data required.
 	Complete(util.Factory, *cobra.Command, []string) error
 	// Validate validates the provided options.
 	Validate() error
 	// Run does the actual work of the command.
 	Run(util.Factory) error
-	// AddFlags adds flags to adjust the output to a cobra command.
-	AddFlags(*pflag.FlagSet)
 }
 
 // Options contains all settings that are used across all commands in gardenctl.
@@ -41,10 +39,10 @@ type Options struct {
 	Output string
 }
 
-var _ CommandOptions = &Options{}
+var _ Runnable = &Options{}
 
 // WrapRunE creates a cobra RunE function that has access to the factory.
-func WrapRunE(o CommandOptions, f util.Factory) func(cmd *cobra.Command, args []string) error {
+func WrapRunE(o Runnable, f util.Factory) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
 		if err := o.Complete(f, cmd, args); err != nil {
 			return fmt.Errorf("failed to complete command options: %w", err)

--- a/pkg/cmd/ssh/access_config.go
+++ b/pkg/cmd/ssh/access_config.go
@@ -1,3 +1,9 @@
+/*
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package ssh
 
 import (
@@ -9,15 +15,14 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
-	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 )
 
-// AccessConfig is a struct used by all ssh related commands.
+// AccessConfig is a struct that is embedded in the options of ssh related commands.
 type AccessConfig struct {
-	base.Options
-
 	// CIDRs is a list of IP address ranges to be allowed for accessing the
 	// created Bastion host. If not given, gardenctl will attempt to
 	// auto-detect the user's IP and allow only it (i.e. use a /32 netmask).
@@ -28,7 +33,7 @@ type AccessConfig struct {
 	AutoDetected bool
 }
 
-func (o *AccessConfig) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+func (o *AccessConfig) Complete(f util.Factory, cmd *cobra.Command, args []string, ioStreams util.IOStreams) error {
 	if len(o.CIDRs) == 0 {
 		ctx, cancel := context.WithTimeout(f.Context(), 60*time.Second)
 		defer cancel()
@@ -48,7 +53,7 @@ func (o *AccessConfig) Complete(f util.Factory, cmd *cobra.Command, args []strin
 			name = "CIDRs"
 		}
 
-		fmt.Fprintf(o.IOStreams.Out, "Auto-detected your system's %s as %s\n", name, strings.Join(cidrs, ", "))
+		fmt.Fprintf(ioStreams.Out, "Auto-detected your system's %s as %s\n", name, strings.Join(cidrs, ", "))
 
 		o.CIDRs = cidrs
 		o.AutoDetected = true
@@ -69,4 +74,77 @@ func (o *AccessConfig) Validate() error {
 	}
 
 	return nil
+}
+
+func (o *AccessConfig) AddFlags(flags *pflag.FlagSet) {
+	flags.StringArrayVar(&o.CIDRs, "cidr", nil, "CIDRs to allow access to the bastion host; if not given, your system's public IPs (v4 and v6) are auto-detected.")
+}
+
+type (
+	cobraCompletionFunc          func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+	cobraCompletionFuncWithError func(f util.Factory) ([]string, error)
+)
+
+func completionWrapper(f util.Factory, ioStreams util.IOStreams, completer cobraCompletionFuncWithError) cobraCompletionFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		result, err := completer(f)
+		if err != nil {
+			fmt.Fprintf(ioStreams.ErrOut, "%v\n", err)
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return util.FilterStringsByPrefix(toComplete, result), cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func RegisterCompletionFuncsForAccessConfigFlags(cmd *cobra.Command, factory util.Factory, ioStreams util.IOStreams, flags *pflag.FlagSet) {
+	utilruntime.Must(cmd.RegisterFlagCompletionFunc("cidr", completionWrapper(factory, ioStreams, cidrFlagCompletionFunc)))
+}
+
+func cidrFlagCompletionFunc(f util.Factory) ([]string, error) {
+	var addresses []string
+
+	ctx := f.Context()
+
+	publicIPs, err := f.PublicIPs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ip := range publicIPs {
+		cidr := ipToCIDR(ip)
+		addresses = append(addresses, fmt.Sprintf("%s\t<public>", cidr))
+	}
+
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+
+	includeFlags := net.FlagUp
+	excludeFlags := net.FlagLoopback
+
+	for _, iface := range interfaces {
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return nil, err
+		}
+
+		if is(iface, includeFlags) && isNot(iface, excludeFlags) {
+			for _, addr := range addrs {
+				addressComp := fmt.Sprintf("%s\t%s", addr.String(), iface.Name)
+				addresses = append(addresses, addressComp)
+			}
+		}
+	}
+
+	return addresses, nil
+}
+
+func is(i net.Interface, flags net.Flags) bool {
+	return i.Flags&flags != 0
+}
+
+func isNot(i net.Interface, flags net.Flags) bool {
+	return i.Flags&flags == 0
 }

--- a/pkg/cmd/ssh/access_config.go
+++ b/pkg/cmd/ssh/access_config.go
@@ -33,7 +33,7 @@ type AccessConfig struct {
 	AutoDetected bool
 }
 
-func (o *AccessConfig) Complete(f util.Factory, cmd *cobra.Command, args []string, ioStreams util.IOStreams) error {
+func (o *AccessConfig) Complete(f util.Factory, _ *cobra.Command, _ []string, ioStreams util.IOStreams) error {
 	if len(o.CIDRs) == 0 {
 		ctx, cancel := context.WithTimeout(f.Context(), 60*time.Second)
 		defer cancel()

--- a/pkg/cmd/ssh/ssh.go
+++ b/pkg/cmd/ssh/ssh.go
@@ -8,7 +8,6 @@ package ssh
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/spf13/cobra"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -40,87 +39,14 @@ func NewCmdSSH(f util.Factory, o *SSHOptions) *cobra.Command {
 		RunE: base.WrapRunE(o, f),
 	}
 
-	cmd.Flags().BoolVar(&o.Interactive, "interactive", o.Interactive, "Open an SSH connection instead of just providing the bastion host (only if NODE_NAME is provided).")
-	cmd.Flags().StringArrayVar(&o.CIDRs, "cidr", nil, "CIDRs to allow access to the bastion host; if not given, your system's public IPs (v4 and v6) are auto-detected.")
-	cmd.Flags().StringVar(&o.SSHPublicKeyFile, "public-key-file", "", "Path to the file that contains a public SSH key. If not given, a temporary keypair will be generated.")
-	cmd.Flags().DurationVar(&o.WaitTimeout, "wait-timeout", o.WaitTimeout, "Maximum duration to wait for the bastion to become available.")
-	cmd.Flags().BoolVar(&o.KeepBastion, "keep-bastion", o.KeepBastion, "Do not delete immediately when gardenctl exits (Bastions will be garbage-collected after some time)")
+	o.AddFlags(cmd.Flags())
+	o.AccessConfig.AddFlags(cmd.Flags())
+	RegisterCompletionFuncsForAccessConfigFlags(cmd, f, o.IOStreams, cmd.Flags())
 
 	manager, err := f.Manager()
 	utilruntime.Must(err)
 	manager.TargetFlags().AddFlags(cmd.Flags())
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, o.IOStreams, cmd.Flags())
 
-	registerCompletionFuncForFlags(cmd, f, o.IOStreams)
-
 	return cmd
-}
-
-func registerCompletionFuncForFlags(cmd *cobra.Command, f util.Factory, ioStreams util.IOStreams) {
-	utilruntime.Must(cmd.RegisterFlagCompletionFunc("cidr", completionWrapper(f, ioStreams, cidrFlagCompletionFunc)))
-}
-
-type (
-	cobraCompletionFunc          func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
-	cobraCompletionFuncWithError func(f util.Factory) ([]string, error)
-)
-
-func completionWrapper(f util.Factory, ioStreams util.IOStreams, completer cobraCompletionFuncWithError) cobraCompletionFunc {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		result, err := completer(f)
-		if err != nil {
-			fmt.Fprintf(ioStreams.ErrOut, "%v\n", err)
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		return util.FilterStringsByPrefix(toComplete, result), cobra.ShellCompDirectiveNoFileComp
-	}
-}
-
-func cidrFlagCompletionFunc(f util.Factory) ([]string, error) {
-	var addresses []string
-
-	ctx := f.Context()
-
-	publicIPs, err := f.PublicIPs(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, ip := range publicIPs {
-		cidr := ipToCIDR(ip)
-		addresses = append(addresses, fmt.Sprintf("%s\t<public>", cidr))
-	}
-
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		return nil, err
-	}
-
-	includeFlags := net.FlagUp
-	excludeFlags := net.FlagLoopback
-
-	for _, iface := range interfaces {
-		addrs, err := iface.Addrs()
-		if err != nil {
-			return nil, err
-		}
-
-		if is(iface, includeFlags) && isNot(iface, excludeFlags) {
-			for _, addr := range addrs {
-				addressComp := fmt.Sprintf("%s\t%s", addr.String(), iface.Name)
-				addresses = append(addresses, addressComp)
-			}
-		}
-	}
-
-	return addresses, nil
-}
-
-func is(i net.Interface, flags net.Flags) bool {
-	return i.Flags&flags != 0
-}
-
-func isNot(i net.Interface, flags net.Flags) bool {
-	return i.Flags&flags == 0
 }

--- a/pkg/cmd/sshpatch/bastionlistpatcher.go
+++ b/pkg/cmd/sshpatch/bastionlistpatcher.go
@@ -1,3 +1,9 @@
+/*
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package sshpatch
 
 import (

--- a/pkg/cmd/sshpatch/completions.go
+++ b/pkg/cmd/sshpatch/completions.go
@@ -1,3 +1,9 @@
+/*
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package sshpatch
 
 import (

--- a/pkg/cmd/sshpatch/export_test.go
+++ b/pkg/cmd/sshpatch/export_test.go
@@ -43,10 +43,9 @@ func NewTestOptions() *TestOptions {
 
 	return &TestOptions{
 		options: options{
-			AccessConfig: ssh.AccessConfig{
-				Options: base.Options{
-					IOStreams: streams,
-				},
+			AccessConfig: ssh.AccessConfig{},
+			Options: base.Options{
+				IOStreams: streams,
 			},
 		},
 		Out: out,

--- a/pkg/cmd/sshpatch/options.go
+++ b/pkg/cmd/sshpatch/options.go
@@ -1,3 +1,9 @@
+/*
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package sshpatch
 
 import (
@@ -9,7 +15,6 @@ import (
 
 	gardenoperationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	networkingv1 "k8s.io/api/networking/v1"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
@@ -18,6 +23,7 @@ import (
 )
 
 type options struct {
+	base.Options
 	ssh.AccessConfig
 
 	// Bastion is the Bastion corresponding to the provided BastionName
@@ -29,10 +35,9 @@ type options struct {
 
 func newOptions(ioStreams util.IOStreams) *options {
 	return &options{
-		AccessConfig: ssh.AccessConfig{
-			Options: base.Options{
-				IOStreams: ioStreams,
-			},
+		AccessConfig: ssh.AccessConfig{},
+		Options: base.Options{
+			IOStreams: ioStreams,
 		},
 	}
 }
@@ -111,7 +116,7 @@ func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) er
 
 	o.bastionPatcher = bastionListPatcher
 
-	if err := o.AccessConfig.Complete(f, cmd, args); err != nil {
+	if err := o.AccessConfig.Complete(f, cmd, args, o.Options.IOStreams); err != nil {
 		return err
 	}
 
@@ -152,6 +157,10 @@ func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) er
 }
 
 func (o *options) Validate() error {
+	if err := o.Options.Validate(); err != nil {
+		return err
+	}
+
 	if err := o.AccessConfig.Validate(); err != nil {
 		return err
 	}
@@ -161,8 +170,4 @@ func (o *options) Validate() error {
 	}
 
 	return nil
-}
-
-func (o *options) AddFlags(flags *pflag.FlagSet) {
-	flags.StringArrayVar(&o.CIDRs, "cidr", o.CIDRs, "CIDRs to allow access to the bastion host; if not given, your system's public IPs (v4 and v6) are auto-detected.")
 }

--- a/pkg/cmd/sshpatch/sshpatch.go
+++ b/pkg/cmd/sshpatch/sshpatch.go
@@ -1,12 +1,21 @@
+/*
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package sshpatch
 
 import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/ssh"
+	"github.com/gardener/gardenctl-v2/pkg/flags"
 )
 
 func NewCmdSSHPatch(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
@@ -37,7 +46,14 @@ gardenctl ssh-patch cli-xxxxxxxx`,
 		},
 	}
 
-	o.AddFlags(cmd.PersistentFlags())
+	o.AccessConfig.AddFlags(cmd.Flags())
+
+	ssh.RegisterCompletionFuncsForAccessConfigFlags(cmd, f, o.IOStreams, cmd.Flags())
+
+	manager, err := f.Manager()
+	utilruntime.Must(err)
+	manager.TargetFlags().AddFlags(cmd.Flags())
+	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, o.IOStreams, cmd.Flags())
 
 	return cmd
 }

--- a/pkg/cmd/sshpatch/sshpatch_test.go
+++ b/pkg/cmd/sshpatch/sshpatch_test.go
@@ -1,5 +1,5 @@
 /*
-SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Gardener contributors
 
 SPDX-License-Identifier: Apache-2.0
 */
@@ -195,6 +195,7 @@ var _ = Describe("SSH Patch Command", func() {
 			return clientcmdConfig, nil
 		}).AnyTimes()
 		manager.EXPECT().CurrentTarget().Return(currentTarget, nil).AnyTimes()
+		manager.EXPECT().TargetFlags().Return(target.NewTargetFlags("", "", "", "", false)).AnyTimes()
 		manager.EXPECT().GardenClient(gomock.Eq(gardenName)).Return(gardenClient, nil).AnyTimes()
 
 		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds the completion for the `--cidr` flag from the `ssh` command to the `ssh-patch` command.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```feature user
add auto-completion and suggestions for the `--cidr` flag for the `ssh-patch` command
```
