### PR TITLE
Output flags improvements

### DIFF
--- a/docs/help/gardenctl_target.md
+++ b/docs/help/gardenctl_target.md
@@ -25,7 +25,6 @@ gardenctl target value/that/matches/pattern --control-plane
       --control-plane    target control plane of shoot, use together with shoot argument
       --garden string    target the given garden cluster
   -h, --help             help for target
-  -o, --output string    One of 'yaml' or 'json'.
       --project string   target the given project
       --seed string      target the given seed cluster
       --shoot string     target the given shoot cluster

--- a/docs/help/gardenctl_target_control-plane.md
+++ b/docs/help/gardenctl_target_control-plane.md
@@ -25,7 +25,6 @@ gardenctl target control-plane --garden my-garden --project my-project --shoot m
 ```
       --garden string    target the given garden cluster
   -h, --help             help for control-plane
-  -o, --output string    One of 'yaml' or 'json'.
       --project string   target the given project
       --seed string      target the given seed cluster
       --shoot string     target the given shoot cluster

--- a/docs/help/gardenctl_target_garden.md
+++ b/docs/help/gardenctl_target_garden.md
@@ -20,8 +20,7 @@ gardenctl target garden my-garden
 ### Options
 
 ```
-  -h, --help            help for garden
-  -o, --output string   One of 'yaml' or 'json'.
+  -h, --help   help for garden
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_target_project.md
+++ b/docs/help/gardenctl_target_project.md
@@ -25,7 +25,6 @@ gardenctl target project my-project --garden my-garden
 ```
       --garden string   target the given garden cluster
   -h, --help            help for project
-  -o, --output string   One of 'yaml' or 'json'.
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_target_seed.md
+++ b/docs/help/gardenctl_target_seed.md
@@ -25,7 +25,6 @@ gardenctl target seed my-seed --garden my-garden
 ```
       --garden string   target the given garden cluster
   -h, --help            help for seed
-  -o, --output string   One of 'yaml' or 'json'.
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_target_shoot.md
+++ b/docs/help/gardenctl_target_shoot.md
@@ -25,7 +25,6 @@ gardenctl target shoot my-shoot --garden my-garden --project my-project
 ```
       --garden string    target the given garden cluster
   -h, --help             help for shoot
-  -o, --output string    One of 'yaml' or 'json'.
       --project string   target the given project
       --seed string      target the given seed cluster
 ```

--- a/pkg/cmd/base/options.go
+++ b/pkg/cmd/base/options.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/yaml"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
@@ -66,6 +67,18 @@ func NewOptions(ioStreams util.IOStreams) *Options {
 // AddFlags adds flags to adjust the output to a cobra command.
 func (o *Options) AddFlags(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.Output, "output", "o", o.Output, "One of 'yaml' or 'json'.")
+}
+
+// RegisterCompletionsForOutputFlag adds output flag completion to the command.
+func (o *Options) RegisterCompletionsForOutputFlag(cmd *cobra.Command) {
+	utilruntime.Must(cmd.RegisterFlagCompletionFunc("output", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return o.AllowedOutputFormats(), cobra.ShellCompDirectiveNoFileComp
+	}))
+}
+
+// AllowedOutputFormats returns the allowed formats for the output flag.
+func (o *Options) AllowedOutputFormats() []string {
+	return []string{"json", "yaml"}
 }
 
 // PrintObject prints an object to IOStreams.out, using o.Output to print in the selected output format.

