### PR TITLE
`ssh`: Add flag to disable keepalive

### DIFF
--- a/docs/help/gardenctl_ssh.md
+++ b/docs/help/gardenctl_ssh.md
@@ -15,6 +15,7 @@ gardenctl ssh [NODE_NAME] [flags]
   -h, --help                      help for ssh
       --interactive               Open an SSH connection instead of just providing the bastion host (only if NODE_NAME is provided). (default true)
       --keep-bastion              Do not delete immediately when gardenctl exits (Bastions will be garbage-collected after some time)
+      --no-keepalive              Exit after the bastion host became available without keeping the bastion alive or establishing an SSH connection. Note that this flag requires the flags --interactive=false and --keep-bastion to be set
       --project string            target the given project
       --public-key-file string    Path to the file that contains a public SSH key. If not given, a temporary keypair will be generated.
       --seed string               target the given seed cluster

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -698,7 +698,7 @@ func (o *SSHOptions) bastionIngressPolicies(logger klog.Logger, providerType str
 					return nil, fmt.Errorf("GCP only supports IPv4: %s", cidr)
 				}
 
-				logger.Info("GCP only supports IPv4, skipped CIDR: %s\n", cidr)
+				logger.Info("GCP only supports IPv4, skipped CIDR: %s\n", "cidr", cidr)
 
 				continue // skip
 			}
@@ -760,7 +760,7 @@ func cleanup(ctx context.Context, o *SSHOptions, gardenClient client.Client, bas
 			}
 		}
 	} else {
-		logger.Info("Keeping bastion", klog.KObj(bastion))
+		logger.Info("Keeping bastion", "bastion", klog.KObj(bastion))
 
 		if o.generatedSSHKeys {
 			logger.Info("The SSH keypair for the bastion remain on disk", "publicKeyPath", o.SSHPublicKeyFile, "privateKeyPath", o.SSHPrivateKeyFile)
@@ -855,7 +855,7 @@ func waitForBastion(ctx context.Context, o *SSHOptions, gardenClient client.Clie
 		}
 
 		if o.SkipAvailabilityCheck {
-			fmt.Fprintln(o.IOStreams.Out, "Bastion is ready, skipping availability check")
+			logger.Info("Bastion is ready, skipping availability check")
 			return true, nil
 		}
 

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -151,6 +151,7 @@ var (
 
 		return cmd.Run()
 	}
+
 	// waitForSignal informs the user about their SSHOptions and keeps the
 	// bastion alive until gardenctl exits.
 	waitForSignal = func(ctx context.Context, o *SSHOptions, shootClient client.Client, bastion *operationsv1alpha1.Bastion, nodeHostname string, nodePrivateKeyFiles []string, signalChan <-chan struct{}) error {

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -523,7 +523,7 @@ var _ = Describe("SSH Command", func() {
 
 			Expect(cmd.RunE(cmd, nil)).To(Succeed())
 
-			Expect(out.String()).To(ContainSubstring("Bastion is ready, skipping availability check"))
+			Expect(logs).To(ContainSubstring("Bastion is ready, skipping availability check"))
 		})
 	})
 

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -525,6 +525,33 @@ var _ = Describe("SSH Command", func() {
 
 			Expect(logs).To(ContainSubstring("Bastion is ready, skipping availability check"))
 		})
+
+		It("should not keep alive the bastion", func() {
+			options := ssh.NewSSHOptions(streams)
+			options.NoKeepalive = true
+			options.KeepBastion = true
+			options.Interactive = false
+
+			cmd := ssh.NewCmdSSH(factory, options)
+
+			ssh.SetWaitForSignal(func(ctx context.Context, o *ssh.SSHOptions, shootClient client.Client, bastion *operationsv1alpha1.Bastion, nodeHostname string, nodePrivateKeyFiles []string, signalChan <-chan struct{}) error {
+				err := errors.New("this function should not be executed as of NoKeepalive = true")
+				Fail(err.Error())
+				return err
+			})
+			ssh.SetExecCommand(func(ctx context.Context, command string, args []string, o *ssh.SSHOptions) error {
+				err := errors.New("this function should not be executed as of NoKeepalive = true")
+				Fail(err.Error())
+				return err
+			})
+
+			// simulate an external controller processing the bastion and proving a successful status
+			go waitForBastionThenSetBastionReady(ctx, gardenClient, bastionName, *testProject.Spec.Namespace, bastionHostname, bastionIP)
+
+			Expect(cmd.RunE(cmd, nil)).To(Succeed())
+
+			Expect(logs).To(ContainSubstring("Bastion host became available."))
+		})
 	})
 
 	Describe("ValidArgsFunction", func() {
@@ -596,6 +623,28 @@ var _ = Describe("SSH Options", func() {
 		o.WaitTimeout = 0
 
 		Expect(o.Validate()).NotTo(Succeed())
+	})
+
+	Context("no-keepalive", func() {
+		It("should require non-interactive mode", func() {
+			o := ssh.NewSSHOptions(streams)
+			o.NoKeepalive = true
+			o.KeepBastion = true
+
+			o.Interactive = true
+
+			Expect(o.Validate()).NotTo(Succeed())
+		})
+
+		It("should require keep bastion", func() {
+			o := ssh.NewSSHOptions(streams)
+			o.NoKeepalive = true
+			o.Interactive = false
+
+			o.KeepBastion = false
+
+			Expect(o.Validate()).NotTo(Succeed())
+		})
 	})
 
 	It("should require a public SSH key file", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `--no-keepalive` flag that controls if the command should exit after the bastion becomes available.
If this option is true, no SSH connection will be established and the bastion will not be kept alive after it became available.
This option can only be used if KeepBastion is set to true and Interactive is set to false.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`ssh`: You can now disable the keepalive using `--no-keepalive` flag. The command exits after the bastion host became available without keeping the bastion alive or establishing an SSH connection. Note that this flag requires the flags `--interactive=false` and `--keep-bastion` to be set
```
