### PR TITLE
Move `CurrentUser` to gardenClient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	golang.org/x/crypto v0.7.0
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
-	k8s.io/apiserver v0.25.0
 	k8s.io/cli-runtime v0.25.0
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/component-base v0.25.0
@@ -123,6 +122,7 @@ require (
 	istio.io/api v0.0.0-20221013011440-bc935762d2b9 // indirect
 	istio.io/client-go v1.15.3 // indirect
 	k8s.io/apiextensions-apiserver v0.25.0 // indirect
+	k8s.io/apiserver v0.25.0 // indirect
 	k8s.io/autoscaler v0.0.0-20190805135949-100e91ba756e // indirect
 	k8s.io/helm v2.16.1+incompatible // indirect
 	k8s.io/kube-aggregator v0.25.0 // indirect

--- a/internal/fake/config.go
+++ b/internal/fake/config.go
@@ -1,0 +1,55 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fake
+
+import (
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// NewConfigData generates a Kubernetes client configuration as a byte slice.
+func NewConfigData(name string) ([]byte, error) {
+	return clientcmd.Write(*NewTokenConfig(name))
+}
+
+// NewTokenConfig generates a new Kubernetes client configuration
+// with token authentication info.
+func NewTokenConfig(name string) *clientcmdapi.Config {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["cluster"] = &clientcmdapi.Cluster{
+		Server: "https://kubernetes:6443/",
+	}
+	config.AuthInfos["user"] = &clientcmdapi.AuthInfo{
+		Token: "token",
+	}
+	config.Contexts[name] = &clientcmdapi.Context{
+		Namespace: "default",
+		AuthInfo:  "user",
+		Cluster:   "cluster",
+	}
+	config.CurrentContext = name
+
+	return config
+}
+
+func NewCertConfig(name string, clientCert []byte) *clientcmdapi.Config {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["cluster"] = &clientcmdapi.Cluster{
+		Server: "https://kubernetes:6443/",
+	}
+	config.AuthInfos["user"] = &clientcmdapi.AuthInfo{
+		ClientCertificateData: clientCert,
+	}
+	config.Contexts[name] = &clientcmdapi.Context{
+		Namespace: "default",
+		AuthInfo:  "user",
+		Cluster:   "cluster",
+	}
+	config.CurrentContext = name
+
+	return config
+}

--- a/internal/fake/x509.go
+++ b/internal/fake/x509.go
@@ -1,0 +1,33 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package fake
+
+import (
+	gardensecrets "github.com/gardener/gardener/pkg/utils/secrets"
+)
+
+func NewCaCert() (*gardensecrets.Certificate, error) {
+	caCertCSC := &gardensecrets.CertificateSecretConfig{
+		Name:       "test-issuer-name",
+		CommonName: "test-issuer-cn",
+		CertType:   gardensecrets.CACert,
+	}
+
+	return caCertCSC.GenerateCertificate()
+}
+
+func NewClientCert(caCert *gardensecrets.Certificate, commonName string, organization []string) (*gardensecrets.Certificate, error) {
+	csc := &gardensecrets.CertificateSecretConfig{
+		Name:         "client-name",
+		CommonName:   commonName,
+		Organization: organization,
+		CertType:     gardensecrets.ClientCert,
+		SigningCA:    caCert,
+	}
+
+	return csc.GenerateCertificate()
+}

--- a/internal/gardenclient/mocks/mock_client.go
+++ b/internal/gardenclient/mocks/mock_client.go
@@ -12,8 +12,7 @@ import (
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	v1alpha10 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	gomock "github.com/golang/mock/gomock"
-	v1 "k8s.io/api/authentication/v1"
-	v10 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -41,19 +40,19 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// CreateTokenReview mocks base method.
-func (m *MockClient) CreateTokenReview(arg0 context.Context, arg1 string) (*v1.TokenReview, error) {
+// CurrentUser mocks base method.
+func (m *MockClient) CurrentUser(arg0 context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateTokenReview", arg0, arg1)
-	ret0, _ := ret[0].(*v1.TokenReview)
+	ret := m.ctrl.Call(m, "CurrentUser", arg0)
+	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CreateTokenReview indicates an expected call of CreateTokenReview.
-func (mr *MockClientMockRecorder) CreateTokenReview(arg0, arg1 interface{}) *gomock.Call {
+// CurrentUser indicates an expected call of CurrentUser.
+func (mr *MockClientMockRecorder) CurrentUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTokenReview", reflect.TypeOf((*MockClient)(nil).CreateTokenReview), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentUser", reflect.TypeOf((*MockClient)(nil).CurrentUser), arg0)
 }
 
 // FindShoot mocks base method.
@@ -76,21 +75,6 @@ func (mr *MockClientMockRecorder) FindShoot(arg0 interface{}, arg1 ...interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindShoot", reflect.TypeOf((*MockClient)(nil).FindShoot), varargs...)
 }
 
-// GetBastion mocks base method.
-func (m *MockClient) GetBastion(arg0 context.Context, arg1, arg2 string) (*v1alpha1.Bastion, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBastion", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*v1alpha1.Bastion)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBastion indicates an expected call of GetBastion.
-func (mr *MockClientMockRecorder) GetBastion(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBastion", reflect.TypeOf((*MockClient)(nil).GetBastion), arg0, arg1, arg2)
-}
-
 // GetCloudProfile mocks base method.
 func (m *MockClient) GetCloudProfile(arg0 context.Context, arg1 string) (*v1beta1.CloudProfile, error) {
 	m.ctrl.T.Helper()
@@ -107,10 +91,10 @@ func (mr *MockClientMockRecorder) GetCloudProfile(arg0, arg1 interface{}) *gomoc
 }
 
 // GetConfigMap mocks base method.
-func (m *MockClient) GetConfigMap(arg0 context.Context, arg1, arg2 string) (*v10.ConfigMap, error) {
+func (m *MockClient) GetConfigMap(arg0 context.Context, arg1, arg2 string) (*v1.ConfigMap, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetConfigMap", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*v10.ConfigMap)
+	ret0, _ := ret[0].(*v1.ConfigMap)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -122,10 +106,10 @@ func (mr *MockClientMockRecorder) GetConfigMap(arg0, arg1, arg2 interface{}) *go
 }
 
 // GetNamespace mocks base method.
-func (m *MockClient) GetNamespace(arg0 context.Context, arg1 string) (*v10.Namespace, error) {
+func (m *MockClient) GetNamespace(arg0 context.Context, arg1 string) (*v1.Namespace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNamespace", arg0, arg1)
-	ret0, _ := ret[0].(*v10.Namespace)
+	ret0, _ := ret[0].(*v1.Namespace)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -167,10 +151,10 @@ func (mr *MockClientMockRecorder) GetProjectByNamespace(arg0, arg1 interface{}) 
 }
 
 // GetSecret mocks base method.
-func (m *MockClient) GetSecret(arg0 context.Context, arg1, arg2 string) (*v10.Secret, error) {
+func (m *MockClient) GetSecret(arg0 context.Context, arg1, arg2 string) (*v1.Secret, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSecret", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*v10.Secret)
+	ret0, _ := ret[0].(*v1.Secret)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/cmd/sshpatch/bastionlistpatcher.go
+++ b/pkg/cmd/sshpatch/bastionlistpatcher.go
@@ -36,7 +36,6 @@ type bastionPatcher interface {
 	Patch(ctx context.Context, oldBastion, newBastion *operationsv1alpha1.Bastion) error
 }
 
-//go:generate mockgen -source=./ssh_patch_userbastionlister.go -destination=./mocks/mock_ssh_patch_userbastionlister.go -package=mocks github.com/gardener/gardenctl-v2/pkg/cmd/ssh bastionListPatcher
 type bastionListPatcher interface {
 	bastionPatcher
 	bastionLister

--- a/pkg/cmd/sshpatch/bastionlistpatcher.go
+++ b/pkg/cmd/sshpatch/bastionlistpatcher.go
@@ -7,20 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package sshpatch
 
 import (
-	"bytes"
 	"context"
-	"crypto/x509"
-	"encoding/json"
-	"encoding/pem"
 	"fmt"
-	"os/exec"
-	"path"
 
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
-	clientauthentication "k8s.io/client-go/pkg/apis/clientauthentication"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	gardenClient "github.com/gardener/gardenctl-v2/internal/gardenclient"
 	"github.com/gardener/gardenctl-v2/pkg/target"
@@ -44,14 +35,13 @@ type bastionListPatcher interface {
 type userBastionListPatcherImpl struct {
 	target       target.Target
 	gardenClient gardenClient.Client
-	clientConfig clientcmd.ClientConfig
 }
 
 var _ bastionListPatcher = &userBastionListPatcherImpl{}
 
 // newUserBastionListPatcher creates a new bastionListPatcher which only lists bastions
 // of the current user.
-func newUserBastionListPatcher(ctx context.Context, manager target.Manager) (bastionListPatcher, error) {
+func newUserBastionListPatcher(manager target.Manager) (bastionListPatcher, error) {
 	currentTarget, err := manager.CurrentTarget()
 	if err != nil {
 		return nil, err
@@ -64,25 +54,14 @@ func newUserBastionListPatcher(ctx context.Context, manager target.Manager) (bas
 		return nil, err
 	}
 
-	clientConfig, err := manager.ClientConfig(ctx, target.NewTarget(gardenName, "", "", ""))
-	if err != nil {
-		return nil, fmt.Errorf("could not retrieve client config for target garden %s: %w", gardenName, err)
-	}
-
 	return &userBastionListPatcherImpl{
 		currentTarget,
 		gardenClient,
-		clientConfig,
 	}, nil
 }
 
 func (u *userBastionListPatcherImpl) List(ctx context.Context) ([]operationsv1alpha1.Bastion, error) {
-	authInfo, err := u.AuthInfo(u.clientConfig)
-	if err != nil {
-		return nil, fmt.Errorf("could not get authInfo: %w", err)
-	}
-
-	user, err := u.CurrentUser(ctx, u.gardenClient, authInfo)
+	user, err := u.gardenClient.CurrentUser(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get current user: %w", err)
 	}
@@ -115,104 +94,6 @@ func (u *userBastionListPatcherImpl) List(ctx context.Context) ([]operationsv1al
 	}
 
 	return bastionsOfUser, nil
-}
-
-func (u *userBastionListPatcherImpl) CurrentUser(ctx context.Context, gardenClient gardenClient.Client, authInfo *clientcmdapi.AuthInfo) (string, error) {
-	baseDir, err := clientcmdapi.MakeAbs(path.Dir(authInfo.LocationOfOrigin), "")
-	if err != nil {
-		return "", fmt.Errorf("could not parse location of kubeconfig origin")
-	}
-
-	switch {
-	case len(authInfo.ClientCertificateData) == 0 && len(authInfo.ClientCertificate) > 0:
-		err := clientcmdapi.FlattenContent(&authInfo.ClientCertificate, &authInfo.ClientCertificateData, baseDir)
-		if err != nil {
-			return "", err
-		}
-	case len(authInfo.Token) == 0 && len(authInfo.TokenFile) > 0:
-		tmpValue := []byte{}
-
-		err := clientcmdapi.FlattenContent(&authInfo.TokenFile, &tmpValue, baseDir)
-		if err != nil {
-			return "", err
-		}
-
-		authInfo.Token = string(tmpValue)
-	case authInfo.Exec != nil && len(authInfo.Exec.Command) > 0:
-		// The command originates from the users kubeconfig and is also executed when using kubectl.
-		// So it should be safe to execute it here as well.
-		var out bytes.Buffer
-
-		execCmd := exec.Command(authInfo.Exec.Command, authInfo.Exec.Args...)
-		execCmd.Stdout = &out
-
-		err := execCmd.Run()
-		if err != nil {
-			return "", err
-		}
-
-		var execCredential clientauthentication.ExecCredential
-
-		err = json.Unmarshal(out.Bytes(), &execCredential)
-		if err != nil {
-			return "", err
-		}
-
-		if token := execCredential.Status.Token; len(token) > 0 {
-			authInfo.Token = token
-		} else if cert := execCredential.Status.ClientCertificateData; len(cert) > 0 {
-			authInfo.ClientCertificateData = []byte(cert)
-		}
-	}
-
-	if len(authInfo.ClientCertificateData) > 0 {
-		block, _ := pem.Decode(authInfo.ClientCertificateData) // does not return an error, just nil
-		if block == nil {
-			return "", fmt.Errorf("could not decode PEM certificate")
-		}
-
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return "", err
-		}
-
-		user := cert.Subject.CommonName
-		if len(user) > 0 {
-			return user, nil
-		}
-	}
-
-	if len(authInfo.Token) > 0 {
-		tokenReview, err := gardenClient.CreateTokenReview(ctx, authInfo.Token)
-		if err != nil {
-			return "", err
-		}
-
-		if user := tokenReview.Status.User.Username; user != "" {
-			return user, nil
-		}
-	}
-
-	return "", fmt.Errorf("could not detect current user")
-}
-
-func (u *userBastionListPatcherImpl) AuthInfo(clientConfig clientcmd.ClientConfig) (*clientcmdapi.AuthInfo, error) {
-	rawConfig, err := clientConfig.RawConfig()
-	if err != nil {
-		return nil, fmt.Errorf("could not retrieve raw config: %w", err)
-	}
-
-	context, ok := rawConfig.Contexts[rawConfig.CurrentContext]
-	if !ok {
-		return nil, fmt.Errorf("no context found for current context %s", rawConfig.CurrentContext)
-	}
-
-	authInfo, ok := rawConfig.AuthInfos[context.AuthInfo]
-	if !ok {
-		return nil, fmt.Errorf("no auth info found with name %s", context.AuthInfo)
-	}
-
-	return authInfo, nil
 }
 
 func (u *userBastionListPatcherImpl) Patch(ctx context.Context, newBastion, oldBastion *operationsv1alpha1.Bastion) error {

--- a/pkg/cmd/sshpatch/completions.go
+++ b/pkg/cmd/sshpatch/completions.go
@@ -26,7 +26,7 @@ func GetBastionNameCompletions(f util.Factory, cmd *cobra.Command, prefix string
 		return nil, fmt.Errorf("failed to get manager: %w", err)
 	}
 
-	userBastionLister, err := newUserBastionListPatcher(ctx, manager)
+	userBastionLister, err := newUserBastionListPatcher(manager)
 	if err != nil {
 		return nil, fmt.Errorf("could not create bastion lister: %w", err)
 	}

--- a/pkg/cmd/sshpatch/export_test.go
+++ b/pkg/cmd/sshpatch/export_test.go
@@ -7,31 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package sshpatch
 
 import (
-	"context"
-
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/ssh"
-	"github.com/gardener/gardenctl-v2/pkg/target"
 )
-
-type TestUserBastionListPatcherImpl struct {
-	userBastionListPatcherImpl
-}
-
-func NewTestUserBastionPatchLister(manager target.Manager) *TestUserBastionListPatcherImpl {
-	target, _ := manager.CurrentTarget()
-	gc, _ := manager.GardenClient(target.GardenName())
-	clientConfig, _ := manager.ClientConfig(context.Background(), target)
-
-	return &TestUserBastionListPatcherImpl{
-		userBastionListPatcherImpl: userBastionListPatcherImpl{
-			gardenClient: gc,
-			target:       target,
-			clientConfig: clientConfig,
-		},
-	}
-}
 
 type TestOptions struct {
 	options

--- a/pkg/cmd/sshpatch/options.go
+++ b/pkg/cmd/sshpatch/options.go
@@ -113,7 +113,7 @@ func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) er
 		return err
 	}
 
-	bastionListPatcher, err := newUserBastionListPatcher(ctx, manager)
+	bastionListPatcher, err := newUserBastionListPatcher(manager)
 	if err != nil {
 		return fmt.Errorf("could not create bastion lister: %w", err)
 	}

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -137,7 +137,7 @@ func newGardenClient(name string, config *config.Config, provider ClientProvider
 		return nil, err
 	}
 
-	return gardenclient.NewGardenClient(client, garden.Name), nil
+	return gardenclient.NewGardenClient(clientConfig, client, garden.Name), nil
 }
 
 // NewManager returns a new manager.

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -146,13 +146,16 @@ var _ = Describe("Target Manager", func() {
 			},
 		}
 
+		testSeedKubeconfig, err := fake.NewConfigData("test-seed")
+		Expect(err).ToNot(HaveOccurred())
+
 		seedKubeconfigSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-seed.login",
 				Namespace: "garden",
 			},
 			Data: map[string][]byte{
-				"kubeconfig": createTestKubeconfig("test-seed"),
+				"kubeconfig": testSeedKubeconfig,
 			},
 		}
 

--- a/pkg/target/mocks/mock_manager.go
+++ b/pkg/target/mocks/mock_manager.go
@@ -8,13 +8,12 @@ import (
 	context "context"
 	reflect "reflect"
 
-	gomock "github.com/golang/mock/gomock"
-	clientcmd "k8s.io/client-go/tools/clientcmd"
-	client "sigs.k8s.io/controller-runtime/pkg/client"
-
 	gardenclient "github.com/gardener/gardenctl-v2/internal/gardenclient"
 	config "github.com/gardener/gardenctl-v2/pkg/config"
 	target "github.com/gardener/gardenctl-v2/pkg/target"
+	gomock "github.com/golang/mock/gomock"
+	clientcmd "k8s.io/client-go/tools/clientcmd"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // MockManager is a mock of Manager interface.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves the code to determine the current user to the gardenClient for better reusability.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
