### PR TITLE
`ssh`: use logger for diagnosis output

### DIFF
--- a/pkg/cmd/ssh/ssh.go
+++ b/pkg/cmd/ssh/ssh.go
@@ -7,9 +7,8 @@ SPDX-License-Identifier: Apache-2.0
 package ssh
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
@@ -23,13 +22,16 @@ func NewCmdSSH(f util.Factory, o *SSHOptions) *cobra.Command {
 		Short: "Establish an SSH connection to a Shoot cluster's node",
 		Args:  cobra.MaximumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			ctx := f.Context()
+			logger := klog.FromContext(ctx)
+
 			if len(args) != 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
 
 			nodeNames, err := getNodeNamesFromShoot(f, toComplete)
 			if err != nil {
-				fmt.Fprintln(o.IOStreams.ErrOut, err.Error())
+				logger.Error(err, "could not get node names from shoot")
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
 
@@ -40,7 +42,7 @@ func NewCmdSSH(f util.Factory, o *SSHOptions) *cobra.Command {
 
 	o.AddFlags(cmd.Flags())
 	o.AccessConfig.AddFlags(cmd.Flags())
-	RegisterCompletionFuncsForAccessConfigFlags(cmd, f, o.IOStreams, cmd.Flags())
+	RegisterCompletionFuncsForAccessConfigFlags(cmd, f)
 
 	f.TargetFlags().AddFlags(cmd.Flags())
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, o.IOStreams, cmd.Flags())

--- a/pkg/cmd/sshpatch/sshpatch.go
+++ b/pkg/cmd/sshpatch/sshpatch.go
@@ -47,7 +47,7 @@ gardenctl ssh-patch cli-xxxxxxxx`,
 
 	o.AccessConfig.AddFlags(cmd.Flags())
 
-	ssh.RegisterCompletionFuncsForAccessConfigFlags(cmd, f, o.IOStreams, cmd.Flags())
+	ssh.RegisterCompletionFuncsForAccessConfigFlags(cmd, f)
 
 	f.TargetFlags().AddFlags(cmd.Flags())
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, o.IOStreams, cmd.Flags())


### PR DESCRIPTION
**What this PR does / why we need it**:
Use logger for diagnosis output to not contaminate the output on stdout. This change is required (at least to write to stderr) to control what is written to stdout, especially when the user requests a specific output format.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
