### PR TITLE
`ssh`: add `--bastion-host`, `--bastion-port` flags to override the defaults

### DIFF
--- a/docs/help/gardenctl_ssh.md
+++ b/docs/help/gardenctl_ssh.md
@@ -39,7 +39,9 @@ gardenctl ssh --keep-bastion --bastion-name cli-xxxxxxxx --public-key-file /path
 ### Options
 
 ```
+      --bastion-host string       Override the hostname or IP address of the bastion used for the SSH client command. If not provided, the address will be automatically determined.
       --bastion-name string       Name of the bastion. If a bastion with this name doesn't exist, it will be created. If it does exist, the provided public SSH key must match the one used during the bastion's creation.
+      --bastion-port string       SSH port of the bastion used for the SSH client command. Defaults to port 22 (default "22")
       --cidr stringArray          CIDRs to allow access to the bastion host; if not given, your system's public IPs (v4 and v6) are auto-detected.
       --control-plane             target control plane of shoot, use together with shoot argument
       --garden string             target the given garden cluster

--- a/pkg/cmd/ssh/arguments.go
+++ b/pkg/cmd/ssh/arguments.go
@@ -44,8 +44,8 @@ func (a *arguments) String() string {
 	return sb.String()
 }
 
-func sshCommandArguments(bastionAddress string, sshPrivateKeyFile PrivateKeyFile, nodeHostname string, nodePrivateKeyFiles []PrivateKeyFile) arguments {
-	proxyCmdArgs := sshProxyCmdArguments(bastionAddress, sshPrivateKeyFile)
+func sshCommandArguments(bastionHost string, bastionPort string, sshPrivateKeyFile PrivateKeyFile, nodeHostname string, nodePrivateKeyFiles []PrivateKeyFile) arguments {
+	proxyCmdArgs := sshProxyCmdArguments(bastionHost, bastionPort, sshPrivateKeyFile)
 
 	args := []argument{
 		{value: "-oStrictHostKeyChecking=no", shellEscapeDisabled: true},
@@ -63,7 +63,7 @@ func sshCommandArguments(bastionAddress string, sshPrivateKeyFile PrivateKeyFile
 	return arguments{list: args}
 }
 
-func sshProxyCmdArguments(bastionAddress string, sshPrivateKeyFile PrivateKeyFile) arguments {
+func sshProxyCmdArguments(bastionHost string, bastionPort string, sshPrivateKeyFile PrivateKeyFile) arguments {
 	args := []argument{
 		{value: "ssh", shellEscapeDisabled: true},
 		{value: "-W%h:%p", shellEscapeDisabled: true},
@@ -75,7 +75,11 @@ func sshProxyCmdArguments(bastionAddress string, sshPrivateKeyFile PrivateKeyFil
 		args = append(args, argument{value: fmt.Sprintf("-i%s", sshPrivateKeyFile)})
 	}
 
-	args = append(args, argument{value: fmt.Sprintf("%s@%s", SSHBastionUsername, bastionAddress)})
+	args = append(args, argument{value: fmt.Sprintf("%s@%s", SSHBastionUsername, bastionHost)})
+
+	if bastionPort != "" {
+		args = append(args, argument{value: fmt.Sprintf("-p%s", bastionPort)})
+	}
 
 	return arguments{list: args}
 }

--- a/pkg/cmd/ssh/connect_information.go
+++ b/pkg/cmd/ssh/connect_information.go
@@ -44,6 +44,8 @@ type Bastion struct {
 	Namespace string `json:"namespace"`
 	// PreferredAddress is the preferred IP address or hostname to use when connecting to the bastion host.
 	PreferredAddress string `json:"preferredAddress"`
+	// Port is the port to use when connecting to the bastion host.
+	Port string `json:"port"`
 	// Address holds information about the IP address and hostname of the bastion host.
 	Address
 	// SSHPublicKeyFile is the full path to the file containing the public SSH key.
@@ -70,7 +72,7 @@ type Address struct {
 
 var _ fmt.Stringer = &Address{}
 
-func NewConnectInformation(bastion *operationsv1alpha1.Bastion, nodeHostname string, sshPublicKeyFile PublicKeyFile, sshPrivateKeyFile PrivateKeyFile, nodePrivateKeyFiles []PrivateKeyFile, nodes []corev1.Node) (*ConnectInformation, error) {
+func NewConnectInformation(bastion *operationsv1alpha1.Bastion, bastionPreferredAddress string, bastionPort string, nodeHostname string, sshPublicKeyFile PublicKeyFile, sshPrivateKeyFile PrivateKeyFile, nodePrivateKeyFiles []PrivateKeyFile, nodes []corev1.Node) (*ConnectInformation, error) {
 	var nodeList []Node
 
 	for _, node := range nodes {
@@ -113,7 +115,8 @@ func NewConnectInformation(bastion *operationsv1alpha1.Bastion, nodeHostname str
 		Bastion: Bastion{
 			Name:             bastion.Name,
 			Namespace:        bastion.Namespace,
-			PreferredAddress: preferredBastionAddress(bastion),
+			PreferredAddress: bastionPreferredAddress,
+			Port:             bastionPort,
 			Address: Address{
 				IP:       bastion.Status.Ingress.IP,
 				Hostname: bastion.Status.Ingress.Hostname,
@@ -175,7 +178,7 @@ func (p *ConnectInformation) String() string {
 		fmt.Fprintln(&buf, "")
 	}
 
-	connectArgs := sshCommandArguments(p.Bastion.PreferredAddress, p.Bastion.SSHPrivateKeyFile, nodeHostname, p.NodePrivateKeyFiles)
+	connectArgs := sshCommandArguments(p.Bastion.PreferredAddress, p.Bastion.Port, p.Bastion.SSHPrivateKeyFile, nodeHostname, p.NodePrivateKeyFiles)
 
 	fmt.Fprintln(&buf, "Connect to shoot nodes by using the bastion as a proxy/jump host, for example:")
 	fmt.Fprintln(&buf, "")

--- a/pkg/cmd/ssh/export_test.go
+++ b/pkg/cmd/ssh/export_test.go
@@ -10,9 +10,11 @@ import (
 	"context"
 	"os"
 	"time"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
 )
 
-func SetBastionAvailabilityChecker(f func(hostname string, privateKey []byte) error) {
+func SetBastionAvailabilityChecker(f func(hostname string, port string, privateKey []byte) error) {
 	bastionAvailabilityChecker = f
 }
 
@@ -28,7 +30,7 @@ func SetCreateSignalChannel(f func() chan os.Signal) {
 	createSignalChannel = f
 }
 
-func SetExecCommand(f func(ctx context.Context, command string, args []string, o *SSHOptions) error) {
+func SetExecCommand(f func(ctx context.Context, command string, args []string, ioStreams util.IOStreams) error) {
 	execCommand = f
 }
 

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -126,7 +126,7 @@ var _ = Describe("SSH Command", func() {
 		klog.LogToStderr(false) // must set to false, otherwise klog will log to os.stderr instead of to our buffer
 
 		// all fake bastions are always immediately available
-		ssh.SetBastionAvailabilityChecker(func(hostname string, privateKey []byte) error {
+		ssh.SetBastionAvailabilityChecker(func(hostname string, port string, privateKey []byte) error {
 			return nil
 		})
 
@@ -340,7 +340,7 @@ var _ = Describe("SSH Command", func() {
 
 			// do not actually execute any commands
 			executedCommands := 0
-			ssh.SetExecCommand(func(ctx context.Context, command string, args []string, o *ssh.SSHOptions) error {
+			ssh.SetExecCommand(func(ctx context.Context, command string, args []string, ioStreams util.IOStreams) error {
 				executedCommands++
 
 				Expect(command).To(Equal("ssh"))
@@ -349,8 +349,8 @@ var _ = Describe("SSH Command", func() {
 					"-oIdentitiesOnly=yes",
 					fmt.Sprintf("-i%s", nodePrivateKeyFile),
 					fmt.Sprintf(
-						"-oProxyCommand=ssh -W%%h:%%p -oStrictHostKeyChecking=no -oIdentitiesOnly=yes '-i%s' '%s@%s'",
-						o.SSHPrivateKeyFile,
+						"-oProxyCommand=ssh -W%%h:%%p -oStrictHostKeyChecking=no -oIdentitiesOnly=yes '-i%s' '%s@%s' '-p22'",
+						options.SSHPrivateKeyFile,
 						ssh.SSHBastionUsername,
 						bastionIP,
 					),
@@ -394,7 +394,7 @@ var _ = Describe("SSH Command", func() {
 
 			// do not actually execute any commands
 			executedCommands := 0
-			ssh.SetExecCommand(func(ctx context.Context, command string, args []string, o *ssh.SSHOptions) error {
+			ssh.SetExecCommand(func(ctx context.Context, command string, args []string, ioStreams util.IOStreams) error {
 				executedCommands++
 
 				Expect(command).To(Equal("ssh"))
@@ -403,8 +403,8 @@ var _ = Describe("SSH Command", func() {
 					"-oIdentitiesOnly=yes",
 					fmt.Sprintf("-i%s", nodePrivateKeyFile),
 					fmt.Sprintf(
-						"-oProxyCommand=ssh -W%%h:%%p -oStrictHostKeyChecking=no -oIdentitiesOnly=yes '-i%s' '%s@%s'",
-						o.SSHPrivateKeyFile,
+						"-oProxyCommand=ssh -W%%h:%%p -oStrictHostKeyChecking=no -oIdentitiesOnly=yes '-i%s' '%s@%s' '-p22'",
+						options.SSHPrivateKeyFile,
 						ssh.SSHBastionUsername,
 						bastionIP,
 					),
@@ -522,7 +522,7 @@ var _ = Describe("SSH Command", func() {
 
 			cmd := ssh.NewCmdSSH(factory, options)
 
-			ssh.SetBastionAvailabilityChecker(func(hostname string, privateKey []byte) error {
+			ssh.SetBastionAvailabilityChecker(func(hostname string, port string, privateKey []byte) error {
 				err := errors.New("this function should not be executed as of SkipAvailabilityCheck = true")
 				Fail(err.Error())
 				return err
@@ -547,7 +547,7 @@ var _ = Describe("SSH Command", func() {
 			ssh.SetWaitForSignal(func(ctx context.Context, o *ssh.SSHOptions, signalChan <-chan struct{}) {
 				Fail("this function should not be executed as of NoKeepalive = true")
 			})
-			ssh.SetExecCommand(func(ctx context.Context, command string, args []string, o *ssh.SSHOptions) error {
+			ssh.SetExecCommand(func(ctx context.Context, command string, args []string, ioStreams util.IOStreams) error {
 				err := errors.New("this function should not be executed as of NoKeepalive = true")
 				Fail(err.Error())
 				return err
@@ -574,7 +574,7 @@ var _ = Describe("SSH Command", func() {
 			ssh.SetWaitForSignal(func(ctx context.Context, o *ssh.SSHOptions, signalChan <-chan struct{}) {
 				Fail("this function should not be executed as of NoKeepalive = true")
 			})
-			ssh.SetExecCommand(func(ctx context.Context, command string, args []string, o *ssh.SSHOptions) error {
+			ssh.SetExecCommand(func(ctx context.Context, command string, args []string, ioStreams util.IOStreams) error {
 				err := errors.New("this function should not be executed as of NoKeepalive = true")
 				Fail(err.Error())
 				return err


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces two new flags, `--bastion-host` and `--bastion-port`, to the `ssh` subcommand. These flags enable user to customize the bastion host and port, for example, in SSH port forwarding scenarios.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`ssh`: Use the `--bastion-host` and `--bastion-port` flags to customize the bastion host and port for the SSH client command, respectively. These flags are useful when you need to specify an alternative host and port for SSH port forwarding scenarios.
- `--bastion-host`: Specify a custom hostname or IP address for the bastion used in the SSH client command. If not provided, the address will be automatically determined.
- `--bastion-port`: Set the SSH port of the bastion used for the SSH client command. By default, this value is set to port 22.
```
