### PR TITLE
[master] Bump golang from 1.19.5 to 1.19.6

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,11 +9,11 @@ gardenctl-v2:
         inject_effective_version: true
     steps:
       check:
-        image: 'golang:1.19.5'
+        image: 'golang:1.19.6'
       test:
-        image: 'golang:1.19.5'
+        image: 'golang:1.19.6'
       build:
-        image: 'golang:1.19.5'
+        image: 'golang:1.19.6'
         output_dir: 'binary'
         timeout: '5m'
 

--- a/.github/workflows/update-gardenctl-v2.yaml
+++ b/.github/workflows/update-gardenctl-v2.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # pin@v3.5.0
         with:
-          go-version: '1.19.5'
+          go-version: '1.19.6'
       - name: Build the binary-files
         id: build_binary_files
         run: |


### PR DESCRIPTION
(cherry picked from commit e80f8bbeb1a596b543432155df3364692eb794c1)

**What this PR does / why we need it**:
Bumps golang from 1.19.5 to 1.19.6

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
