### PR TITLE
`ssh` add `--bastion-name` to reuse bastion

### DIFF
--- a/docs/help/gardenctl_ssh.md
+++ b/docs/help/gardenctl_ssh.md
@@ -31,11 +31,15 @@ gardenctl ssh
 # Create the bastion and output the connection information in JSON format
 gardenctl ssh --no-keepalive --keep-bastion --interactive=false --output json
 
+# Reuse a previously created bastion
+gardenctl ssh --keep-bastion --bastion-name cli-xxxxxxxx --public-key-file /path/to/ssh/key.pub --private-key-file /path/to/ssh/key
+
 ```
 
 ### Options
 
 ```
+      --bastion-name string       Name of the bastion. If a bastion with this name doesn't exist, it will be created. If it does exist, the provided public SSH key must match the one used during the bastion's creation.
       --cidr stringArray          CIDRs to allow access to the bastion host; if not given, your system's public IPs (v4 and v6) are auto-detected.
       --control-plane             target control plane of shoot, use together with shoot argument
       --garden string             target the given garden cluster
@@ -44,6 +48,7 @@ gardenctl ssh --no-keepalive --keep-bastion --interactive=false --output json
       --keep-bastion              Do not delete immediately when gardenctl exits (Bastions will be garbage-collected after some time)
       --no-keepalive              Exit after the bastion host became available without keeping the bastion alive or establishing an SSH connection. Note that this flag requires the flags --interactive=false and --keep-bastion to be set
   -o, --output string             One of 'yaml' or 'json'.
+      --private-key-file string   Path to the file that contains a private SSH key. Must be provided alongside the --public-key-file flag if you want to use a custom keypair. If not provided, gardenctl will either generate a temporary keypair or rely on the user's SSH agent for an available private key.
       --project string            target the given project
       --public-key-file string    Path to the file that contains a public SSH key. If not given, a temporary keypair will be generated.
       --seed string               target the given seed cluster

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -192,9 +192,9 @@ type SSHOptions struct {
 	// private SSH key. If not set, gardenctl relies on the user's SSH agent.
 	SSHPrivateKeyFile PrivateKeyFile
 
-	// generatedSSHKeys is true if the public and private SSH keys have been generated
+	// GeneratedSSHKeys is true if the public and private SSH keys have been generated
 	// instead of being provided by the user. This will then be used for the cleanup.
-	generatedSSHKeys bool
+	GeneratedSSHKeys bool
 
 	// WaitTimeout is the maximum time to wait for a bastion to become ready.
 	WaitTimeout time.Duration
@@ -259,7 +259,7 @@ func (o *SSHOptions) Complete(f util.Factory, cmd *cobra.Command, args []string)
 
 		o.SSHPublicKeyFile = publicKeyFile
 		o.SSHPrivateKeyFile = privateKeyFile
-		o.generatedSSHKeys = true
+		o.GeneratedSSHKeys = true
 	}
 
 	if len(o.SSHPrivateKeyFile) == 0 {
@@ -732,7 +732,7 @@ func cleanup(ctx context.Context, o *SSHOptions, gardenClient client.Client, bas
 			logger.Error(err, "Failed to delete bastion.", "bastion", klog.KObj(bastion))
 		}
 
-		if o.generatedSSHKeys {
+		if o.GeneratedSSHKeys {
 			if err := os.Remove(o.SSHPublicKeyFile.String()); err != nil {
 				logger.Error(err, "Failed to delete SSH public key file", "path", o.SSHPublicKeyFile)
 			}
@@ -753,7 +753,7 @@ func cleanup(ctx context.Context, o *SSHOptions, gardenClient client.Client, bas
 	} else {
 		logger.Info("Keeping bastion", "bastion", klog.KRef(bastionKey.Namespace, bastionKey.Name))
 
-		if o.generatedSSHKeys {
+		if o.GeneratedSSHKeys {
 			logger.Info("The SSH keypair for the bastion remain on disk", "publicKeyPath", o.SSHPublicKeyFile, "privateKeyPath", o.SSHPrivateKeyFile)
 		}
 

--- a/pkg/cmd/ssh/ssh.go
+++ b/pkg/cmd/ssh/ssh.go
@@ -38,6 +38,9 @@ gardenctl ssh
 
 # Create the bastion and output the connection information in JSON format
 gardenctl ssh --no-keepalive --keep-bastion --interactive=false --output json
+
+# Reuse a previously created bastion
+gardenctl ssh --keep-bastion --bastion-name cli-xxxxxxxx --public-key-file /path/to/ssh/key.pub --private-key-file /path/to/ssh/key
 `,
 		Args: cobra.MaximumNArgs(1),
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {


### PR DESCRIPTION
**What this PR does / why we need it**:
add `--bastion-name` flag. If a bastion with this name doesn't exist, it will be created. If it does exist, the provided public SSH key must match the one used during the bastion's creation.
In addition the `--private-key-file` flag was added. It must be provided alongside the `--public-key-file` flag if you want to use a custom keypair. If not provided, gardenctl will either generate a temporary keypair or rely on the user's SSH agent for an available private key.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`ssh`: reuse bastion, e.g. `gardenctl ssh --keep-bastion --bastion-name cli-xxxxxxxx --public-key-file /path/to/ssh/key.pub --private-key-file /path/to/ssh/key`
- `--bastion-name` flag was added. If a bastion with this name doesn't exist, it will be created. If it does exist, the provided public SSH key must match the one used during the bastion's creation
- `--private-key-file` flag was added. It must be provided alongside the `--public-key-file` flag if you want to use a custom keypair. If not provided, gardenctl will either generate a temporary keypair or rely on the user's SSH agent for an available private key.
```