### PR TITLE
Refactor ssh command builder

### DIFF
--- a/docs/help/gardenctl.md
+++ b/docs/help/gardenctl.md
@@ -56,7 +56,7 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 * [gardenctl kubectl-env](gardenctl_kubectl-env.md)	 - Generate a script that points KUBECONFIG to the targeted cluster for the specified shell
 * [gardenctl provider-env](gardenctl_provider-env.md)	 - Generate the cloud provider CLI configuration script for the specified shell
 * [gardenctl rc](gardenctl_rc.md)	 - Generate a gardenctl startup script for the specified shell
-* [gardenctl ssh](gardenctl_ssh.md)	 - Establish an SSH connection to a Shoot cluster's node
+* [gardenctl ssh](gardenctl_ssh.md)	 - Establish an SSH connection to a node of a Shoot cluster
 * [gardenctl ssh-patch](gardenctl_ssh-patch.md)	 - Update a bastion host previously created through the ssh command
 * [gardenctl target](gardenctl_target.md)	 - Set scope for next operations, using subcommands or pattern
 * [gardenctl version](gardenctl_version.md)	 - Print the gardenctl version information

--- a/docs/help/gardenctl_ssh-patch.md
+++ b/docs/help/gardenctl_ssh-patch.md
@@ -10,7 +10,7 @@ gardenctl ssh-patch [BASTION_NAME] [flags]
 
 ```
 # Update CIDRs on one of your bastion hosts. You can specify multiple CIDRs.
-gardenctl ssh-patch cli-xxxxxxxx --cidr 10.1.2.3/20 --cidr dead:beaf::/64
+gardenctl ssh-patch cli-xxxxxxxx --cidr 10.1.2.3/32 --cidr dead:beaf::/64
 
 # You can also omit the CIDR-flag and your system's public IPs (v4 and v6) will be auto-detected.
 gardenctl ssh-patch cli-xxxxxxxx

--- a/docs/help/gardenctl_ssh.md
+++ b/docs/help/gardenctl_ssh.md
@@ -1,9 +1,36 @@
 ## gardenctl ssh
 
-Establish an SSH connection to a Shoot cluster's node
+Establish an SSH connection to a node of a Shoot cluster
+
+### Synopsis
+
+Establish an SSH connection to a node of a Shoot cluster by specifying its name. 
+
+A bastion is created to access the node and is automatically cleaned up afterwards.
+
+If a node name is not provided, gardenctl will display the hostnames/IPs of the Shoot worker nodes and the corresponding SSH command.
+To connect to a desired node, copy the printed SSH command, replace the target hostname accordingly, and execute the command.
 
 ```
 gardenctl ssh [NODE_NAME] [flags]
