### PR TITLE
`provider-env`: support `json` / `yaml` output

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -16,6 +16,8 @@ Files:
   pkg/env/testdata/*/*.fish
   pkg/env/testdata/*/*.bash
   pkg/env/testdata/*/*.pwsh
+  pkg/env/testdata/*/*.json
+  pkg/env/testdata/*/*.yaml
   pkg/env/testdata/gcp/serviceaccount.json
   .dockerignore
   .gimps.yaml

--- a/docs/help/gardenctl_provider-env.md
+++ b/docs/help/gardenctl_provider-env.md
@@ -27,6 +27,10 @@ for the respective provider in the "templates" folder of the gardenctl home dire
 Please refer to the templates of the already supported cloud providers which can be found
 here https://github.com/gardener/gardenctl-v2/tree/master/pkg/cmd/env/templates.
 
+```
+gardenctl provider-env [flags]
+```
+
 ### Options
 
 ```
@@ -34,6 +38,7 @@ here https://github.com/gardener/gardenctl-v2/tree/master/pkg/cmd/env/templates.
   -f, --force            Generate the script even if there are access restrictions to be confirmed
       --garden string    target the given garden cluster
   -h, --help             help for provider-env
+  -o, --output string    One of 'yaml' or 'json'.
       --project string   target the given project
       --seed string      target the given seed cluster
       --shoot string     target the given shoot cluster

--- a/pkg/cmd/providerenv/export_test.go
+++ b/pkg/cmd/providerenv/export_test.go
@@ -43,8 +43,8 @@ func NewOptions() *TestOptions {
 	}
 }
 
-func (o *TestOptions) ExecTmpl(shoot *gardencorev1beta1.Shoot, secret *corev1.Secret, cloudProfile *gardencorev1beta1.CloudProfile, messages ...*ac.AccessRestrictionMessage) error {
-	return execTmpl(&o.options, shoot, secret, cloudProfile, messages)
+func (o *TestOptions) OutputProviderEnv(shoot *gardencorev1beta1.Shoot, secret *corev1.Secret, cloudProfile *gardencorev1beta1.CloudProfile, messages ...*ac.AccessRestrictionMessage) error {
+	return outputProviderEnv(&o.options, shoot, secret, cloudProfile, messages)
 }
 
 func (o *TestOptions) GenerateMetadata(cli string) map[string]interface{} {

--- a/pkg/cmd/providerenv/export_test.go
+++ b/pkg/cmd/providerenv/export_test.go
@@ -43,8 +43,8 @@ func NewOptions() *TestOptions {
 	}
 }
 
-func (o *TestOptions) OutputProviderEnv(shoot *gardencorev1beta1.Shoot, secret *corev1.Secret, cloudProfile *gardencorev1beta1.CloudProfile, messages ...*ac.AccessRestrictionMessage) error {
-	return outputProviderEnv(&o.options, shoot, secret, cloudProfile, messages)
+func (o *TestOptions) PrintProviderEnv(shoot *gardencorev1beta1.Shoot, secret *corev1.Secret, cloudProfile *gardencorev1beta1.CloudProfile, messages ...*ac.AccessRestrictionMessage) error {
+	return printProviderEnv(&o.options, shoot, secret, cloudProfile, messages)
 }
 
 func (o *TestOptions) GenerateMetadata(cli string) map[string]interface{} {

--- a/pkg/cmd/providerenv/options.go
+++ b/pkg/cmd/providerenv/options.go
@@ -162,10 +162,10 @@ func (o *options) Run(f util.Factory) error {
 		return err
 	}
 
-	return outputProviderEnv(o, shoot, secret, cloudProfile, messages)
+	return printProviderEnv(o, shoot, secret, cloudProfile, messages)
 }
 
-func outputProviderEnv(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret, cloudProfile *gardencorev1beta1.CloudProfile, messages ac.AccessRestrictionMessages) error {
+func printProviderEnv(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret, cloudProfile *gardencorev1beta1.CloudProfile, messages ac.AccessRestrictionMessages) error {
 	providerType := shoot.Spec.Provider.Type
 	cli := getProviderCLI(providerType)
 

--- a/pkg/cmd/providerenv/options.go
+++ b/pkg/cmd/providerenv/options.go
@@ -55,7 +55,10 @@ type options struct {
 
 // Complete adapts from the command line args to the data required.
 func (o *options) Complete(f util.Factory, cmd *cobra.Command, _ []string) error {
-	o.Shell = cmd.Name()
+	if cmd.Name() != "provider-env" {
+		o.Shell = cmd.Name()
+	}
+
 	o.CmdPath = cmd.Parent().CommandPath()
 	o.GardenDir = f.GardenHomeDir()
 	o.Template = env.NewTemplate("helpers")
@@ -73,13 +76,19 @@ func (o *options) Complete(f util.Factory, cmd *cobra.Command, _ []string) error
 
 // Validate validates the provided command options.
 func (o *options) Validate() error {
-	if o.Shell == "" {
+	if o.Shell == "" && o.Output == "" {
 		return pflag.ErrHelp
 	}
 
-	s := env.Shell(o.Shell)
+	// Usually, we would check and return an error if both shell and output are set (not empty). However, this is not required because the output flag is not set for the shell subcommands.
 
-	return s.Validate()
+	if o.Shell != "" {
+		s := env.Shell(o.Shell)
+
+		return s.Validate()
+	}
+
+	return o.Options.Validate()
 }
 
 // AddFlags binds the command options to a given flagset.
@@ -153,10 +162,10 @@ func (o *options) Run(f util.Factory) error {
 		return err
 	}
 
-	return execTmpl(o, shoot, secret, cloudProfile, messages)
+	return outputProviderEnv(o, shoot, secret, cloudProfile, messages)
 }
 
-func execTmpl(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret, cloudProfile *gardencorev1beta1.CloudProfile, messages ac.AccessRestrictionMessages) error {
+func outputProviderEnv(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret, cloudProfile *gardencorev1beta1.CloudProfile, messages ac.AccessRestrictionMessages) error {
 	providerType := shoot.Spec.Provider.Type
 	cli := getProviderCLI(providerType)
 
@@ -169,6 +178,12 @@ func execTmpl(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret,
 		if o.TargetFlags.ShootName() == "" || o.Force {
 			metadata["notification"] = b.String()
 		} else {
+			if o.Output != "" {
+				return errors.New(
+					"the cloud provider CLI configuration script can only be generated if you confirm the access despite the existing restrictions. Use the --force flag to confirm the access",
+				)
+			}
+
 			s := env.Shell(o.Shell)
 			return o.Template.ExecuteTemplate(o.IOStreams.Out, "printf", map[string]interface{}{
 				"format": b.String() + "\n%s %s\n%s\n",
@@ -181,6 +196,19 @@ func execTmpl(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret,
 		}
 	}
 
+	data, err := generateData(o, shoot, secret, cloudProfile, providerType, metadata)
+	if err != nil {
+		return err
+	}
+
+	if o.Output != "" {
+		return o.PrintObject(data)
+	}
+
+	return o.Template.ExecuteTemplate(o.IOStreams.Out, o.Shell, data)
+}
+
+func generateData(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret, cloudProfile *gardencorev1beta1.CloudProfile, providerType string, metadata map[string]interface{}) (map[string]interface{}, error) {
 	data := map[string]interface{}{
 		"__meta": metadata,
 		"region": shoot.Spec.Region,
@@ -195,7 +223,7 @@ func execTmpl(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret,
 		if !o.Unset {
 			configDir, err := createProviderConfigDir(o.SessionDir, providerType)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			data["configDir"] = configDir
@@ -205,13 +233,13 @@ func execTmpl(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret,
 
 		serviceaccountJSON, err := parseGCPCredentials(secret, &credentials)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if !o.Unset {
 			configDir, err := createProviderConfigDir(o.SessionDir, providerType)
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			data["configDir"] = configDir
@@ -222,7 +250,7 @@ func execTmpl(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret,
 	case "openstack":
 		authURL, err := getKeyStoneURL(cloudProfile, shoot.Spec.Region)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		data["authURL"] = authURL
@@ -245,20 +273,23 @@ func execTmpl(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Secret,
 
 	filename := filepath.Join(o.GardenDir, "templates", providerType+".tmpl")
 	if err := o.Template.ParseFiles(filename); err != nil {
-		return fmt.Errorf("failed to generate the cloud provider CLI configuration script: %w", err)
+		return nil, fmt.Errorf("failed to generate the cloud provider CLI configuration script: %w", err)
 	}
 
-	return o.Template.ExecuteTemplate(o.IOStreams.Out, o.Shell, data)
+	return data, nil
 }
 
 func generateMetadata(o *options, cli string) map[string]interface{} {
 	metadata := make(map[string]interface{})
 	metadata["unset"] = o.Unset
-	metadata["shell"] = o.Shell
 	metadata["commandPath"] = o.CmdPath
 	metadata["cli"] = cli
-	metadata["prompt"] = env.Shell(o.Shell).Prompt(runtime.GOOS)
 	metadata["targetFlags"] = getTargetFlags(o.Target)
+
+	if o.Shell != "" {
+		metadata["shell"] = o.Shell
+		metadata["prompt"] = env.Shell(o.Shell).Prompt(runtime.GOOS)
+	}
 
 	return metadata
 }

--- a/pkg/cmd/providerenv/options_test.go
+++ b/pkg/cmd/providerenv/options_test.go
@@ -450,7 +450,7 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				It("should render the template successfully", func() {
-					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(Succeed())
+					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
 					Expect(options.String()).To(Equal(fmt.Sprintf(readTestFile("gcp/export.bash"), filepath.Join(sessionDir, ".config", "gcloud"))))
 				})
 			})
@@ -462,7 +462,7 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				It("should render the template successfully", func() {
-					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(Succeed())
+					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
 					Expect(options.String()).To(Equal(readTestFile("gcp/unset.pwsh")))
 				})
 			})
@@ -473,7 +473,7 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				It("should fail to render the template with JSON parse error", func() {
-					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(MatchError("unexpected end of JSON input"))
+					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError("unexpected end of JSON input"))
 				})
 			})
 
@@ -484,7 +484,7 @@ var _ = Describe("Env Commands - Options", func() {
 
 				It("should fail to render the template with JSON parse error", func() {
 					noTemplateFmt := "template: no template %q associated with template %q"
-					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(MatchError(fmt.Sprintf(noTemplateFmt, shell, "base")))
+					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError(fmt.Sprintf(noTemplateFmt, shell, "base")))
 				})
 			})
 
@@ -502,7 +502,7 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				It("should render the template successfully", func() {
-					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(Succeed())
+					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
 					Expect(options.String()).To(Equal(readTestFile("test/export.bash")))
 				})
 			})
@@ -514,7 +514,7 @@ var _ = Describe("Env Commands - Options", func() {
 
 				It("should fail to render the template with a not supported error", func() {
 					message := "failed to generate the cloud provider CLI configuration script"
-					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp(message)))
+					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp(message)))
 				})
 			})
 
@@ -533,14 +533,14 @@ var _ = Describe("Env Commands - Options", func() {
 
 				It("should fail to render the template with a not supported error", func() {
 					message := "failed to generate the cloud provider CLI configuration script"
-					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp(message)))
+					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp(message)))
 				})
 			})
 
 			Context("when the configuration directory could not be created", func() {
 				It("should fail a mkdir error", func() {
 					options.SessionDir = string([]byte{0})
-					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp("^failed to create gcloud configuration directory:")))
+					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp("^failed to create gcloud configuration directory:")))
 				})
 			})
 
@@ -565,13 +565,13 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				It("should render the template successfully", func() {
-					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(Succeed())
+					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
 					Expect(options.String()).To(Equal(readTestFile("openstack/export.bash")))
 				})
 
 				It("should fail with invalid provider config", func() {
 					cloudProfile.Spec.ProviderConfig = nil
-					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp("^failed to get openstack provider config:")))
+					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp("^failed to get openstack provider config:")))
 				})
 			})
 
@@ -596,13 +596,13 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				It("should render the template successfully", func() {
-					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(Succeed())
+					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
 					Expect(options.String()).To(Equal(fmt.Sprintf(readTestFile("azure/export.fish"), filepath.Join(sessionDir, ".config", "az"))))
 				})
 
 				It("should fail with mkdir error", func() {
 					options.SessionDir = string([]byte{0})
-					Expect(options.ExecTmpl(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp("^failed to create az configuration directory:")))
+					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp("^failed to create az configuration directory:")))
 				})
 			})
 		})

--- a/pkg/cmd/providerenv/options_test.go
+++ b/pkg/cmd/providerenv/options_test.go
@@ -469,7 +469,7 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				It("should render the template successfully", func() {
-					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
+					Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
 					Expect(options.String()).To(Equal(fmt.Sprintf(readTestFile("gcp/export.bash"), filepath.Join(sessionDir, ".config", "gcloud"))))
 				})
 			})
@@ -481,7 +481,7 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				It("should render the template successfully", func() {
-					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
+					Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
 					Expect(options.String()).To(Equal(readTestFile("gcp/unset.pwsh")))
 				})
 			})
@@ -492,7 +492,7 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				It("should fail to render the template with JSON parse error", func() {
-					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError("unexpected end of JSON input"))
+					Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(MatchError("unexpected end of JSON input"))
 				})
 			})
 
@@ -503,7 +503,7 @@ var _ = Describe("Env Commands - Options", func() {
 
 				It("should fail to render the template with JSON parse error", func() {
 					noTemplateFmt := "template: no template %q associated with template %q"
-					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError(fmt.Sprintf(noTemplateFmt, shell, "base")))
+					Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(MatchError(fmt.Sprintf(noTemplateFmt, shell, "base")))
 				})
 			})
 
@@ -521,7 +521,7 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				It("should render the template successfully", func() {
-					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
+					Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
 					Expect(options.String()).To(Equal(readTestFile("test/export.bash")))
 				})
 			})
@@ -533,7 +533,7 @@ var _ = Describe("Env Commands - Options", func() {
 
 				It("should fail to render the template with a not supported error", func() {
 					message := "failed to generate the cloud provider CLI configuration script"
-					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp(message)))
+					Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp(message)))
 				})
 			})
 
@@ -552,14 +552,14 @@ var _ = Describe("Env Commands - Options", func() {
 
 				It("should fail to render the template with a not supported error", func() {
 					message := "failed to generate the cloud provider CLI configuration script"
-					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp(message)))
+					Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp(message)))
 				})
 			})
 
 			Context("when the configuration directory could not be created", func() {
 				It("should fail a mkdir error", func() {
 					options.SessionDir = string([]byte{0})
-					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp("^failed to create gcloud configuration directory:")))
+					Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp("^failed to create gcloud configuration directory:")))
 				})
 			})
 
@@ -584,13 +584,13 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				It("should render the template successfully", func() {
-					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
+					Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
 					Expect(options.String()).To(Equal(readTestFile("openstack/export.bash")))
 				})
 
 				It("should fail with invalid provider config", func() {
 					cloudProfile.Spec.ProviderConfig = nil
-					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp("^failed to get openstack provider config:")))
+					Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp("^failed to get openstack provider config:")))
 				})
 
 				Context("output is json", func() {
@@ -600,7 +600,7 @@ var _ = Describe("Env Commands - Options", func() {
 					})
 
 					It("should render the json successfully", func() {
-						Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
+						Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
 						Expect(options.String()).To(Equal(readTestFile("openstack/export.json")))
 					})
 				})
@@ -627,13 +627,13 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 
 				It("should render the template successfully", func() {
-					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
+					Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
 					Expect(options.String()).To(Equal(fmt.Sprintf(readTestFile("azure/export.fish"), filepath.Join(sessionDir, ".config", "az"))))
 				})
 
 				It("should fail with mkdir error", func() {
 					options.SessionDir = string([]byte{0})
-					Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp("^failed to create az configuration directory:")))
+					Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(MatchError(MatchRegexp("^failed to create az configuration directory:")))
 				})
 
 				Context("output is json", func() {
@@ -643,7 +643,7 @@ var _ = Describe("Env Commands - Options", func() {
 					})
 
 					It("should render the json successfully", func() {
-						Expect(options.OutputProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
+						Expect(options.PrintProviderEnv(shoot, secret, cloudProfile)).To(Succeed())
 						fmt.Println(options.String())
 						Expect(options.String()).To(Equal(fmt.Sprintf(readTestFile("azure/export.json"), filepath.Join(sessionDir, ".config", "az"))))
 					})

--- a/pkg/cmd/providerenv/providerenv.go
+++ b/pkg/cmd/providerenv/providerenv.go
@@ -52,6 +52,7 @@ for the respective provider in the "templates" folder of the gardenctl home dire
 Please refer to the templates of the already supported cloud providers which can be found
 here https://github.com/gardener/gardenctl-v2/tree/master/pkg/cmd/env/templates.`,
 		Aliases: []string{"p-env", "cloud-env"},
+		RunE:    runE,
 	}
 
 	persistentFlags := cmd.PersistentFlags()
@@ -59,6 +60,10 @@ here https://github.com/gardener/gardenctl-v2/tree/master/pkg/cmd/env/templates.
 
 	f.TargetFlags().AddFlags(persistentFlags)
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, persistentFlags)
+
+	// add output flag only to the base provider-env command
+	cmdFlags := cmd.Flags()
+	o.Options.AddFlags(cmdFlags)
 
 	for _, s := range env.ValidShells() {
 		cmd.AddCommand(&cobra.Command{

--- a/pkg/cmd/providerenv/providerenv_test.go
+++ b/pkg/cmd/providerenv/providerenv_test.go
@@ -7,14 +7,27 @@ SPDX-License-Identifier: Apache-2.0
 package providerenv_test
 
 import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 
+	clientgarden "github.com/gardener/gardenctl-v2/internal/client/garden"
+	"github.com/gardener/gardenctl-v2/internal/fake"
 	"github.com/gardener/gardenctl-v2/internal/util"
 	utilmocks "github.com/gardener/gardenctl-v2/internal/util/mocks"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/providerenv"
+	"github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/env"
 	"github.com/gardener/gardenctl-v2/pkg/target"
 	targetmocks "github.com/gardener/gardenctl-v2/pkg/target/mocks"
@@ -24,7 +37,11 @@ var _ = Describe("Env Commands", func() {
 	var (
 		ctrl    *gomock.Controller
 		factory *utilmocks.MockFactory
+		manager *targetmocks.MockManager
 		streams util.IOStreams
+		out     *util.SafeBytesBuffer
+		errOut  *util.SafeBytesBuffer
+		parent  cobra.Command
 		cmd     *cobra.Command
 	)
 
@@ -32,13 +49,13 @@ var _ = Describe("Env Commands", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		factory = utilmocks.NewMockFactory(ctrl)
 
-		manager := targetmocks.NewMockManager(ctrl)
+		manager = targetmocks.NewMockManager(ctrl)
 		factory.EXPECT().Manager().Return(manager, nil).AnyTimes()
 
 		targetFlags := target.NewTargetFlags("", "", "", "", false)
 		factory.EXPECT().TargetFlags().Return(targetFlags).AnyTimes()
 
-		streams = util.IOStreams{}
+		streams, _, out, errOut = util.NewTestIOStreams()
 	})
 
 	AfterEach(func() {
@@ -46,15 +63,21 @@ var _ = Describe("Env Commands", func() {
 	})
 
 	Describe("given a ProviderEnv instance", func() {
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			cmd = providerenv.NewCmdProviderEnv(factory, streams)
+
+			// Add cmd to a dummy parent to avoid test failure when ProviderEnv command accesses the parent
+			parent = cobra.Command{Use: "test-parent"}
+			parent.AddCommand(cmd)
+			parent.SetOut(out)
+			parent.SetErr(errOut)
 		})
 
 		It("should have Use, Flags and SubCommands", func() {
 			Expect(cmd.Use).To(Equal("provider-env"))
 			Expect(cmd.Aliases).To(HaveLen(2))
 			Expect(cmd.Aliases).To(Equal([]string{"p-env", "cloud-env"}))
-			Expect(cmd.Flag("output")).To(BeNil())
+			Expect(cmd.Flag("output")).NotTo(BeNil())
 			flag := cmd.Flag("unset")
 			Expect(flag).NotTo(BeNil())
 			Expect(flag.Shorthand).To(Equal("u"))
@@ -62,9 +85,125 @@ var _ = Describe("Env Commands", func() {
 			Expect(len(subCmds)).To(Equal(4))
 			for _, c := range subCmds {
 				Expect(c.Flag("unset")).To(BeIdenticalTo(flag))
+				Expect(c.Flag("output")).To(BeNil())
 				s := env.Shell(c.Name())
 				Expect(s).To(BeElementOf(env.ValidShells()))
 			}
+		})
+
+		Context("command execution", func() {
+			var (
+				ctx               context.Context
+				cfg               *config.Config
+				t                 target.Target
+				secretBindingName string
+				cloudProfileName  string
+				region            string
+				provider          *gardencorev1beta1.Provider
+				secretRef         *corev1.SecretReference
+				project           *gardencorev1beta1.Project
+				shoot             *gardencorev1beta1.Shoot
+				secretBinding     *gardencorev1beta1.SecretBinding
+				cloudProfile      *gardencorev1beta1.CloudProfile
+				providerConfig    *openstackv1alpha1.CloudProfileConfig
+				secret            *corev1.Secret
+			)
+
+			BeforeEach(func() {
+				t = target.NewTarget("test", "project", "seed", "shoot")
+				cfg = &config.Config{
+					Gardens: []config.Garden{
+						{
+							Name: t.GardenName(),
+						},
+					},
+				}
+
+				manager.EXPECT().SessionDir().Return(sessionDir)
+				manager.EXPECT().CurrentTarget().Return(t, nil)
+				manager.EXPECT().Configuration().Return(cfg)
+
+				factory.EXPECT().GardenHomeDir().Return(gardenHomeDir)
+
+				ctx = context.Background()
+				factory.EXPECT().Context().Return(ctx)
+
+				secretBindingName = "secret-binding"
+				cloudProfileName = "cloud-profile"
+				region = "europe"
+				provider = &gardencorev1beta1.Provider{
+					Type: "gcp",
+				}
+				providerConfig = nil
+				secretRef = &corev1.SecretReference{
+					Namespace: "private",
+					Name:      "secret",
+				}
+				namespace := "garden-" + t.ProjectName()
+
+				project = &gardencorev1beta1.Project{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: t.ProjectName(),
+					},
+					Spec: gardencorev1beta1.ProjectSpec{
+						Namespace: pointer.String(namespace),
+					},
+				}
+				shoot = &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      t.ShootName(),
+						Namespace: namespace,
+					},
+					Spec: gardencorev1beta1.ShootSpec{
+						CloudProfileName:  cloudProfileName,
+						Region:            region,
+						SecretBindingName: secretBindingName,
+						Provider:          *provider.DeepCopy(),
+					},
+				}
+				secretBinding = &gardencorev1beta1.SecretBinding{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretBindingName,
+						Namespace: shoot.Namespace,
+					},
+					SecretRef: *secretRef.DeepCopy(),
+				}
+				secret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: secretRef.Namespace,
+						Name:      secretRef.Name,
+					},
+					Data: map[string][]byte{
+						"serviceaccount.json": []byte(readTestFile(provider.Type + "/serviceaccount.json")),
+					},
+				}
+				cloudProfile = &gardencorev1beta1.CloudProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: cloudProfileName,
+					},
+					Spec: gardencorev1beta1.CloudProfileSpec{
+						Type: provider.Type,
+						ProviderConfig: &runtime.RawExtension{
+							Object: providerConfig,
+							Raw:    nil,
+						},
+					},
+				}
+
+				client := clientgarden.NewClient(
+					nil,
+					fake.NewClientWithObjects(project, shoot, secretBinding, secret, cloudProfile),
+					t.GardenName(),
+				)
+				manager.EXPECT().GardenClient(t.GardenName()).Return(client, nil)
+			})
+
+			It("should output in yaml format", func() {
+				parent.SetArgs([]string{"provider-env", "--output", "yaml"})
+				Expect(parent.Execute()).To(Succeed())
+				configDir := filepath.Join(sessionDir, ".config", "gcloud")
+				Expect(out.String()).To(Equal(fmt.Sprintf(readTestFile("gcp/export.yaml"), configDir)))
+			})
 		})
 	})
 })

--- a/pkg/env/testdata/azure/export.json
+++ b/pkg/env/testdata/azure/export.json
@@ -1,0 +1,16 @@
+{
+  "__meta": {
+    "cli": "az",
+    "commandPath": "gardenctl provider-env",
+    "targetFlags": "--garden test --project project --shoot shoot",
+    "unset": false
+  },
+  "clientID": "client-id",
+  "clientSecret": "client-secret",
+  "configDir": "%s",
+  "region": "europe",
+  "serviceaccount.json": "{\n  \"project_id\": \"test\",\n  \"client_email\": \"test@example.org\"\n}",
+  "subscriptionID": "subscription-id",
+  "tenantID": "tenant-id",
+  "testToken": "token"
+}

--- a/pkg/env/testdata/gcp/export.yaml
+++ b/pkg/env/testdata/gcp/export.yaml
@@ -1,0 +1,11 @@
+__meta:
+  cli: gcloud
+  commandPath: test-parent
+  targetFlags: --garden test --project project --shoot shoot
+  unset: false
+configDir: %s
+credentials:
+  client_email: test@example.org
+  project_id: test
+region: europe
+serviceaccount.json: '{"client_email":"test@example.org","project_id":"test"}'

--- a/pkg/env/testdata/openstack/export.json
+++ b/pkg/env/testdata/openstack/export.json
@@ -1,0 +1,21 @@
+{
+  "__meta": {
+    "cli": "openstack",
+    "commandPath": "gardenctl provider-env",
+    "targetFlags": "--garden test --project project --shoot shoot",
+    "unset": false
+  },
+  "applicationCredentialID": "",
+  "applicationCredentialName": "",
+  "applicationCredentialSecret": "",
+  "authStrategy": "keystone",
+  "authType": "",
+  "authURL": "keyStoneURL",
+  "domainName": "domain",
+  "password": "secret",
+  "region": "europe",
+  "serviceaccount.json": "{\n  \"project_id\": \"test\",\n  \"client_email\": \"test@example.org\"\n}",
+  "tenantName": "tenant",
+  "testToken": "token",
+  "username": "user"
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `--output` flag to the `provider-env` command

**Which issue(s) this PR fixes**:
Fixes #287

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`provider-env`: You can now control the output format using `--output` flag. The data that is typically passed to the templating engine for generating provider-env scripts is instead output in the specified format. Usage: `gardenctl provider-env -oyaml`
```
