### PR TITLE
[hotfix-2.2] Fix help command not working when session id envs not set

### DIFF
--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package cmd_test
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -78,6 +79,37 @@ var _ = Describe("Gardenctl command", func() {
 				Expect(current.SeedName()).To(BeEmpty())
 				Expect(current.ShootName()).To(Equal(shootName))
 			})
+		})
+	})
+
+	Context("when running the help command", func() {
+		var (
+			sessionID     string
+			termSessionID string
+		)
+
+		BeforeEach(func() {
+			sessionID = os.Getenv("GCTL_SESSION_ID")
+			termSessionID = os.Getenv("GCTL_SESSION_ID")
+
+			Expect(os.Unsetenv("GCTL_SESSION_ID")).To(Succeed())
+			Expect(os.Unsetenv("TERM_SESSION_ID")).To(Succeed())
+		})
+
+		AfterEach(func() {
+			// restore env variables
+			Expect(os.Setenv("GCTL_SESSION_ID", sessionID)).To(Succeed())
+			Expect(os.Setenv("TERM_SESSION_ID", termSessionID)).To(Succeed())
+		})
+
+		It("should succeed without session IDs", func() {
+			args := []string{
+				"help",
+			}
+
+			cmd := cmd.NewGardenctlCommand(util.NewFactoryImpl(), streams)
+			cmd.SetArgs(args)
+			Expect(cmd.Execute()).To(Succeed())
 		})
 	})
 })

--- a/pkg/cmd/env/env.go
+++ b/pkg/cmd/env/env.go
@@ -11,7 +11,6 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
@@ -57,9 +56,7 @@ here https://github.com/gardener/gardenctl-v2/tree/master/pkg/cmd/env/templates.
 	persistentFlags := cmd.PersistentFlags()
 	o.AddFlags(persistentFlags)
 
