### PR TITLE
React on merge_group event

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,7 +5,8 @@ on:
       - v*
     branches:
       - master
-  pull_request: ~
+  pull_request:
+  merge_group:
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -1,6 +1,6 @@
 name: REUSE Compliance Check
 
-on: [push, pull_request]
+on: [push, pull_request, merge_group]
 
 jobs:
   test:


### PR DESCRIPTION
**What this PR does / why we need it**:
For the merge queue feature the github actions should react on the merge_group event
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