--- a/pkg/cmd/config/view.go
+++ b/pkg/cmd/config/view.go
@@ -30,6 +30,7 @@ gardenctl config view`,
 	}
 
 	o.AddFlags(cmd.Flags())
+	o.RegisterCompletionsForOutputFlag(cmd)
 
 	return cmd
 }

--- a/pkg/cmd/ssh/ssh.go
+++ b/pkg/cmd/ssh/ssh.go
@@ -63,6 +63,8 @@ gardenctl ssh --keep-bastion --bastion-name cli-xxxxxxxx --public-key-file /path
 	}
 
 	o.AddFlags(cmd.Flags())
+	o.RegisterCompletionsForOutputFlag(cmd)
+
 	o.AccessConfig.AddFlags(cmd.Flags())
 	RegisterCompletionFuncsForAccessConfigFlags(cmd, f)
 

--- a/pkg/cmd/target/control-plane.go
+++ b/pkg/cmd/target/control-plane.go
@@ -35,8 +35,6 @@ gardenctl target control-plane --garden my-garden --project my-project --shoot m
 		RunE:              base.WrapRunE(o, f),
 	}
 
-	o.AddFlags(cmd.Flags())
-
 	f.TargetFlags().AddGardenFlag(cmd.Flags())
 	f.TargetFlags().AddProjectFlag(cmd.Flags())
 	f.TargetFlags().AddShootFlag(cmd.Flags())

--- a/pkg/cmd/target/garden.go
+++ b/pkg/cmd/target/garden.go
@@ -31,7 +31,5 @@ gardenctl target garden my-garden`,
 		RunE:              base.WrapRunE(o, f),
 	}
 
-	o.AddFlags(cmd.Flags())
-
 	return cmd
 }

--- a/pkg/cmd/target/project.go
+++ b/pkg/cmd/target/project.go
@@ -35,8 +35,6 @@ gardenctl target project my-project --garden my-garden`,
 		RunE:              base.WrapRunE(o, f),
 	}
 
-	o.AddFlags(cmd.Flags())
-
 	f.TargetFlags().AddGardenFlag(cmd.Flags())
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, cmd.Flags())
 

--- a/pkg/cmd/target/seed.go
+++ b/pkg/cmd/target/seed.go
@@ -35,8 +35,6 @@ gardenctl target seed my-seed --garden my-garden`,
 		RunE:              base.WrapRunE(o, f),
 	}
 
-	o.AddFlags(cmd.Flags())
-
 	f.TargetFlags().AddGardenFlag(cmd.Flags())
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, cmd.Flags())
 

--- a/pkg/cmd/target/shoot.go
+++ b/pkg/cmd/target/shoot.go
@@ -35,8 +35,6 @@ gardenctl target shoot my-shoot --garden my-garden --project my-project`,
 		RunE:              base.WrapRunE(o, f),
 	}
 
-	o.AddFlags(cmd.Flags())
-
 	f.TargetFlags().AddGardenFlag(cmd.Flags())
 	f.TargetFlags().AddProjectFlag(cmd.Flags())
 	f.TargetFlags().AddSeedFlag(cmd.Flags())

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -49,8 +49,6 @@ gardenctl target value/that/matches/pattern --control-plane`,
 	cmd.AddCommand(NewCmdUnset(f, ioStreams))
 	cmd.AddCommand(NewCmdView(f, ioStreams))
 
-	o.AddFlags(cmd.Flags())
-
 	f.TargetFlags().AddFlags(cmd.Flags())
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, cmd.Flags())
 

--- a/pkg/cmd/target/view.go
+++ b/pkg/cmd/target/view.go
@@ -35,6 +35,7 @@ func NewCmdView(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
 	}
 
 	o.AddFlags(cmd.Flags())
+	o.RegisterCompletionsForOutputFlag(cmd)
 
 	f.TargetFlags().AddFlags(cmd.Flags())
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, cmd.Flags())

--- a/pkg/cmd/version/version.go
+++ b/pkg/cmd/version/version.go
@@ -35,6 +35,7 @@ func NewCmdVersion(f util.Factory, o *VersionOptions) *cobra.Command {
 	}
 
 	o.AddFlags(cmd.Flags())
+	o.RegisterCompletionsForOutputFlag(cmd)
 
 	return cmd
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR
- adds missing output flag completions for
  - `target view`
  - `ssh`
  - `config view`
  - `version`
- Removed wrongfully added output flag for the following commands. Setting the flag did not have any effect:
  -  `target`
  -  `target garden`
  -  `target project`
  -  `target seed`
  -  `target shoot`
  -  `target control-plane`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Removed wrongfully added `--output` flag for the following commands. Setting the flag did not have any effect previously but will now result in an error:
-  `target`
-  `target garden`
-  `target project`
-  `target seed`
-  `target shoot`
-  `target control-plane`
```
