### PR TITLE
Use `client.authentication.k8s.io/v1` for exec plugin config of Shoot cluster kubeconfig

### DIFF
--- a/.gimps.yaml
+++ b/.gimps.yaml
@@ -31,6 +31,10 @@ aliasRules:
     expr: '^k8s.io/client-go/tools/([a-z0-9-]+)/api/(latest)$'
     alias: '$1$2'
 
+  - name: client-go-apis
+    expr: '^k8s.io/client-go/pkg/apis/([a-z0-9-]+)/(v[a-z0-9-]+)$'
+    alias: '$1$2'
+
   - name: k8s-api
     expr: '^k8s.io/api/([a-z0-9-]+)/(v[a-z0-9-]+)$'
     alias: '$1$2'

--- a/internal/client/garden/client_test.go
+++ b/internal/client/garden/client_test.go
@@ -19,6 +19,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientauthenticationv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
+	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -235,6 +237,7 @@ var _ = Describe("Client", func() {
 
 				Expect(rawConfig.AuthInfos).To(HaveLen(1))
 				authInfo := rawConfig.AuthInfos[context.AuthInfo]
+				Expect(authInfo.Exec.APIVersion).To(Equal(clientauthenticationv1.SchemeGroupVersion.String()))
 				Expect(authInfo.Exec.Command).To(Equal("kubectl-gardenlogin"))
 				Expect(authInfo.Exec.Args).To(Equal([]string{
 					"get-client-certificate",
@@ -248,7 +251,7 @@ var _ = Describe("Client", func() {
 					testShoot1.Spec.Kubernetes.Version = k8sVersionLegacy
 				})
 
-				It("should create legacy kubeconfig configMap", func() {
+				It("should create legacy kubeconfig", func() {
 					clientConfig, err := gardenClient.GetShootClientConfig(ctx, namespace, shootName)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -266,6 +269,7 @@ var _ = Describe("Client", func() {
 
 					Expect(rawConfig.AuthInfos).To(HaveLen(1))
 					authInfo := rawConfig.AuthInfos[context.AuthInfo]
+					Expect(authInfo.Exec.APIVersion).To(Equal(clientauthenticationv1beta1.SchemeGroupVersion.String()))
 					Expect(authInfo.Exec.Command).To(Equal("kubectl-gardenlogin"))
 					Expect(authInfo.Exec.Args).To(Equal([]string{
 						"get-client-certificate",

--- a/internal/client/garden/shoot_client.go
+++ b/internal/client/garden/shoot_client.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
+	clientauthenticationv1 "k8s.io/client-go/pkg/apis/clientauthentication/v1"
 	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -135,6 +136,8 @@ func (k *shootKubeconfigRequest) generate(legacy bool) (*clientcmdapi.Config, er
 		"get-client-certificate",
 	}
 
+	apiVersion := clientauthenticationv1.SchemeGroupVersion.String()
+
 	if legacy {
 		args = append(
 			args,
@@ -142,6 +145,7 @@ func (k *shootKubeconfigRequest) generate(legacy bool) (*clientcmdapi.Config, er
 			fmt.Sprintf("--namespace=%s", k.namespace),
 			fmt.Sprintf("--garden-cluster-identity=%s", k.gardenClusterIdentity),
 		)
+		apiVersion = clientauthenticationv1beta1.SchemeGroupVersion.String()
 	} else {
 		extension = &execPluginConfig{
 			ShootRef: shootRef{
@@ -159,7 +163,7 @@ func (k *shootKubeconfigRequest) generate(legacy bool) (*clientcmdapi.Config, er
 		Command:            "kubectl-gardenlogin",
 		Args:               args,
 		Env:                nil,
-		APIVersion:         clientauthenticationv1beta1.SchemeGroupVersion.String(),
+		APIVersion:         apiVersion,
 		InstallHint:        "Follow the instructions on https://github.com/gardener/gardenlogin#installation to install gardenlogin",
 		ProvideClusterInfo: true,
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Exec plugin config in kubeconfig is now using API version `client.authentication.k8s.io/v1` when kubernetes version of `Shoot` is >= `v1.20.0`. For older versions it will fallback to `client.authentication.k8s.io/v1beta1`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/hold until https://github.com/gardener/gardenlogin/pull/43 is merged and released

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Make sure to update `gardenlogin` to `v0.4.0` or higher
```

```other user
Exec plugin config in kubeconfig is now using API version `client.authentication.k8s.io/v1` when kubernetes version of `Shoot` is >= `v1.20.0`. For older versions it will fallback to `client.authentication.k8s.io/v1beta1`
```
