### PR TITLE
bump golang to 1.20.3 and golangci-lint to 1.52.2

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -9,11 +9,11 @@ gardenctl-v2:
         inject_effective_version: true
     steps:
       check:
-        image: 'golang:1.19.7'
+        image: 'golang:1.20.3'
       test:
-        image: 'golang:1.19.7'
+        image: 'golang:1.20.3'
       build:
-        image: 'golang:1.19.7'
+        image: 'golang:1.20.3'
         output_dir: 'binary'
         timeout: '5m'
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,5 +20,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@07db5389c99593f11ad7b44463c2d4233066a9b1 # pin@v3.3.0
         with:
-          version: v1.50
+          version: v1.52.2
           args: --verbose --timeout 5m

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f # pin@v3.3.1
         with:
-          go-version: 1.19
+          go-version: '1.20'
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
       - name: golangci-lint
         uses: golangci/golangci-lint-action@07db5389c99593f11ad7b44463c2d4233066a9b1 # pin@v3.3.0

--- a/.github/workflows/update-gardenctl-v2.yaml
+++ b/.github/workflows/update-gardenctl-v2.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # pin@v3.3.0
       - uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # pin@v3.5.0
         with:
-          go-version: '1.19.7'
+          go-version: '1.20.3'
       - name: Build the binary-files
         id: build_binary_files
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/gardenctl-v2
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/semver v1.5.0

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -17,7 +17,7 @@ else
 fi
 
 # Install golangci-lint (linting tool)
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.51.2
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.52.2
 
 cd "$SOURCE_PATH"
 

--- a/internal/fake/factory.go
+++ b/internal/fake/factory.go
@@ -97,7 +97,7 @@ func (f *Factory) Clock() util.Clock {
 	return f.ClockImpl
 }
 
