### PR TITLE
Refactoring: Target provider should merge target with targetFlags

### DIFF
--- a/pkg/target/export_test.go
+++ b/pkg/target/export_test.go
@@ -1,0 +1,9 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package target
+
+var Merge = merge

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -60,6 +60,9 @@ type Target interface {
 	IsEmpty() bool
 	// AsListOption returns the target as list option
 	AsListOption() client.ListOption
+
+	// DeepCopy returns a deep copy of the target
+	DeepCopy() Target
 }
 
 type targetImpl struct {
@@ -202,4 +205,14 @@ func (t *targetImpl) AsListOption() client.ListOption {
 	}
 
 	return opt
+}
+
+func (t *targetImpl) DeepCopy() Target {
+	return &targetImpl{
+		Garden:           t.Garden,
+		Project:          t.Project,
+		Seed:             t.Seed,
+		Shoot:            t.Shoot,
+		ControlPlaneFlag: t.ControlPlaneFlag,
+	}
 }

--- a/pkg/target/target_flags_test.go
+++ b/pkg/target/target_flags_test.go
@@ -66,17 +66,6 @@ var _ = Describe("Target Flags", func() {
 		Expect(target.NewTargetFlags("garden", "project", "", "shoot", true).IsTargetValid()).To(BeTrue())
 	})
 
-	It("should override a target with target flags", func() {
-		tf := target.NewTargetFlags("garden", "project", "", "shoot", true)
-		t, err := tf.OverrideTarget(target.NewTarget("a", "b", "c", "d"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(t.GardenName()).To(Equal("garden"))
-		Expect(t.ProjectName()).To(Equal("project"))
-		Expect(t.SeedName()).To(BeEmpty())
-		Expect(t.ShootName()).To(Equal("shoot"))
-		Expect(t.ControlPlane()).To(BeTrue())
-	})
-
 	It("should convert to target", func() {
 		t := target.NewTargetFlags("garden", "project", "", "shoot", true).ToTarget()
 		Expect(t.GardenName()).To(Equal("garden"))
@@ -84,11 +73,5 @@ var _ = Describe("Target Flags", func() {
 		Expect(t.SeedName()).To(BeEmpty())
 		Expect(t.ShootName()).To(Equal("shoot"))
 		Expect(t.ControlPlane()).To(BeTrue())
-	})
-
-	It("should fail to override a target", func() {
-		tf := target.NewTargetFlags("", "", "", "shoot", false)
-		_, err := tf.OverrideTarget(target.NewTarget("", "b", "c", "d"))
-		Expect(err).To(HaveOccurred())
 	})
 })

--- a/pkg/target/target_provider_test.go
+++ b/pkg/target/target_provider_test.go
@@ -77,6 +77,24 @@ var _ = Describe("Target Provider", func() {
 		Expect(target.ShootName()).To(Equal(t.ShootName()))
 		Expect(target.ControlPlane()).To(Equal(t.ControlPlane()))
 	})
+
+	It("should override a target with target flags", func() {
+		tf := target.NewTargetFlags("garden", "project", "", "shoot", true)
+
+		t, err := target.Merge(target.NewTarget("a", "b", "c", "d"), tf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(t.GardenName()).To(Equal("garden"))
+		Expect(t.ProjectName()).To(Equal("project"))
+		Expect(t.SeedName()).To(BeEmpty())
+		Expect(t.ShootName()).To(Equal("shoot"))
+		Expect(t.ControlPlane()).To(BeTrue())
+	})
+
+	It("should fail to override a target", func() {
+		tf := target.NewTargetFlags("", "", "", "shoot", false)
+		_, err := target.Merge(target.NewTarget("", "b", "c", "d"), tf)
+		Expect(err).To(HaveOccurred())
+	})
 })
 
 var _ = Describe("Dynamic Target Provider", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
The target provider should merge the target with targetFlags.
It always returns a new copy of the target

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
