### PR TITLE
`ssh`: Add output flag

### DIFF
--- a/docs/help/gardenctl_ssh.md
+++ b/docs/help/gardenctl_ssh.md
@@ -16,6 +16,7 @@ gardenctl ssh [NODE_NAME] [flags]
       --interactive               Open an SSH connection instead of just providing the bastion host (only if NODE_NAME is provided). (default true)
       --keep-bastion              Do not delete immediately when gardenctl exits (Bastions will be garbage-collected after some time)
       --no-keepalive              Exit after the bastion host became available without keeping the bastion alive or establishing an SSH connection. Note that this flag requires the flags --interactive=false and --keep-bastion to be set
+  -o, --output string             One of 'yaml' or 'json'.
       --project string            target the given project
       --public-key-file string    Path to the file that contains a public SSH key. If not given, a temporary keypair will be generated.
       --seed string               target the given seed cluster

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	k8s.io/klog/v2 v2.70.1
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	sigs.k8s.io/controller-runtime v0.13.0
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -131,7 +132,6 @@ require (
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
 replace k8s.io/client-go => k8s.io/client-go v0.25.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	golang.org/x/crypto v0.7.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/apiserver v0.25.0
@@ -120,6 +119,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	istio.io/api v0.0.0-20221013011440-bc935762d2b9 // indirect
 	istio.io/client-go v1.15.3 // indirect
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect

--- a/pkg/ac/access_restriction.go
+++ b/pkg/ac/access_restriction.go
@@ -20,23 +20,23 @@ import (
 // AccessRestriction is used to define an access restriction.
 type AccessRestriction struct {
 	// Key is the identifier of an access restriction
-	Key string `yaml:"key,omitempty" json:"key,omitempty"`
+	Key string `json:"key,omitempty"`
 	// NotifyIf controls which value the annotation must have for a notification to be sent
-	NotifyIf bool `yaml:"notifyIf,omitempty" json:"notifyIf,omitempty"`
+	NotifyIf bool `json:"notifyIf,omitempty"`
 	// Msg is the notification text that is sent
-	Msg string `yaml:"msg,omitempty" json:"msg,omitempty"`
+	Msg string `json:"msg,omitempty"`
 	// Options is a list of access restriction options
-	Options []AccessRestrictionOption `yaml:"options,omitempty" json:"options,omitempty"`
+	Options []AccessRestrictionOption `json:"options,omitempty"`
 }
 
 // AccessRestrictionOption is used to define an access restriction option.
 type AccessRestrictionOption struct {
 	// Key is the identifier of an access restriction option
-	Key string `yaml:"key,omitempty" json:"key,omitempty"`
+	Key string `json:"key,omitempty"`
 	// NotifyIf controls which value the annotation must have for a notification to be sent
-	NotifyIf bool `yaml:"notifyIf,omitempty" json:"notifyIf,omitempty"`
+	NotifyIf bool `json:"notifyIf,omitempty"`
 	// Msg is the notification text that is sent
-	Msg string `yaml:"msg,omitempty" json:"msg,omitempty"`
+	Msg string `json:"msg,omitempty"`
 }
 
 // AccessRestrictionHandler is a function that should display a single AccessRestrictionMessage to the user.

--- a/pkg/cmd/base/options.go
+++ b/pkg/cmd/base/options.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
 )
@@ -75,15 +75,12 @@ func (o *Options) PrintObject(obj interface{}) error {
 		fmt.Fprintf(o.IOStreams.Out, "%v", obj)
 
 	case "yaml":
-		yamlEncoder := yaml.NewEncoder(o.IOStreams.Out)
-		defer yamlEncoder.Close()
-
-		yamlEncoder.SetIndent(2)
-
-		err := yamlEncoder.Encode(&obj)
+		marshalled, err := yaml.Marshal(&obj)
 		if err != nil {
 			return err
 		}
+
+		fmt.Fprintln(o.IOStreams.Out, string(marshalled))
 	case "json":
 		marshalled, err := json.MarshalIndent(&obj, "", "  ")
 		if err != nil {

--- a/pkg/cmd/base/options.go
+++ b/pkg/cmd/base/options.go
@@ -72,8 +72,11 @@ func (o *Options) AddFlags(flags *pflag.FlagSet) {
 func (o *Options) PrintObject(obj interface{}) error {
 	switch o.Output {
 	case "":
-		fmt.Fprintf(o.IOStreams.Out, "%v", obj)
-
+		if _, ok := obj.(fmt.Stringer); ok {
+			fmt.Fprintf(o.IOStreams.Out, "%s", obj)
+		} else {
+			fmt.Fprintf(o.IOStreams.Out, "%v", obj)
+		}
 	case "yaml":
 		marshalled, err := yaml.Marshal(&obj)
 		if err != nil {

--- a/pkg/cmd/base/options_test.go
+++ b/pkg/cmd/base/options_test.go
@@ -24,12 +24,12 @@ import (
 var _ = Describe("Base Options", func() {
 	Describe("given an instance", func() {
 		type barType struct {
-			Baz string
+			Baz string `json:"baz"`
 		}
 
 		type fooType struct {
-			Foo string
-			Bar barType
+			Foo string  `json:"foo"`
+			Bar barType `json:"bar"`
 		}
 
 		var (
@@ -78,9 +78,9 @@ var _ = Describe("Base Options", func() {
 				Expect(options.PrintObject(foo)).To(Succeed())
 				Expect(buf.String()).To(Equal(fmt.Sprintf(
 					`{
-  "Foo": %q,
-  "Bar": {
-    "Baz": %q
+  "foo": %q,
+  "bar": {
+    "baz": %q
   }
 }
 `, foo.Foo, foo.Bar.Baz)))
@@ -99,11 +99,12 @@ var _ = Describe("Base Options", func() {
 			It("should print with yaml format", func() {
 				Expect(options.PrintObject(foo)).To(Succeed())
 				Expect(buf.String()).To(Equal(fmt.Sprintf(
-					`foo: %s
-bar:
+					`bar:
   baz: %s
+foo: %s
+
 `,
-					foo.Foo, foo.Bar.Baz)))
+					foo.Bar.Baz, foo.Foo)))
 			})
 		})
 

--- a/pkg/cmd/config/config_test.go
+++ b/pkg/cmd/config/config_test.go
@@ -12,7 +12,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
 	"github.com/gardener/gardenctl-v2/pkg/config"

--- a/pkg/cmd/ssh/export_test.go
+++ b/pkg/cmd/ssh/export_test.go
@@ -10,9 +10,6 @@ import (
 	"context"
 	"os"
 	"time"
-
-	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func SetBastionAvailabilityChecker(f func(hostname string, privateKey []byte) error) {
@@ -46,6 +43,6 @@ func SetKeepAliveInterval(d time.Duration) {
 	keepAliveInterval = d
 }
 
-func SetWaitForSignal(f func(ctx context.Context, o *SSHOptions, shootClient client.Client, bastion *operationsv1alpha1.Bastion, nodeHostname string, nodePrivateKeyFiles []string, signalChan <-chan struct{}) error) {
+func SetWaitForSignal(f func(ctx context.Context, o *SSHOptions, signalChan <-chan struct{})) {
 	waitForSignal = f
 }

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -671,20 +671,10 @@ func (o *SSHOptions) Run(f util.Factory) error {
 		return fmt.Errorf("an error occurred while waiting for the bastion to be ready: %w", err)
 	}
 
+	logger.Info("Bastion host became available.", "address", toAdress(bastion.Status.Ingress).String())
 
-	ingress := bastion.Status.Ingress
-	printAddr := ""
 
-	switch {
-	case ingress.Hostname != "" && ingress.IP != "":
-		printAddr = fmt.Sprintf("%s (%s)", ingress.IP, ingress.Hostname)
-	case ingress.Hostname != "":
-		printAddr = ingress.Hostname
-	default:
-		printAddr = ingress.IP
-	}
 
-	logger.Info("Bastion host became available.", "address", printAddr)
 
 	if o.NoKeepalive {
 		return nil

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -665,17 +665,12 @@ func (o *SSHOptions) Run(f util.Factory) error {
 	logger.Info("Waiting for bastion to be ready…", "waitTimeout", o.WaitTimeout)
 
 	err = waitForBastion(ctx, o, gardenClient.RuntimeClient(), bastion)
-
 	if err == wait.ErrWaitTimeout {
-		logger.Info("Timed out waiting for the bastion to be ready.")
+		return errors.New("timed out waiting for the bastion to be ready")
 	} else if err != nil {
-		logger.Error(err, "An error occurred while waiting for the bastion to be ready.")
+		return fmt.Errorf("an error occurred while waiting for the bastion to be ready: %w", err)
 	}
 
-	if err != nil {
-		// actual error has already been printed
-		return errors.New("precondition failed")
-	}
 
 	ingress := bastion.Status.Ingress
 	printAddr := ""

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -316,10 +316,10 @@ var _ = Describe("SSH Command", func() {
 			Expect(gardenClient.Get(ctx, key, bastion)).NotTo(Succeed())
 
 			// assert that no temporary SSH keypair remained on disk
-			_, err := os.Stat(options.SSHPublicKeyFile)
+			_, err := os.Stat(options.SSHPublicKeyFile.String())
 			Expect(err).To(HaveOccurred())
 
-			_, err = os.Stat(options.SSHPrivateKeyFile)
+			_, err = os.Stat(options.SSHPrivateKeyFile.String())
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -368,10 +368,10 @@ var _ = Describe("SSH Command", func() {
 			Expect(gardenClient.Get(ctx, key, bastion)).NotTo(Succeed())
 
 			// assert that no temporary SSH keypair remained on disk
-			_, err := os.Stat(options.SSHPublicKeyFile)
+			_, err := os.Stat(options.SSHPublicKeyFile.String())
 			Expect(err).To(HaveOccurred())
 
-			_, err = os.Stat(options.SSHPrivateKeyFile)
+			_, err = os.Stat(options.SSHPrivateKeyFile.String())
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -423,10 +423,10 @@ var _ = Describe("SSH Command", func() {
 			Expect(gardenClient.Get(ctx, key, bastion)).NotTo(Succeed())
 
 			// assert that no temporary SSH keypair remained on disk
-			_, err := os.Stat(options.SSHPublicKeyFile)
+			_, err := os.Stat(options.SSHPublicKeyFile.String())
 			Expect(err).To(HaveOccurred())
 
-			_, err = os.Stat(options.SSHPrivateKeyFile)
+			_, err = os.Stat(options.SSHPrivateKeyFile.String())
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -656,7 +656,7 @@ var _ = Describe("SSH Options", func() {
 	})
 
 	It("should require a valid public SSH key file", func() {
-		Expect(os.WriteFile(publicSSHKeyFile, []byte("not a key"), 0o644)).To(Succeed())
+		Expect(os.WriteFile(publicSSHKeyFile.String(), []byte("not a key"), 0o644)).To(Succeed())
 
 		o := ssh.NewSSHOptions(streams)
 		o.CIDRs = []string{"8.8.8.8/32"}

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -305,9 +305,9 @@ var _ = Describe("SSH Command", func() {
 			Expect(cmd.RunE(cmd, nil)).To(Succeed())
 
 			// assert the output
-			Expect(logs).To(ContainSubstring(bastionName))
-			Expect(logs).To(ContainSubstring(bastionHostname))
-			Expect(out).To(ContainSubstring(bastionIP))
+			Expect(logs.String()).To(ContainSubstring(bastionName))
+			Expect(logs.String()).To(ContainSubstring(bastionHostname))
+			Expect(out.String()).To(ContainSubstring(bastionIP))
 
 			// assert that the bastion has been cleaned up
 			key := types.NamespacedName{Name: bastionName, Namespace: *testProject.Spec.Namespace}
@@ -357,9 +357,9 @@ var _ = Describe("SSH Command", func() {
 
 			// assert output
 			Expect(executedCommands).To(Equal(1))
-			Expect(logs).To(ContainSubstring(bastionName))
-			Expect(logs).To(ContainSubstring(bastionHostname))
-			Expect(out).To(ContainSubstring(bastionIP))
+			Expect(logs.String()).To(ContainSubstring(bastionName))
+			Expect(logs.String()).To(ContainSubstring(bastionHostname))
+			Expect(out.String()).To(ContainSubstring(bastionIP))
 
 			// assert that the bastion has been cleaned up
 			key := types.NamespacedName{Name: bastionName, Namespace: *testProject.Spec.Namespace}
@@ -411,10 +411,10 @@ var _ = Describe("SSH Command", func() {
 
 			// assert output
 			Expect(executedCommands).To(Equal(1))
-			Expect(logs).To(ContainSubstring(bastionName))
-			Expect(logs).To(ContainSubstring(bastionHostname))
-			Expect(out).To(ContainSubstring(bastionIP))
-			Expect(logs).To(ContainSubstring("node did not yet join the cluster"))
+			Expect(logs.String()).To(ContainSubstring(bastionName))
+			Expect(logs.String()).To(ContainSubstring(bastionHostname))
+			Expect(out.String()).To(ContainSubstring(bastionIP))
+			Expect(logs.String()).To(ContainSubstring("node did not yet join the cluster"))
 
 			// assert that the bastion has been cleaned up
 			key := types.NamespacedName{Name: bastionName, Namespace: *testProject.Spec.Namespace}
@@ -523,7 +523,7 @@ var _ = Describe("SSH Command", func() {
 
 			Expect(cmd.RunE(cmd, nil)).To(Succeed())
 
-			Expect(logs).To(ContainSubstring("Bastion is ready, skipping availability check"))
+			Expect(logs.String()).To(ContainSubstring("Bastion is ready, skipping availability check"))
 		})
 
 		It("should not keep alive the bastion", func() {
@@ -550,7 +550,7 @@ var _ = Describe("SSH Command", func() {
 
 			Expect(cmd.RunE(cmd, nil)).To(Succeed())
 
-			Expect(logs).To(ContainSubstring("Bastion host became available."))
+			Expect(logs.String()).To(ContainSubstring("Bastion host became available."))
 		})
 	})
 

--- a/pkg/cmd/ssh/types.go
+++ b/pkg/cmd/ssh/types.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/pflag"
+	corev1 "k8s.io/api/core/v1"
 )
 
 type PublicKeyFile string
@@ -39,4 +40,33 @@ var _ fmt.Stringer = (*PrivateKeyFile)(nil)
 
 func (s *PrivateKeyFile) String() string {
 	return string(*s)
+}
+
+// Address holds information about an IP address and hostname.
+type Address struct {
+	Hostname string `json:"hostname"`
+	IP       string `json:"ip"`
+}
+
+var _ fmt.Stringer = &Address{}
+func toAdress(ingress *corev1.LoadBalancerIngress) *Address {
+	if ingress == nil {
+		return nil
+	}
+
+	return &Address{
+		Hostname: ingress.Hostname,
+		IP:       ingress.IP,
+	}
+}
+
+func (a *Address) String() string {
+	switch {
+	case a.Hostname != "" && a.IP != "":
+		return fmt.Sprintf("%s (%s)", a.IP, a.Hostname)
+	case a.Hostname != "":
+		return a.Hostname
+	default:
+		return a.IP
+	}
 }

--- a/pkg/cmd/ssh/types.go
+++ b/pkg/cmd/ssh/types.go
@@ -7,10 +7,16 @@ SPDX-License-Identifier: Apache-2.0
 package ssh
 
 import (
+	"bytes"
 	"fmt"
 
+	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/klog/v2"
 )
 
 type PublicKeyFile string
@@ -42,6 +48,50 @@ func (s *PrivateKeyFile) String() string {
 	return string(*s)
 }
 
+// ConnectInformation holds connect information required to establish an SSH connection
+// to Shoot worker nodes.
+type ConnectInformation struct {
+	// Bastion holds information about the bastion host used to connect to the worker nodes.
+	Bastion Bastion `json:"bastion"`
+
+	// NodeHostname is the name of the Shoot cluster node that the user wants to connect to.
+	NodeHostname string `json:"nodeHostname,omitempty"`
+
+	// NodePrivateKeyFiles is a list of file paths containing the private SSH keys for the worker nodes.
+	NodePrivateKeyFiles []string `json:"nodePrivateKeyFiles"`
+
+	// Nodes is a list of Node objects containing information about the worker nodes.
+	Nodes []Node `json:"nodes"`
+}
+
+var _ fmt.Stringer = &ConnectInformation{}
+
+// Bastion holds information about the bastion host used to connect to the worker nodes.
+type Bastion struct {
+	// Name is the name of the Bastion resource.
+	Name string `json:"name"`
+	// Namespace is the namespace of the Bastion resource.
+	Namespace string `json:"namespace"`
+	// PreferredAddress is the preferred IP address or hostname to use when connecting to the bastion host.
+	PreferredAddress string `json:"preferredAddress"`
+	// Address holds information about the IP address and hostname of the bastion host.
+	Address
+	// SSHPublicKeyFile is the full path to the file containing the public SSH key.
+	SSHPublicKeyFile PublicKeyFile `json:"publicKeyFile"`
+	// SSHPrivateKeyFile is the full path to the file containing the private SSH key.
+	SSHPrivateKeyFile PrivateKeyFile `json:"privateKeyFile"`
+}
+
+// Node holds information about a worker node.
+type Node struct {
+	// Name is the name of the worker node.
+	Name string `json:"name"`
+	// Status is the current status of the worker node.
+	Status string `json:"status"`
+	// Address holds information about the IP address and hostname of the worker node.
+	Address
+}
+
 // Address holds information about an IP address and hostname.
 type Address struct {
 	Hostname string `json:"hostname"`
@@ -49,6 +99,132 @@ type Address struct {
 }
 
 var _ fmt.Stringer = &Address{}
+
+func NewConnectInformation(bastion *operationsv1alpha1.Bastion, nodeHostname string, sshPublicKeyFile PublicKeyFile, sshPrivateKeyFile PrivateKeyFile, nodePrivateKeyFiles []string, nodes []corev1.Node) (*ConnectInformation, error) {
+	var nodeList []Node
+
+	for _, node := range nodes {
+		n := Node{}
+		n.Name = node.Name
+		n.Status = "Ready"
+
+		if !isNodeReady(node) {
+			n.Status = "Not Ready"
+		}
+
+		for _, addr := range node.Status.Addresses {
+			switch addr.Type {
+			case corev1.NodeInternalIP:
+				n.IP = addr.Address
+
+			case corev1.NodeInternalDNS:
+				n.Hostname = addr.Address
+
+			// internal names have priority, as we jump via a bastion host,
+			// but in case the cloud provider does not offer internal IPs,
+			// we fallback to external values
+
+			case corev1.NodeExternalIP:
+				if n.IP == "" {
+					n.IP = addr.Address
+				}
+
+			case corev1.NodeExternalDNS:
+				if n.Hostname == "" {
+					n.Hostname = addr.Address
+				}
+			}
+		}
+
+		nodeList = append(nodeList, n)
+	}
+
+	return &ConnectInformation{
+		Bastion: Bastion{
+			Name:             bastion.Name,
+			Namespace:        bastion.Namespace,
+			PreferredAddress: preferredBastionAddress(bastion),
+			Address: Address{
+				IP:       bastion.Status.Ingress.IP,
+				Hostname: bastion.Status.Ingress.Hostname,
+			},
+			SSHPublicKeyFile:  sshPublicKeyFile,
+			SSHPrivateKeyFile: sshPrivateKeyFile,
+		},
+		NodeHostname:        nodeHostname,
+		NodePrivateKeyFiles: nodePrivateKeyFiles,
+		Nodes:               nodeList,
+	}, nil
+}
+
+func (p *ConnectInformation) String() string {
+	buf := bytes.Buffer{}
+
+	nodeHostname := p.NodeHostname
+	if nodeHostname == "" {
+		nodeHostname = "IP_OR_HOSTNAME"
+
+		table := &metav1beta1.Table{
+			ColumnDefinitions: []metav1.TableColumnDefinition{
+				{
+					Name:   "Node Name",
+					Type:   "string",
+					Format: "name",
+				},
+				{
+					Name: "Status",
+					Type: "string",
+				},
+				{
+					Name: "IP",
+					Type: "string",
+				},
+				{
+					Name: "Hostname",
+					Type: "string",
+				},
+			},
+			Rows: []metav1.TableRow{},
+		}
+
+		for _, node := range p.Nodes {
+			table.Rows = append(table.Rows, metav1.TableRow{
+				Cells: []interface{}{node.Name, node.Status, node.IP, node.Hostname},
+			})
+		}
+
+		fmt.Fprintln(&buf, "The shoot cluster has the following nodes:")
+		fmt.Fprintln(&buf, "")
+
+		printer := printers.NewTablePrinter(printers.PrintOptions{})
+		if err := printer.PrintObj(table, &buf); err != nil {
+			klog.Background().Error(err, "failed to output node table: %w")
+			return ""
+		}
+
+		fmt.Fprintln(&buf, "")
+	}
+
+	connectCmd := sshCommandLine(p.Bastion.SSHPrivateKeyFile, p.Bastion.PreferredAddress, p.NodePrivateKeyFiles, nodeHostname)
+
+	fmt.Fprintln(&buf, "Connect to shoot nodes by using the bastion as a proxy/jump host, for example:")
+	fmt.Fprintln(&buf, "")
+	fmt.Fprintln(&buf, connectCmd)
+	fmt.Fprintln(&buf, "")
+
+	return buf.String()
+}
+
+func isNodeReady(node corev1.Node) bool {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == corev1.NodeReady {
+			return cond.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
+}
+
 func toAdress(ingress *corev1.LoadBalancerIngress) *Address {
 	if ingress == nil {
 		return nil

--- a/pkg/cmd/ssh/types.go
+++ b/pkg/cmd/ssh/types.go
@@ -58,7 +58,7 @@ type ConnectInformation struct {
 	NodeHostname string `json:"nodeHostname,omitempty"`
 
 	// NodePrivateKeyFiles is a list of file paths containing the private SSH keys for the worker nodes.
-	NodePrivateKeyFiles []string `json:"nodePrivateKeyFiles"`
+	NodePrivateKeyFiles []PrivateKeyFile `json:"nodePrivateKeyFiles"`
 
 	// Nodes is a list of Node objects containing information about the worker nodes.
 	Nodes []Node `json:"nodes"`
@@ -100,7 +100,7 @@ type Address struct {
 
 var _ fmt.Stringer = &Address{}
 
-func NewConnectInformation(bastion *operationsv1alpha1.Bastion, nodeHostname string, sshPublicKeyFile PublicKeyFile, sshPrivateKeyFile PrivateKeyFile, nodePrivateKeyFiles []string, nodes []corev1.Node) (*ConnectInformation, error) {
+func NewConnectInformation(bastion *operationsv1alpha1.Bastion, nodeHostname string, sshPublicKeyFile PublicKeyFile, sshPrivateKeyFile PrivateKeyFile, nodePrivateKeyFiles []PrivateKeyFile, nodes []corev1.Node) (*ConnectInformation, error) {
 	var nodeList []Node
 
 	for _, node := range nodes {

--- a/pkg/cmd/ssh/types.go
+++ b/pkg/cmd/ssh/types.go
@@ -1,0 +1,42 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ssh
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+type PublicKeyFile string
+
+var (
+	_ pflag.Value  = (*PublicKeyFile)(nil)
+	_ fmt.Stringer = (*PublicKeyFile)(nil)
+)
+
+func (s *PublicKeyFile) Set(val string) error {
+	*s = PublicKeyFile(val)
+
+	return nil
+}
+
+func (s *PublicKeyFile) Type() string {
+	return "string"
+}
+
+func (s *PublicKeyFile) String() string {
+	return string(*s)
+}
+
+type PrivateKeyFile string
+
+var _ fmt.Stringer = (*PrivateKeyFile)(nil)
+
+func (s *PrivateKeyFile) String() string {
+	return string(*s)
+}

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package config_test
 
 import (
-	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -18,15 +17,3 @@ func TestConfiguration(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Config Test Suite")
 }
-
-var gardenHomeDir string
-
-var _ = BeforeSuite(func() {
-	dir, err := os.MkdirTemp("", "garden-*")
-	Expect(err).NotTo(HaveOccurred())
-	gardenHomeDir = dir
-})
-
-var _ = AfterSuite(func() {
-	Expect(os.RemoveAll(gardenHomeDir)).To(Succeed())
-})

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -63,11 +63,11 @@ type Target interface {
 }
 
 type targetImpl struct {
-	Garden           string `yaml:"garden,omitempty" json:"garden,omitempty"`
-	Project          string `yaml:"project,omitempty" json:"project,omitempty"`
-	Seed             string `yaml:"seed,omitempty" json:"seed,omitempty"`
-	Shoot            string `yaml:"shoot,omitempty" json:"shoot,omitempty"`
-	ControlPlaneFlag bool   `yaml:"controlPlane,omitempty" json:"controlPlane,omitempty"`
+	Garden           string `json:"garden,omitempty"`
+	Project          string `json:"project,omitempty"`
+	Seed             string `json:"seed,omitempty"`
+	Shoot            string `json:"shoot,omitempty"`
+	ControlPlaneFlag bool   `json:"controlPlane,omitempty"`
 }
 
 var _ Target = &targetImpl{}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds an output flag for the `ssh` command

Usage example:
```bash
gardenctl ssh --no-keepalive --keep-bastion -oyaml
```

Output:
```yaml
bastion:
  hostname: bastion.example.com
  ip: 1.2.3.4
  name: cli-budw1wnb
  namespace: garden-myproject
  preferredAddress: 1.2.3.4
  privateKeyFile: /foo/bar/gen_id_rsa_baz
  publicKeyFile: /foo/bar/gen_id_rsa_baz.pub
nodePrivateKeyFiles:
  - /foo/bar/gctlv23456
  - /foo/bar/gctlv24567
nodes:
  - hostname: node.example.com
    ip: 4.5.6.7
    name: node.name.internal
    status: Ready
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`ssh`: You can now control the output format using `--output` flag
```
