### PR TITLE
`ssh`: Abort keepalive on not found

### DIFF
--- a/pkg/cmd/ssh/export_test.go
+++ b/pkg/cmd/ssh/export_test.go
@@ -10,6 +10,9 @@ import (
 	"context"
 	"os"
 	"time"
+
+	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func SetBastionAvailabilityChecker(f func(hostname string, privateKey []byte) error) {
@@ -41,4 +44,8 @@ func SetKeepAliveInterval(d time.Duration) {
 	defer keepAliveIntervalMutex.Unlock()
 
 	keepAliveInterval = d
+}
+
+func SetWaitForSignal(f func(ctx context.Context, o *SSHOptions, shootClient client.Client, bastion *operationsv1alpha1.Bastion, nodeHostname string, nodePrivateKeyFiles []string, signalChan <-chan struct{}) error) {
+	waitForSignal = f
 }

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -735,10 +735,10 @@ func cleanup(ctx context.Context, o *SSHOptions, gardenClient client.Client, bas
 	logger := klog.FromContext(ctx)
 
 	if !o.KeepBastion {
-		logger.Info("Deleting bastion", "bastion", klog.KObj(bastion))
+		logger.Info("Cleaning up")
 
 		if err := gardenClient.Delete(ctx, bastion); client.IgnoreNotFound(err) != nil {
-			logger.Error(err, "Failed to delete bastion.")
+			logger.Error(err, "Failed to delete bastion.", "bastion", klog.KObj(bastion))
 		}
 
 		if o.generatedSSHKeys {


### PR DESCRIPTION
**What this PR does / why we need it**:
The bastion keepalive is now aborted in case the bastion was deleted

**Which issue(s) this PR fixes**:
Fixes #232

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
`ssh`: the command will now exit in case the `Bastion` resource was deleted
```