-func (f *Factory) PublicIPs(ctx context.Context) ([]string, error) {
+func (f *Factory) PublicIPs(_ context.Context) ([]string, error) {
 	return []string{"192.0.2.42", "2001:db8::8a2e:370:7334"}, nil
 }
 

--- a/pkg/cmd/base/options.go
+++ b/pkg/cmd/base/options.go
@@ -111,7 +111,7 @@ func (o *Options) Validate() error {
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *Options) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+func (o *Options) Complete(_ util.Factory, _ *cobra.Command, _ []string) error {
 	return nil
 }
 

--- a/pkg/cmd/config/delete_garden.go
+++ b/pkg/cmd/config/delete_garden.go
@@ -46,7 +46,7 @@ type deleteGardenOptions struct {
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *deleteGardenOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+func (o *deleteGardenOptions) Complete(f util.Factory, _ *cobra.Command, args []string) error {
 	config, err := getConfiguration(f)
 	if err != nil {
 		return err

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -75,7 +75,7 @@ type setGardenOptions struct {
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *setGardenOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+func (o *setGardenOptions) Complete(f util.Factory, _ *cobra.Command, args []string) error {
 	config, err := getConfiguration(f)
 	if err != nil {
 		return err
@@ -96,11 +96,7 @@ func (o *setGardenOptions) Validate() error {
 		return errors.New("garden identity is required")
 	}
 
-	if err := validatePatterns(o.Patterns); err != nil {
-		return err
-	}
-
-	return nil
+	return validatePatterns(o.Patterns)
 }
 
 // AddFlags adds flags to adjust the output to a cobra command.

--- a/pkg/cmd/config/view.go
+++ b/pkg/cmd/config/view.go
@@ -41,7 +41,7 @@ type viewOptions struct {
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *viewOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+func (o *viewOptions) Complete(f util.Factory, _ *cobra.Command, _ []string) error {
 	config, err := getConfiguration(f)
 	if err != nil {
 		return err

--- a/pkg/cmd/env/options.go
+++ b/pkg/cmd/env/options.go
@@ -58,7 +58,7 @@ type options struct {
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *options) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+func (o *options) Complete(f util.Factory, cmd *cobra.Command, _ []string) error {
 	o.Shell = cmd.Name()
 	o.CmdPath = cmd.Parent().CommandPath()
 	o.GardenDir = f.GardenHomeDir()
@@ -92,11 +92,8 @@ func (o *options) Validate() error {
 	}
 
 	s := Shell(o.Shell)
-	if err := s.Validate(); err != nil {
-		return err
-	}
 
-	return nil
+	return s.Validate()
 }
 
 // AddFlags binds the command options to a given flagset.

--- a/pkg/cmd/env/rc.go
+++ b/pkg/cmd/env/rc.go
@@ -187,7 +187,7 @@ type rcOptions struct {
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *rcOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+func (o *rcOptions) Complete(_ util.Factory, cmd *cobra.Command, _ []string) error {
 	o.Shell = cmd.Name()
 	o.CmdPath = cmd.Parent().CommandPath()
 	o.Template = newTemplate("rc")
@@ -214,7 +214,7 @@ func (o *rcOptions) Validate() error {
 }
 
 // Run does the actual work of the command.
-func (o *rcOptions) Run(f util.Factory) error {
+func (o *rcOptions) Run(_ util.Factory) error {
 	data := map[string]interface{}{
 		"shell":        o.Shell,
 		"prefix":       o.Prefix,

--- a/pkg/cmd/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kubeconfig/kubeconfig.go
@@ -149,7 +149,7 @@ func (o *options) Validate() error {
 }
 
 // Run does the actual work of the command.
-func (o *options) Run(f util.Factory) error {
+func (o *options) Run(_ util.Factory) error {
 	if o.Minify {
 		if len(o.Context) > 0 {
 			o.RawConfig.CurrentContext = o.Context

--- a/pkg/cmd/sshpatch/completions.go
+++ b/pkg/cmd/sshpatch/completions.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gardener/gardenctl-v2/internal/util"
 )
 
-func GetBastionNameCompletions(f util.Factory, cmd *cobra.Command, prefix string) ([]string, error) {
+func GetBastionNameCompletions(f util.Factory, _ *cobra.Command, prefix string) ([]string, error) {
 	ctx, cancel := context.WithTimeout(f.Context(), 30*time.Second)
 	defer cancel()
 

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -133,7 +133,7 @@ func NewTargetOptions(ioStreams util.IOStreams) *TargetOptions {
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *TargetOptions) Complete(f util.Factory, cmd *cobra.Command, args []string) error {
+func (o *TargetOptions) Complete(f util.Factory, _ *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		if o.Kind == "" {
 			o.Kind = TargetKindPattern

--- a/pkg/cmd/target/unset.go
+++ b/pkg/cmd/target/unset.go
@@ -54,7 +54,7 @@ type UnsetOptions struct {
 }
 
 // Complete adapts from the command line args to the data required.
-func (o *UnsetOptions) Complete(_ util.Factory, cmd *cobra.Command, args []string) error {
+func (o *UnsetOptions) Complete(_ util.Factory, _ *cobra.Command, args []string) error {
 	if len(args) > 0 {
 		o.Kind = TargetKind(strings.TrimSpace(args[0]))
 	}
@@ -76,11 +76,7 @@ func ValidateKind(kind TargetKind) error {
 
 // Validate validates the provided options.
 func (o *UnsetOptions) Validate() error {
-	if err := ValidateKind(o.Kind); err != nil {
-		return err
-	}
-
-	return nil
+	return ValidateKind(o.Kind)
 }
 
 // Run executes the command.

--- a/pkg/flags/target.go
+++ b/pkg/flags/target.go
@@ -21,7 +21,7 @@ import (
 // RegisterCompletionFuncsForTargetFlags registers the completion functions to a given cobra command
 // for the target flags (--garden, --project, --seed and --shoot). Each completion function is only
 // registered if the flag has been previously added to the provided flag set.
-func RegisterCompletionFuncsForTargetFlags(cmd *cobra.Command, factory util.Factory, ioStreams util.IOStreams, flags *pflag.FlagSet) {
+func RegisterCompletionFuncsForTargetFlags(cmd *cobra.Command, factory util.Factory, ioStreams util.IOStreams, _ *pflag.FlagSet) {
 	if cmd.Flag("garden") != nil {
 		utilruntime.Must(cmd.RegisterFlagCompletionFunc("garden", completionWrapper(factory, ioStreams, gardenFlagCompletionFunc)))
 	}

--- a/pkg/target/target_builder.go
+++ b/pkg/target/target_builder.go
@@ -178,7 +178,7 @@ func (b *targetBuilderImpl) SetShoot(ctx context.Context, name string) TargetBui
 	return b
 }
 
-func (b *targetBuilderImpl) SetControlPlane(ctx context.Context) TargetBuilder {
+func (b *targetBuilderImpl) SetControlPlane(_ context.Context) TargetBuilder {
 	b.actions = append(b.actions, func(t *targetImpl) error {
 		if t.Garden == "" {
 			return ErrNoGardenTargeted


### PR DESCRIPTION
**What this PR does / why we need it**:
bumps golang to 1.20.3 and golangci-lint to 1.52.2

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

```other developer
The golang version to build the binaries is upgraded to `v1.20.3`
```