+```
+
+### Examples
+
+```
+# Establish an SSH connection to a specific Shoot cluster node
+gardenctl ssh my-shoot-node-1
+
+# Establish an SSH connection with custom CIDRs to allow access to the bastion host
+gardenctl ssh my-shoot-node-1 --cidr 10.1.2.3/32
+
+# Establish an SSH connection to any Shoot cluster node
+# Copy the printed SSH command, replace the 'IP_OR_HOSTNAME' placeholder for the target hostname/IP, and execute the command to connect to the desired node
+gardenctl ssh
+
+# Create the bastion and output the connection information in JSON format
+gardenctl ssh --no-keepalive --keep-bastion --interactive=false --output json
+
 ```
 
 ### Options

--- a/pkg/cmd/ssh/arguments.go
+++ b/pkg/cmd/ssh/arguments.go
@@ -1,0 +1,81 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ssh
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+)
+
+type arguments struct {
+	list []argument
+}
+
+var _ fmt.Stringer = (*arguments)(nil)
+
+type argument struct {
+	value               string
+	shellEscapeDisabled bool
+}
+
+// String returns a shell escaped arguments string.
+func (a *arguments) String() string {
+	var sb strings.Builder
+
+	for i, arg := range a.list {
+		if i > 0 {
+			sb.WriteString(" ")
+		}
+
+		value := arg.value
+		if !arg.shellEscapeDisabled {
+			value = util.ShellEscape(value)
+		}
+
+		sb.WriteString(value)
+	}
+
+	return sb.String()
+}
+
+func sshCommandArguments(bastionAddress string, sshPrivateKeyFile PrivateKeyFile, nodeHostname string, nodePrivateKeyFiles []PrivateKeyFile) arguments {
+	proxyCmdArgs := sshProxyCmdArguments(bastionAddress, sshPrivateKeyFile)
+
+	args := []argument{
+		{value: "-oStrictHostKeyChecking=no", shellEscapeDisabled: true},
+		{value: "-oIdentitiesOnly=yes", shellEscapeDisabled: true},
+	}
+
+	for _, file := range nodePrivateKeyFiles {
+		args = append(args, argument{value: fmt.Sprintf("-i%s", file)})
+	}
+
+	args = append(args, argument{value: fmt.Sprintf("-oProxyCommand=%s", proxyCmdArgs.String())})
+
+	args = append(args, argument{value: fmt.Sprintf("%s@%s", SSHNodeUsername, nodeHostname)})
+
+	return arguments{list: args}
+}
+
+func sshProxyCmdArguments(bastionAddress string, sshPrivateKeyFile PrivateKeyFile) arguments {
+	args := []argument{
+		{value: "ssh", shellEscapeDisabled: true},
+		{value: "-W%h:%p", shellEscapeDisabled: true},
+		{value: "-oStrictHostKeyChecking=no", shellEscapeDisabled: true},
+	}
+
+	if sshPrivateKeyFile != "" {
+		args = append(args, argument{value: "-oIdentitiesOnly=yes", shellEscapeDisabled: true})
+		args = append(args, argument{value: fmt.Sprintf("-i%s", sshPrivateKeyFile)})
+	}
+
+	args = append(args, argument{value: fmt.Sprintf("%s@%s", SSHBastionUsername, bastionAddress)})
+
+	return arguments{list: args}
+}

--- a/pkg/cmd/ssh/key_file.go
+++ b/pkg/cmd/ssh/key_file.go
@@ -1,0 +1,55 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package ssh
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+type PublicKeyFile string
+
+var (
+	_ pflag.Value  = (*PublicKeyFile)(nil)
+	_ fmt.Stringer = (*PublicKeyFile)(nil)
+)
+
+func (s *PublicKeyFile) Set(val string) error {
+	*s = PublicKeyFile(val)
+
+	return nil
+}
+
+func (s *PublicKeyFile) Type() string {
+	return "string"
+}
+
+func (s *PublicKeyFile) String() string {
+	return string(*s)
+}
+
+type PrivateKeyFile string
+
+var (
+	_ pflag.Value  = (*PrivateKeyFile)(nil)
+	_ fmt.Stringer = (*PrivateKeyFile)(nil)
+)
+
+func (s *PrivateKeyFile) Set(val string) error {
+	*s = PrivateKeyFile(val)
+
+	return nil
+}
+
+func (s *PrivateKeyFile) Type() string {
+	return "string"
+}
+
+func (s *PrivateKeyFile) String() string {
+	return string(*s)
+}

--- a/pkg/cmd/ssh/ssh.go
+++ b/pkg/cmd/ssh/ssh.go
@@ -19,8 +19,27 @@ import (
 func NewCmdSSH(f util.Factory, o *SSHOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ssh [NODE_NAME]",
-		Short: "Establish an SSH connection to a Shoot cluster's node",
-		Args:  cobra.MaximumNArgs(1),
+		Short: "Establish an SSH connection to a node of a Shoot cluster",
+		Long: `Establish an SSH connection to a node of a Shoot cluster by specifying its name. 
+
+A bastion is created to access the node and is automatically cleaned up afterwards.
+
+If a node name is not provided, gardenctl will display the hostnames/IPs of the Shoot worker nodes and the corresponding SSH command.
+To connect to a desired node, copy the printed SSH command, replace the target hostname accordingly, and execute the command.`,
+		Example: `# Establish an SSH connection to a specific Shoot cluster node
+gardenctl ssh my-shoot-node-1
+
+# Establish an SSH connection with custom CIDRs to allow access to the bastion host
+gardenctl ssh my-shoot-node-1 --cidr 10.1.2.3/32
+
+# Establish an SSH connection to any Shoot cluster node
+# Copy the printed SSH command, replace the 'IP_OR_HOSTNAME' placeholder for the target hostname/IP, and execute the command to connect to the desired node
+gardenctl ssh
+
+# Create the bastion and output the connection information in JSON format
+gardenctl ssh --no-keepalive --keep-bastion --interactive=false --output json
+`,
+		Args: cobra.MaximumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			ctx := f.Context()
 			logger := klog.FromContext(ctx)

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -345,15 +345,15 @@ var _ = Describe("SSH Command", func() {
 
 				Expect(command).To(Equal("ssh"))
 				Expect(args).To(Equal([]string{
-					"-o", "StrictHostKeyChecking=no",
-					"-o", "IdentitiesOnly=yes",
-					"-o", fmt.Sprintf(
-						"ProxyCommand=ssh -W%%h:%%p -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i %s %s@%s",
+					"-oStrictHostKeyChecking=no",
+					"-oIdentitiesOnly=yes",
+					fmt.Sprintf("-i%s", nodePrivateKeyFile),
+					fmt.Sprintf(
+						"-oProxyCommand=ssh -W%%h:%%p -oStrictHostKeyChecking=no -oIdentitiesOnly=yes '-i%s' '%s@%s'",
 						o.SSHPrivateKeyFile,
 						ssh.SSHBastionUsername,
 						bastionIP,
 					),
-					"-i", nodePrivateKeyFile,
 					fmt.Sprintf("%s@%s", ssh.SSHNodeUsername, nodeHostname),
 				}))
 
@@ -399,15 +399,15 @@ var _ = Describe("SSH Command", func() {
 
 				Expect(command).To(Equal("ssh"))
 				Expect(args).To(Equal([]string{
-					"-o", "StrictHostKeyChecking=no",
-					"-o", "IdentitiesOnly=yes",
-					"-o", fmt.Sprintf(
-						"ProxyCommand=ssh -W%%h:%%p -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i %s %s@%s",
+					"-oStrictHostKeyChecking=no",
+					"-oIdentitiesOnly=yes",
+					fmt.Sprintf("-i%s", nodePrivateKeyFile),
+					fmt.Sprintf(
+						"-oProxyCommand=ssh -W%%h:%%p -oStrictHostKeyChecking=no -oIdentitiesOnly=yes '-i%s' '%s@%s'",
 						o.SSHPrivateKeyFile,
 						ssh.SSHBastionUsername,
 						bastionIP,
 					),
-					"-i", nodePrivateKeyFile,
 					fmt.Sprintf("%s@%s", ssh.SSHNodeUsername, nodeName),
 				}))
 

--- a/pkg/cmd/sshpatch/bastionlistpatcher.go
+++ b/pkg/cmd/sshpatch/bastionlistpatcher.go
@@ -18,7 +18,7 @@ import (
 )
 
 type bastionLister interface {
-	// List lists all bastions for the current target
+	// List lists all bastions for the current user and current target
 	List(ctx context.Context) ([]operationsv1alpha1.Bastion, error)
 }
 
@@ -32,16 +32,16 @@ type bastionListPatcher interface {
 	bastionLister
 }
 
-type userBastionListPatcherImpl struct {
+type bastionListPatcherImpl struct {
 	target       target.Target
 	gardenClient clientgarden.Client
 }
 
-var _ bastionListPatcher = &userBastionListPatcherImpl{}
+var _ bastionListPatcher = &bastionListPatcherImpl{}
 
-// newUserBastionListPatcher creates a new bastionListPatcher which only lists bastions
+// newBastionListPatcher creates a new bastionListPatcher which only lists bastions
 // of the current user.
-func newUserBastionListPatcher(manager target.Manager) (bastionListPatcher, error) {
+func newBastionListPatcher(manager target.Manager) (bastionListPatcher, error) {
 	currentTarget, err := manager.CurrentTarget()
 	if err != nil {
 		return nil, err
@@ -54,13 +54,13 @@ func newUserBastionListPatcher(manager target.Manager) (bastionListPatcher, erro
 		return nil, err
 	}
 
-	return &userBastionListPatcherImpl{
+	return &bastionListPatcherImpl{
 		currentTarget,
 		gardenClient,
 	}, nil
 }
 
-func (u *userBastionListPatcherImpl) List(ctx context.Context) ([]operationsv1alpha1.Bastion, error) {
+func (u *bastionListPatcherImpl) List(ctx context.Context) ([]operationsv1alpha1.Bastion, error) {
 	user, err := u.gardenClient.CurrentUser(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("could not get current user: %w", err)
@@ -96,6 +96,6 @@ func (u *userBastionListPatcherImpl) List(ctx context.Context) ([]operationsv1al
 	return bastionsOfUser, nil
 }
 
-func (u *userBastionListPatcherImpl) Patch(ctx context.Context, newBastion, oldBastion *operationsv1alpha1.Bastion) error {
+func (u *bastionListPatcherImpl) Patch(ctx context.Context, newBastion, oldBastion *operationsv1alpha1.Bastion) error {
 	return u.gardenClient.PatchBastion(ctx, newBastion, oldBastion)
 }

--- a/pkg/cmd/sshpatch/completions.go
+++ b/pkg/cmd/sshpatch/completions.go
@@ -26,7 +26,7 @@ func GetBastionNameCompletions(f util.Factory, _ *cobra.Command, prefix string) 
 		return nil, fmt.Errorf("failed to get manager: %w", err)
 	}
 
-	userBastionLister, err := newUserBastionListPatcher(manager)
+	userBastionLister, err := newBastionListPatcher(manager)
 	if err != nil {
 		return nil, fmt.Errorf("could not create bastion lister: %w", err)
 	}

--- a/pkg/cmd/sshpatch/options.go
+++ b/pkg/cmd/sshpatch/options.go
@@ -113,7 +113,7 @@ func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) er
 		return err
 	}
 
-	bastionListPatcher, err := newUserBastionListPatcher(manager)
+	bastionListPatcher, err := newBastionListPatcher(manager)
 	if err != nil {
 		return fmt.Errorf("could not create bastion lister: %w", err)
 	}

--- a/pkg/cmd/sshpatch/sshpatch.go
+++ b/pkg/cmd/sshpatch/sshpatch.go
@@ -24,7 +24,7 @@ func NewCmdSSHPatch(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
 		Use:   "ssh-patch [BASTION_NAME]",
 		Short: "Update a bastion host previously created through the ssh command",
 		Example: `# Update CIDRs on one of your bastion hosts. You can specify multiple CIDRs.
-gardenctl ssh-patch cli-xxxxxxxx --cidr 10.1.2.3/20 --cidr dead:beaf::/64
+gardenctl ssh-patch cli-xxxxxxxx --cidr 10.1.2.3/32 --cidr dead:beaf::/64
 
 # You can also omit the CIDR-flag and your system's public IPs (v4 and v6) will be auto-detected.
 gardenctl ssh-patch cli-xxxxxxxx`,


### PR DESCRIPTION
**What this PR does / why we need it**:
- This PR refactors the code responsible for constructing the SSH command arguments
- Deduplicated code: Now, there is a single implementation for building the ssh command arguments, which is used for both printing to stdout and passing to `exec.CommandContext`
- The `ssh` command that is printed to stdout is now shell-escaped

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
`ssh`: the command that is printed to stdout is now shell-escaped
```