-	manager, err := f.Manager()
-	utilruntime.Must(err)
-	manager.TargetFlags().AddFlags(persistentFlags)
+	f.TargetFlags().AddFlags(persistentFlags)
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, persistentFlags)
 
 	for _, s := range validShells {

--- a/pkg/cmd/env/env_test.go
+++ b/pkg/cmd/env/env_test.go
@@ -35,6 +35,7 @@ var _ = Describe("Env Commands", func() {
 		factory.EXPECT().Manager().Return(manager, nil).AnyTimes()
 
 		targetFlags := target.NewTargetFlags("", "", "", "", false)
+		factory.EXPECT().TargetFlags().Return(targetFlags).AnyTimes()
 		manager.EXPECT().TargetFlags().Return(targetFlags).AnyTimes()
 
 		streams = util.IOStreams{}

--- a/pkg/cmd/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kubeconfig/kubeconfig.go
@@ -48,9 +48,7 @@ gardenctl kubeconfig --garden my-garden --project my-project`,
 
 	o.AddFlags(cmd.Flags())
 
-	manager, err := f.Manager()
-	utilruntime.Must(err)
-	manager.TargetFlags().AddFlags(cmd.Flags())
+	f.TargetFlags().AddFlags(cmd.Flags())
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, cmd.Flags())
 
 	utilruntime.Must(cmd.RegisterFlagCompletionFunc("output", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/pkg/cmd/kubeconfig/kubeconfig_test.go
+++ b/pkg/cmd/kubeconfig/kubeconfig_test.go
@@ -68,15 +68,13 @@ var _ = Describe("Kubeconfig Command - Options", func() {
 			manager.EXPECT().ClientConfig(ctx, t).Return(config, nil)
 
 			targetFlags := target.NewTargetFlags("", "", "", "", false)
-			manager.EXPECT().TargetFlags().Return(targetFlags).AnyTimes()
+			factory.EXPECT().TargetFlags().Return(targetFlags).AnyTimes()
 
 			streams, _, out, _ = util.NewTestIOStreams()
 			cmd = cmdkubeconfig.NewCmdKubeconfig(factory, streams)
 		})
 
 		It("should execute the kubeconfig subcommand", func() {
-			factory.EXPECT().Manager().Return(manager, nil).Times(2)
-
 			cmd = cmdkubeconfig.NewCmdKubeconfig(factory, streams)
 			cmd.SetArgs([]string{"--output", "yaml"})
 			Expect(cmd.Execute()).To(Succeed())

--- a/pkg/cmd/ssh/ssh.go
+++ b/pkg/cmd/ssh/ssh.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
@@ -43,9 +42,7 @@ func NewCmdSSH(f util.Factory, o *SSHOptions) *cobra.Command {
 	o.AccessConfig.AddFlags(cmd.Flags())
 	RegisterCompletionFuncsForAccessConfigFlags(cmd, f, o.IOStreams, cmd.Flags())
 
-	manager, err := f.Manager()
-	utilruntime.Must(err)
-	manager.TargetFlags().AddFlags(cmd.Flags())
+	f.TargetFlags().AddFlags(cmd.Flags())
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, o.IOStreams, cmd.Flags())
 
 	return cmd

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -282,7 +282,7 @@ var _ = Describe("SSH Command", func() {
 
 		It("should reject bad options", func() {
 			o := ssh.NewSSHOptions(streams)
-			cmd := ssh.NewCmdSSH(&util.FactoryImpl{}, o)
+			cmd := ssh.NewCmdSSH(util.NewFactoryImpl(), o)
 
 			Expect(cmd.RunE(cmd, nil)).NotTo(Succeed())
 		})

--- a/pkg/cmd/sshpatch/sshpatch.go
+++ b/pkg/cmd/sshpatch/sshpatch.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
@@ -50,9 +49,7 @@ gardenctl ssh-patch cli-xxxxxxxx`,
 
 	ssh.RegisterCompletionFuncsForAccessConfigFlags(cmd, f, o.IOStreams, cmd.Flags())
 
-	manager, err := f.Manager()
-	utilruntime.Must(err)
-	manager.TargetFlags().AddFlags(cmd.Flags())
+	f.TargetFlags().AddFlags(cmd.Flags())
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, o.IOStreams, cmd.Flags())
 
 	return cmd

--- a/pkg/cmd/sshpatch/sshpatch_test.go
+++ b/pkg/cmd/sshpatch/sshpatch_test.go
@@ -188,6 +188,8 @@ var _ = Describe("SSH Patch Command", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		gardenClient = gcmocks.NewMockClient(ctrl)
 
+		targetFlags := target.NewTargetFlags("", "", "", "", false)
+
 		manager = targetmocks.NewMockManager(ctrl)
 		manager.EXPECT().ClientConfig(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, _ target.Target) (clientcmd.ClientConfig, error) {
 			// DoAndReturn allows us to modify the apiConfig within the testcase
@@ -195,7 +197,6 @@ var _ = Describe("SSH Patch Command", func() {
 			return clientcmdConfig, nil
 		}).AnyTimes()
 		manager.EXPECT().CurrentTarget().Return(currentTarget, nil).AnyTimes()
-		manager.EXPECT().TargetFlags().Return(target.NewTargetFlags("", "", "", "", false)).AnyTimes()
 		manager.EXPECT().GardenClient(gomock.Eq(gardenName)).Return(gardenClient, nil).AnyTimes()
 
 		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
@@ -203,6 +204,7 @@ var _ = Describe("SSH Patch Command", func() {
 
 		factory = utilmocks.NewMockFactory(ctrl)
 		factory.EXPECT().Manager().Return(manager, nil).AnyTimes()
+		factory.EXPECT().TargetFlags().Return(targetFlags).AnyTimes()
 		factory.EXPECT().Context().Return(ctx).AnyTimes()
 		factory.EXPECT().Clock().Return(clock).AnyTimes()
 		fakeIPs := []string{"192.0.2.42", "2001:db8::8a2e:370:7334"}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix help command not working when session id envs not set

**Which issue(s) this PR fixes**:
Fixes #216 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixes an issue where the `help` command did not work anymore in case `GCTL_SESSION_ID` or `TERM_SESSION_ID` environment variable was not set
```
