### PR TITLE
Add `resolve` command

### DIFF
--- a/docs/help/gardenctl.md
+++ b/docs/help/gardenctl.md
@@ -56,6 +56,7 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 * [gardenctl kubectl-env](gardenctl_kubectl-env.md)	 - Generate a script that points KUBECONFIG to the targeted cluster for the specified shell
 * [gardenctl provider-env](gardenctl_provider-env.md)	 - Generate the cloud provider CLI configuration script for the specified shell
 * [gardenctl rc](gardenctl_rc.md)	 - Generate a gardenctl startup script for the specified shell
+* [gardenctl resolve](gardenctl_resolve.md)	 - Resolve the current target
 * [gardenctl ssh](gardenctl_ssh.md)	 - Establish an SSH connection to a node of a Shoot cluster
 * [gardenctl ssh-patch](gardenctl_ssh-patch.md)	 - Update a bastion host previously created through the ssh command
 * [gardenctl target](gardenctl_target.md)	 - Set scope for next operations, using subcommands or pattern

--- a/docs/help/gardenctl_resolve.md
+++ b/docs/help/gardenctl_resolve.md
@@ -1,0 +1,41 @@
+## gardenctl resolve
+
+Resolve the current target
+
+### Synopsis
+
+Resolve garden, seed, project or shoot for the current target
+
+### Options
+
+```
+  -h, --help   help for resolve
+```
+
+### Options inherited from parent commands
+
+```
+      --add-dir-header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
+      --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log-dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
+      --log-file string                  If non-empty, use this log file (no effect when -logtostderr=true)
+      --log-file-max-size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files (default true)
+      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
+      --skip-headers                     If true, avoid header prefixes in the log messages
+      --skip-log-headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+
+* [gardenctl](gardenctl.md)	 - Gardenctl is a utility to interact with Gardener installations
+* [gardenctl resolve garden](gardenctl_resolve_garden.md)	 - Resolve garden for the current target
+* [gardenctl resolve project](gardenctl_resolve_project.md)	 - Resolve project for the current target
+* [gardenctl resolve seed](gardenctl_resolve_seed.md)	 - Resolve seed for the current target
+* [gardenctl resolve shoot](gardenctl_resolve_shoot.md)	 - Resolve shoot for the current target
+

--- a/docs/help/gardenctl_resolve_garden.md
+++ b/docs/help/gardenctl_resolve_garden.md
@@ -1,0 +1,39 @@
+## gardenctl resolve garden
+
+Resolve garden for the current target
+
+```
+gardenctl resolve garden [flags]
+```
+
+### Options
+
+```
+      --garden string   target the given garden cluster
+  -h, --help            help for garden
+  -o, --output string   One of 'yaml' or 'json'. (default "yaml")
+```
+
+### Options inherited from parent commands
+
+```
+      --add-dir-header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
+      --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log-dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
+      --log-file string                  If non-empty, use this log file (no effect when -logtostderr=true)
+      --log-file-max-size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files (default true)
+      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
+      --skip-headers                     If true, avoid header prefixes in the log messages
+      --skip-log-headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+
+* [gardenctl resolve](gardenctl_resolve.md)	 - Resolve the current target
+

--- a/docs/help/gardenctl_resolve_project.md
+++ b/docs/help/gardenctl_resolve_project.md
@@ -1,0 +1,42 @@
+## gardenctl resolve project
+
+Resolve project for the current target
+
+```
+gardenctl resolve project [flags]
+```
+
+### Options
+
+```
+      --garden string    target the given garden cluster
+  -h, --help             help for project
+  -o, --output string    One of 'yaml' or 'json'. (default "yaml")
+      --project string   target the given project
+      --seed string      target the given seed cluster
+      --shoot string     target the given shoot cluster
+```
+
+### Options inherited from parent commands
+
+```
+      --add-dir-header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
+      --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log-dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
+      --log-file string                  If non-empty, use this log file (no effect when -logtostderr=true)
+      --log-file-max-size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files (default true)
+      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
+      --skip-headers                     If true, avoid header prefixes in the log messages
+      --skip-log-headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+
+* [gardenctl resolve](gardenctl_resolve.md)	 - Resolve the current target
+

--- a/docs/help/gardenctl_resolve_seed.md
+++ b/docs/help/gardenctl_resolve_seed.md
@@ -1,0 +1,42 @@
+## gardenctl resolve seed
+
+Resolve seed for the current target
+
+```
+gardenctl resolve seed [flags]
+```
+
+### Options
+
+```
+      --garden string    target the given garden cluster
+  -h, --help             help for seed
+  -o, --output string    One of 'yaml' or 'json'. (default "yaml")
+      --project string   target the given project
+      --seed string      target the given seed cluster
+      --shoot string     target the given shoot cluster
+```
+
+### Options inherited from parent commands
+
+```
+      --add-dir-header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
+      --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log-dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
+      --log-file string                  If non-empty, use this log file (no effect when -logtostderr=true)
+      --log-file-max-size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files (default true)
+      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
+      --skip-headers                     If true, avoid header prefixes in the log messages
+      --skip-log-headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+
+* [gardenctl resolve](gardenctl_resolve.md)	 - Resolve the current target
+

--- a/docs/help/gardenctl_resolve_shoot.md
+++ b/docs/help/gardenctl_resolve_shoot.md
@@ -1,0 +1,64 @@
+## gardenctl resolve shoot
+
+Resolve shoot for the current target
+
+### Synopsis
+
+Resolve shoot for the current target.
+This command is particularly useful when you need to understand which shoot the current target translates to, regardless of whether a seed or a shoot is targeted.
+It fetches and displays information about its associated garden, project, seed, and shoot.
+A garden and either a seed or shoot must be specified, either from a previously saved target or directly via target flags. Target flags temporarily override the saved target for the current command run.
+
+```
+gardenctl resolve shoot [flags]
+```
+
+### Examples
+
+```
+# Resolve shoot for managed seed
+gardenctl resolve shoot --garden mygarden --seed myseed
+
+# Resolve shoot. Output in json format
+gardenctl resolve shoot --garden mygarden --shoot myseed -ojson
+
+# Resolve shoot cluster details for a shoot that might have the same name as others across different projects
+# Use fully qualified target flags to specify the correct garden, project, and shoot
+gardenctl resolve shoot --garden mygarden --project myproject --shoot myshoot
+```
+
+### Options
+
+```
+      --control-plane    target control plane of shoot, use together with shoot argument
+      --garden string    target the given garden cluster
+  -h, --help             help for shoot
+  -o, --output string    One of 'yaml' or 'json'. (default "yaml")
+      --project string   target the given project
+      --seed string      target the given seed cluster
+      --shoot string     target the given shoot cluster
+```
+
+### Options inherited from parent commands
+
+```
+      --add-dir-header                   If true, adds the file directory to the header of the log messages
+      --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
+      --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+      --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
+      --log-dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)
+      --log-file string                  If non-empty, use this log file (no effect when -logtostderr=true)
+      --log-file-max-size uint           Defines the maximum size a log file can grow to (no effect when -logtostderr=true). Unit is megabytes. If the value is 0, the maximum file size is unlimited. (default 1800)
+      --logtostderr                      log to standard error instead of files (default true)
+      --one-output                       If true, only write logs to their native severity level (vs also writing to each lower severity level; no effect when -logtostderr=true)
+      --skip-headers                     If true, avoid header prefixes in the log messages
+      --skip-log-headers                 If true, avoid headers when opening log files (no effect when -logtostderr=true)
+      --stderrthreshold severity         logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=false) (default 2)
+  -v, --v Level                          number for the log level verbosity
+      --vmodule moduleSpec               comma-separated list of pattern=N settings for file-filtered logging
+```
+
+### SEE ALSO
+
+* [gardenctl resolve](gardenctl_resolve.md)	 - Resolve the current target
+

--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -161,7 +161,7 @@ func (g *clientImpl) GetSeed(ctx context.Context, name string) (*gardencorev1bet
 	key := types.NamespacedName{Name: name}
 
 	if err := g.c.Get(ctx, key, seed); err != nil {
-		return nil, fmt.Errorf("failed to get seed %v: %w", key, err)
+		return nil, fmt.Errorf("failed to get seed %s: %w", name, err)
 	}
 
 	return seed, nil
@@ -455,6 +455,8 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string) (clie
 		if oidcErr != nil {
 			return nil, fmt.Errorf("failed to get kubeconfig for seed %v: %w", key, err) // use original not-found error as cause and ignore error of fallback
 		}
+
+		klog.FromContext(ctx).Info("Using deprecated secret to obtain seed kubeconfig", "secret", klog.KRef("garden", name+".oidc"))
 	}
 
 	value, ok := secret.Data["kubeconfig"]

--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -87,7 +87,7 @@ type Client interface {
 	GetSecret(ctx context.Context, namespace, name string) (*corev1.Secret, error)
 	// GetConfigMap returns a Kubernetes configmap resource
 	GetConfigMap(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error)
-	// GetShootOfManagedSeed returns shoot of seed using ManagedSeed resource, nil if not a managed seed
+	// GetShootOfManagedSeed returns shoot of seed using ManagedSeed resource. An error is returned if it is not a managed seed or the referenced shoot is nil
 	GetShootOfManagedSeed(ctx context.Context, name string) (*seedmanagementv1alpha1.Shoot, error)
 
 	// ListBastions returns all Gardener bastion resources, filtered by a list option
@@ -290,14 +290,13 @@ func (g *clientImpl) GetShootOfManagedSeed(ctx context.Context, name string) (*s
 	key := types.NamespacedName{Namespace: "garden", Name: name} // Currently, managed seeds are restricted to the garden namespace
 
 	if err := g.c.Get(ctx, key, managedSeed); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, nil
-		}
-
-		return nil, fmt.Errorf("failed to get managed seed %v: %w", key, err)
+		return nil, err
 	}
 
-	klog.V(1).Infof("using referred shoot %q for seed %q", managedSeed.Spec.Shoot.Name, name)
+	referredShoot := managedSeed.Spec.Shoot
+	if referredShoot == nil {
+		return nil, fmt.Errorf("no shoot referenced for managed seed %s", name)
+	}
 
 	return managedSeed.Spec.Shoot, nil
 }
@@ -423,9 +422,21 @@ func (g *clientImpl) CurrentUser(ctx context.Context) (string, error) {
 }
 
 func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string) (clientcmd.ClientConfig, error) {
-	if shoot, err := g.GetShootOfManagedSeed(ctx, name); err != nil {
+	logger := klog.FromContext(ctx)
+
+	shoot, err := g.GetShootOfManagedSeed(ctx, name)
+	if client.IgnoreNotFound(err) != nil {
 		return nil, err
-	} else if shoot != nil {
+	}
+
+	if !apierrors.IsNotFound(err) {
+		logger.V(1).Info("using referred shoot of managed seed",
+			"shoot", klog.ObjectRef{
+				Namespace: "garden",
+				Name:      shoot.Name,
+			},
+			"seed", name)
+
 		return g.GetShootClientConfig(ctx, "garden", shoot.Name)
 	}
 

--- a/pkg/cmd/base/options.go
+++ b/pkg/cmd/base/options.go
@@ -86,32 +86,36 @@ func (o *Options) PrintObject(obj interface{}) error {
 	switch o.Output {
 	case "":
 		if _, ok := obj.(fmt.Stringer); ok {
-			fmt.Fprintf(o.IOStreams.Out, "%s", obj)
-		} else {
-			fmt.Fprintf(o.IOStreams.Out, "%v", obj)
+			_, err := fmt.Fprintf(o.IOStreams.Out, "%s", obj)
+			return err
 		}
+
+		_, err := fmt.Fprintf(o.IOStreams.Out, "%v", obj)
+
+		return err
 	case "yaml":
 		marshalled, err := yaml.Marshal(&obj)
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprint(o.IOStreams.Out, string(marshalled))
+		_, err = fmt.Fprint(o.IOStreams.Out, string(marshalled))
+
+		return err
 	case "json":
 		marshalled, err := json.MarshalIndent(&obj, "", "  ")
 		if err != nil {
 			return err
 		}
 
-		fmt.Fprintln(o.IOStreams.Out, string(marshalled))
+		_, err = fmt.Fprintln(o.IOStreams.Out, string(marshalled))
 
+		return err
 	default:
 		// There is a bug in the program if we hit this case.
 		// However, we follow a policy of never panicking.
 		return fmt.Errorf("options were not validated: --output=%q should have been rejected", o.Output)
 	}
-
-	return nil
 }
 
 // Validate validates the provided options.

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -25,6 +25,7 @@ import (
 	cmdkubectl "github.com/gardener/gardenctl-v2/pkg/cmd/kubectlenv"
 	cmdprovider "github.com/gardener/gardenctl-v2/pkg/cmd/providerenv"
 	cmdrc "github.com/gardener/gardenctl-v2/pkg/cmd/rc"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/resolve"
 	cmdssh "github.com/gardener/gardenctl-v2/pkg/cmd/ssh"
 	cmdsshpatch "github.com/gardener/gardenctl-v2/pkg/cmd/sshpatch"
 	cmdtarget "github.com/gardener/gardenctl-v2/pkg/cmd/target"
@@ -123,6 +124,7 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 	cmd.AddCommand(cmdkubectl.NewCmdKubectlEnv(f, ioStreams))
 	cmd.AddCommand(cmdrc.NewCmdRC(f, ioStreams))
 	cmd.AddCommand(kubeconfig.NewCmdKubeconfig(f, ioStreams))
+	cmd.AddCommand(resolve.NewCmdResolve(f, ioStreams))
 
 	return cmd
 }

--- a/pkg/cmd/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kubeconfig/kubeconfig.go
@@ -173,6 +173,5 @@ func (o *options) Run(_ util.Factory) error {
 		return err
 	}
 
-	// TODO align PrintObject in base and in this implementation
 	return o.PrintObject(convertedObj, o.IOStreams.Out)
 }

--- a/pkg/cmd/resolve/export_test.go
+++ b/pkg/cmd/resolve/export_test.go
@@ -1,0 +1,29 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resolve
+
+import (
+	"github.com/gardener/gardenctl-v2/internal/util"
+)
+
+type TestOptions struct {
+	options
+	out *util.SafeBytesBuffer
+}
+
+func NewOptions(kind Kind) *TestOptions {
+	streams, _, out, _ := util.NewTestIOStreams()
+
+	return &TestOptions{
+		options: *newOptions(streams, kind),
+		out:     out,
+	}
+}
+
+func (o *TestOptions) String() string {
+	return o.out.String()
+}

--- a/pkg/cmd/resolve/options.go
+++ b/pkg/cmd/resolve/options.go
@@ -1,0 +1,295 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resolve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	clientgarden "github.com/gardener/gardenctl-v2/internal/client/garden"
+	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/config"
+	"github.com/gardener/gardenctl-v2/pkg/target"
+)
+
+// options is a struct to support resolve command.
+type options struct {
+	base.Options
+
+	// Kind is the kind to resolve, for example "garden", "project", "seed" or "shoot"
+	Kind Kind
+
+	// CurrentTarget holds the current target configuration
+	CurrentTarget target.Target
+
+	// Garden is the garden config, depending on the current target
+	Garden *config.Garden
+
+	// GardenClient is the client for the garden cluster
+	GardenClient clientgarden.Client
+}
+
+// Kind is representing the type of things that can be resolved.
+type Kind string
+
+const (
+	KindGarden  Kind = "garden"
+	KindProject Kind = "project"
+	KindSeed    Kind = "seed"
+	KindShoot   Kind = "shoot"
+)
+
+// Garden represents a garden cluster.
+type Garden struct {
+	// Name is a unique identifier of this Garden that can be used to target this Garden
+	Name string `json:"name"`
+
+	// Alias is a unique identifier of this Garden that can be used as an alternate name to target this Garden
+	Alias string `json:"alias,omitempty"`
+}
+
+// Project represents a gardener project.
+type Project struct {
+	// Name is the name of the project.
+	Name string `json:"name"`
+
+	// Namespace is the namespace within which the project exists.
+	Namespace *string `json:"namespace,omitempty"`
+}
+
+// Shoot represents a shoot cluster.
+type Shoot struct {
+	// Name is the name of the shoot cluster.
+	Name string `json:"name"`
+
+	// Namespace is the namespace within which the shoot exists.
+	Namespace string `json:"namespace"`
+}
+
+// Seed represents a seed cluster.
+type Seed struct {
+	// Name is the name of the seed cluster.
+	Name string `json:"name"`
+}
+
+// ResolvedTarget represents the resolved target.
+// It contains the details of the Garden, Project, Shoot, and Seed.
+type ResolvedTarget struct {
+	// Garden is the garden where the clusters are hosted.
+	Garden Garden `json:"garden"`
+
+	// Project is the project related to the resolved target. It is optional, hence the omitempty tag.
+	Project *Project `json:"project,omitempty"`
+
+	// Shoot is the shoot cluster related to the resolved target. It is optional, hence the omitempty tag.
+	Shoot *Shoot `json:"shoot,omitempty"`
+
+	// Seed is the seed cluster related to the resolved target. It is optional, hence the omitempty tag.
+	Seed *Seed `json:"seed,omitempty"`
+}
+
+// newOptions returns initialized options.
+func newOptions(ioStreams util.IOStreams, kind Kind) *options {
+	return &options{
+		Options: base.Options{
+			IOStreams: ioStreams,
+			Output:    "yaml",
+		},
+		Kind: kind,
+	}
+}
+
+// Complete adapts from the command line args to the data required.
+func (o *options) Complete(f util.Factory, _ *cobra.Command, _ []string) error {
+	manager, err := f.Manager()
+	if err != nil {
+		return err
+	}
+
+	currentTarget, err := manager.CurrentTarget()
+	if err != nil {
+		return err
+	}
+
+	if currentTarget.GardenName() == "" {
+		return target.ErrNoGardenTargeted
+	}
+
+	o.CurrentTarget = currentTarget
+
+	garden, err := manager.Configuration().Garden(currentTarget.GardenName())
+	if err != nil {
+		return err
+	}
+
+	o.Garden = garden
+
+	gardenClient, err := manager.GardenClient(currentTarget.GardenName())
+	if err != nil {
+		return err
+	}
+
+	o.GardenClient = gardenClient
+
+	return nil
+}
+
+// Validate validates the provided command options.
+func (o *options) Validate() error {
+	if o.Options.Output == "" {
+		return errors.New("output must be 'yaml' or 'json'")
+	}
+
+	return nil
+}
+
+// Run does the actual work of the command.
+func (o *options) Run(f util.Factory) error {
+	ctx := f.Context()
+
+	resolvedTarget := ResolvedTarget{
+		Garden: Garden{
+			Name:  o.Garden.Name,
+			Alias: o.Garden.Alias,
+		},
+	}
+
+	if o.Kind == KindGarden {
+		return o.PrintObject(resolvedTarget)
+	}
+
+	if o.CurrentTarget.ProjectName() != "" && o.Kind == KindProject {
+		project, err := o.GardenClient.GetProject(ctx, o.CurrentTarget.ProjectName())
+		if err != nil {
+			return err
+		}
+
+		resolvedTarget.Project = &Project{
+			Name:      project.Name,
+			Namespace: project.Spec.Namespace,
+		}
+
+		return o.PrintObject(resolvedTarget)
+	}
+
+	if o.CurrentTarget.SeedName() != "" && o.Kind == KindSeed {
+		// We already have the seed name, however we get the seed in order to verify that it exists
+		seed, err := o.GardenClient.GetSeed(ctx, o.CurrentTarget.SeedName())
+		if err != nil {
+			return err
+		}
+
+		resolvedTarget.Seed = &Seed{
+			Name: seed.Name,
+		}
+
+		return o.PrintObject(resolvedTarget)
+	}
+
+	shoot, err := findShoot(ctx, o.GardenClient, o.CurrentTarget)
+	if err != nil {
+		if errors.Is(err, target.ErrNoShootTargeted) && o.Kind == KindProject {
+			return target.ErrNoProjectTargeted
+		}
+
+		return err
+	}
+
+	if o.Kind == KindSeed {
+		resolvedTarget.Seed = &Seed{
+			Name: *shoot.Spec.SeedName,
+		}
+
+		return o.PrintObject(resolvedTarget)
+	}
+
+	if o.CurrentTarget.ControlPlane() {
+		shoot, err = findShoot(ctx, o.GardenClient, o.CurrentTarget.WithSeedName("").WithProjectName("garden").WithShootName(*shoot.Spec.SeedName).WithControlPlane(false))
+		if err != nil {
+			return err
+		}
+	}
+
+	resolvedTarget.Seed = &Seed{
+		Name: *shoot.Spec.SeedName,
+	}
+
+	if resolvedTarget.Project == nil {
+		project, err := o.GardenClient.GetProjectByNamespace(ctx, shoot.Namespace)
+		if err != nil {
+			return err
+		}
+
+		resolvedTarget.Project = &Project{
+			Name:      project.Name,
+			Namespace: project.Spec.Namespace,
+		}
+	}
+
+	if o.Kind == KindProject {
+		resolvedTarget.Seed = nil
+		return o.PrintObject(resolvedTarget)
+	}
+
+	resolvedTarget.Shoot = &Shoot{
+		Name:      shoot.Name,
+		Namespace: shoot.Namespace,
+	}
+
+	return o.PrintObject(resolvedTarget)
+}
+
+func findShoot(ctx context.Context, gardenclient clientgarden.Client, t target.Target) (*gardencorev1beta1.Shoot, error) {
+	opt, err := shootListOption(ctx, gardenclient, t)
+	if err != nil {
+		return nil, err
+	}
+
+	shoot, err := gardenclient.FindShoot(ctx, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	if shoot.Spec.SeedName == nil {
+		return nil, fmt.Errorf("no seed assigned to shoot %s/%s", shoot.Namespace, shoot.Name)
+	}
+
+	return shoot, nil
+}
+
+// shootListOption returns the list options for the shoot.
+// If no shoot or seed (that is a managed seed) was targeted, target.ErrNoShootTargeted is returned.
+func shootListOption(ctx context.Context, gardenClient clientgarden.Client, t target.Target) (client.ListOption, error) {
+	if t.ShootName() != "" {
+		return t.AsListOption(), nil
+	}
+
+	if t.SeedName() != "" {
+		shootOfManagedSeed, err := gardenClient.GetShootOfManagedSeed(ctx, t.SeedName())
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("%s is not a managed seed: %w", t.SeedName(), err)
+			}
+
+			return nil, err
+		}
+
+		return clientgarden.ProjectFilter{
+			"metadata.name": shootOfManagedSeed.Name,
+			"project":       "garden",
+		}, nil
+	}
+
+	return nil, target.ErrNoShootTargeted
+}

--- a/pkg/cmd/resolve/options.go
+++ b/pkg/cmd/resolve/options.go
@@ -199,8 +199,13 @@ func (o *options) Run(f util.Factory) error {
 
 	shoot, err := findShoot(ctx, o.GardenClient, o.CurrentTarget)
 	if err != nil {
-		if errors.Is(err, target.ErrNoShootTargeted) && o.Kind == KindProject {
-			return target.ErrNoProjectTargeted
+		if errors.Is(err, target.ErrNoShootTargeted) {
+			switch o.Kind {
+			case KindProject:
+				return target.ErrNoProjectTargeted
+			case KindSeed:
+				return target.ErrNoSeedTargeted
+			}
 		}
 
 		return err

--- a/pkg/cmd/resolve/options_test.go
+++ b/pkg/cmd/resolve/options_test.go
@@ -255,6 +255,13 @@ seed:
 `))
 				})
 			})
+
+			It("should fail if no seed is targeted", func() {
+				t := target.NewTarget(gardenName, "", "", "")
+				o.CurrentTarget = t
+
+				Expect(o.Run(factory)).To(MatchError(target.ErrNoSeedTargeted))
+			})
 		})
 
 		Context("Resolve Project", func() {

--- a/pkg/cmd/resolve/options_test.go
+++ b/pkg/cmd/resolve/options_test.go
@@ -1,0 +1,420 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resolve_test
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	clientgarden "github.com/gardener/gardenctl-v2/internal/client/garden"
+	gardenclientmocks "github.com/gardener/gardenctl-v2/internal/client/garden/mocks"
+	utilmocks "github.com/gardener/gardenctl-v2/internal/util/mocks"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/resolve"
+	"github.com/gardener/gardenctl-v2/pkg/config"
+	"github.com/gardener/gardenctl-v2/pkg/target"
+	targetmocks "github.com/gardener/gardenctl-v2/pkg/target/mocks"
+)
+
+var _ = Describe("Resolve Command - Options", func() {
+	const gardenName = "mygarden"
+	var (
+		ctrl         *gomock.Controller
+		factory      *utilmocks.MockFactory
+		garden       config.Garden
+		gardenClient *gardenclientmocks.MockClient
+
+		o *resolve.TestOptions
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		factory = utilmocks.NewMockFactory(ctrl)
+		gardenClient = gardenclientmocks.NewMockClient(ctrl)
+
+		garden = config.Garden{Name: gardenName}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("Complete", func() {
+		var (
+			manager *targetmocks.MockManager
+			cfg     *config.Config
+		)
+
+		BeforeEach(func() {
+			manager = targetmocks.NewMockManager(ctrl)
+
+			factory.EXPECT().Manager().Return(manager, nil)
+
+			cfg = &config.Config{
+				LinkKubeconfig: pointer.Bool(false),
+				Gardens:        []config.Garden{garden},
+			}
+
+			o = resolve.NewOptions(resolve.KindGarden)
+		})
+
+		It("should return an error if no garden is targeted", func() {
+			t := target.NewTarget("", "", "", "")
+			manager.EXPECT().CurrentTarget().Return(t, nil)
+
+			err := o.Complete(factory, &cobra.Command{}, []string{})
+			Expect(err).To(MatchError(target.ErrNoGardenTargeted))
+		})
+
+		It("should return an error if garden configuration is not found", func() {
+			t := target.NewTarget("non-existing", "", "", "")
+			manager.EXPECT().CurrentTarget().Return(t, nil)
+			manager.EXPECT().Configuration().Return(cfg)
+
+			err := o.Complete(factory, &cobra.Command{}, []string{})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should complete successfully", func() {
+			t := target.NewTarget(gardenName, "", "", "")
+			manager.EXPECT().CurrentTarget().Return(t, nil)
+			manager.EXPECT().Configuration().Return(cfg)
+			manager.EXPECT().GardenClient(gardenName).Return(gardenClient, nil)
+
+			err := o.Complete(factory, &cobra.Command{}, []string{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("Validate", func() {
+		BeforeEach(func() {
+			o = resolve.NewOptions(resolve.KindGarden)
+			o.Options.Output = "yaml"
+		})
+
+		It("should succeed", func() {
+			Expect(o.Validate()).To(Succeed())
+		})
+
+		It("should fail if output is not set", func() {
+			o.Options.Output = ""
+
+			Expect(o.Validate()).To(MatchError("output must be 'yaml' or 'json'"))
+		})
+	})
+
+	Describe("Run", func() {
+		const (
+			projectName = "myproject"
+			seedName    = "myseed"
+			soilName    = "mysoil"
+			shootName   = "myshoot"
+		)
+
+		var (
+			ctx           context.Context
+			namespace     string
+			project       *gardencorev1beta1.Project
+			projectGarden *gardencorev1beta1.Project
+			seed          *gardencorev1beta1.Seed
+			soil          *gardencorev1beta1.Seed
+			shoot         *gardencorev1beta1.Shoot
+			shoot2        *gardencorev1beta1.Shoot
+
+			kind resolve.Kind
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			factory.EXPECT().Context().Return(ctx)
+
+			namespace = "garden-" + projectName
+
+			project = &gardencorev1beta1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: projectName,
+				},
+				Spec: gardencorev1beta1.ProjectSpec{
+					Namespace: pointer.String(namespace),
+				},
+			}
+
+			projectGarden = &gardencorev1beta1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "garden",
+				},
+				Spec: gardencorev1beta1.ProjectSpec{
+					Namespace: pointer.String("garden"),
+				},
+			}
+
+			seed = &gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: seedName,
+				},
+			}
+
+			soil = &gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: soilName,
+				},
+			}
+
+			// shoot2 acts as shooted-seed
+			shoot2 = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      seedName,
+					Namespace: "garden",
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: pointer.String(soil.Name),
+				},
+			}
+
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      shootName,
+					Namespace: namespace,
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: pointer.String(seed.Name),
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			o = resolve.NewOptions(kind)
+			o.Garden = &garden
+			o.GardenClient = gardenClient
+			o.Options.Output = "yaml"
+		})
+
+		Context("Resolve Garden", func() {
+			BeforeEach(func() {
+				kind = resolve.KindGarden
+			})
+
+			It("should succeed", func() {
+				t := target.NewTarget(gardenName, "", "", "")
+				o.CurrentTarget = t
+
+				Expect(o.Run(factory)).To(Succeed())
+				Expect(o.String()).To(Equal(`garden:
+  name: mygarden
+`))
+			})
+		})
+
+		Context("Resolve Seed", func() {
+			BeforeEach(func() {
+				kind = resolve.KindSeed
+			})
+
+			Context("when garden and seed targeted", func() {
+				It("should succeed", func() {
+					t := target.NewTarget(gardenName, "", seedName, "")
+					o.CurrentTarget = t
+
+					gardenClient.EXPECT().GetSeed(ctx, seedName).Return(seed, nil)
+
+					err := o.Run(factory)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(o.String()).To(Equal(`garden:
+  name: mygarden
+seed:
+  name: myseed
+`))
+				})
+			})
+
+			Context("when garden and shoot targeted", func() {
+				It("should succeed", func() {
+					t := target.NewTarget(gardenName, "", "", shootName)
+					o.CurrentTarget = t
+
+					gardenClient.EXPECT().FindShoot(ctx, t.AsListOption()).Return(shoot, nil)
+
+					err := o.Run(factory)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(o.String()).To(Equal(`garden:
+  name: mygarden
+seed:
+  name: myseed
+`))
+				})
+			})
+		})
+
+		Context("Resolve Project", func() {
+			BeforeEach(func() {
+				kind = resolve.KindProject
+			})
+
+			Context("when project is targeted", func() {
+				It("should succeed", func() {
+					t := target.NewTarget(gardenName, projectName, "", "")
+					o.CurrentTarget = t
+
+					gardenClient.EXPECT().GetProject(ctx, projectName).Return(project, nil)
+
+					Expect(o.Run(factory)).To(Succeed())
+					Expect(o.String()).To(Equal(`garden:
+  name: mygarden
+project:
+  name: myproject
+  namespace: garden-myproject
+`))
+				})
+			})
+
+			Context("when managed seed is targeted", func() {
+				It("should succeed", func() {
+					t := target.NewTarget(gardenName, "", seedName, "")
+					o.CurrentTarget = t
+
+					gardenClient.EXPECT().GetShootOfManagedSeed(ctx, seedName).Return(&seedmanagementv1alpha1.Shoot{Name: shoot2.Name}, nil)
+					gardenClient.EXPECT().FindShoot(ctx, clientgarden.ProjectFilter{
+						"metadata.name": seedName,
+						"project":       "garden",
+					}).Return(shoot2, nil)
+					gardenClient.EXPECT().GetProjectByNamespace(ctx, "garden").Return(projectGarden, nil)
+
+					Expect(o.Run(factory)).To(Succeed())
+					Expect(o.String()).To(Equal(`garden:
+  name: mygarden
+project:
+  name: garden
+  namespace: garden
+`))
+				})
+			})
+
+			It("should fail if no project is targeted", func() {
+				t := target.NewTarget(gardenName, "", "", "")
+				o.CurrentTarget = t
+
+				Expect(o.Run(factory)).To(MatchError(target.ErrNoProjectTargeted))
+			})
+		})
+
+		Context("Resolve Shoot", func() {
+			BeforeEach(func() {
+				kind = resolve.KindShoot
+			})
+
+			Context("when garden and seed is targeted", func() {
+				It("should succeed", func() {
+					t := target.NewTarget(gardenName, "", seedName, "")
+					o.CurrentTarget = t
+
+					gardenClient.EXPECT().GetShootOfManagedSeed(ctx, seedName).Return(&seedmanagementv1alpha1.Shoot{Name: shoot2.Name}, nil)
+					gardenClient.EXPECT().FindShoot(ctx, clientgarden.ProjectFilter{
+						"metadata.name": seedName,
+						"project":       "garden",
+					}).Return(shoot2, nil)
+					gardenClient.EXPECT().GetProjectByNamespace(ctx, "garden").Return(projectGarden, nil)
+
+					Expect(o.Run(factory)).To(Succeed())
+					Expect(o.String()).To(Equal(`garden:
+  name: mygarden
+project:
+  name: garden
+  namespace: garden
+seed:
+  name: mysoil
+shoot:
+  name: myseed
+  namespace: garden
+`))
+				})
+			})
+
+			Context("when garden and shoot is targeted", func() {
+				It("should succeed", func() {
+					t := target.NewTarget(gardenName, "", "", shootName)
+					o.CurrentTarget = t
+
+					gardenClient.EXPECT().FindShoot(ctx, t.AsListOption()).Return(shoot, nil)
+					gardenClient.EXPECT().GetProjectByNamespace(ctx, namespace).Return(project, nil)
+
+					Expect(o.Run(factory)).To(Succeed())
+					Expect(o.String()).To(Equal(`garden:
+  name: mygarden
+project:
+  name: myproject
+  namespace: garden-myproject
+seed:
+  name: myseed
+shoot:
+  name: myshoot
+  namespace: garden-myproject
+`))
+				})
+
+				It("should fail if no seed is assigned to shoot", func() {
+					t := target.NewTarget(gardenName, "", "", shootName)
+					o.CurrentTarget = t
+
+					shoot.Spec.SeedName = nil
+
+					gardenClient.EXPECT().FindShoot(ctx, t.AsListOption()).Return(shoot, nil)
+
+					Expect(o.Run(factory)).To(MatchError("no seed assigned to shoot garden-myproject/myshoot"))
+				})
+			})
+
+			Context("when garden, shoot and control-plane is targeted", func() {
+				It("should succeed", func() {
+					t := target.NewTarget(gardenName, "", "", shootName).WithControlPlane(true)
+					o.CurrentTarget = t
+
+					shoot2Target := target.NewTarget(gardenName, "garden", "", seedName).WithControlPlane(true)
+					gardenClient.EXPECT().FindShoot(ctx, t.AsListOption()).Return(shoot, nil)
+					gardenClient.EXPECT().FindShoot(ctx, shoot2Target.AsListOption()).Return(shoot2, nil)
+					gardenClient.EXPECT().GetProjectByNamespace(ctx, "garden").Return(projectGarden, nil)
+
+					Expect(o.Run(factory)).To(Succeed())
+					Expect(o.String()).To(Equal(`garden:
+  name: mygarden
+project:
+  name: garden
+  namespace: garden
+seed:
+  name: mysoil
+shoot:
+  name: myseed
+  namespace: garden
+`))
+				})
+			})
+
+			It("should fail if no shoot or seed is targeted", func() {
+				t := target.NewTarget(gardenName, projectName, "", "")
+				o.CurrentTarget = t
+
+				Expect(o.Run(factory)).To(MatchError(target.ErrNoShootTargeted))
+			})
+
+			It("should fail if seed is not a managed seed", func() {
+				t := target.NewTarget(gardenName, "", "seed", "")
+				o.CurrentTarget = t
+
+				gardenClient.EXPECT().GetShootOfManagedSeed(ctx, "seed").Return(nil, apierrors.NewNotFound(seedmanagementv1alpha1.Resource("managedseed"), "my-seed"))
+
+				Expect(o.Run(factory)).To(MatchError(MatchRegexp("^seed is not a managed seed")))
+			})
+		})
+	})
+})

--- a/pkg/cmd/resolve/resolve.go
+++ b/pkg/cmd/resolve/resolve.go
@@ -1,0 +1,126 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resolve
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/flags"
+)
+
+// NewCmdResolve returns a new resolve command.
+func NewCmdResolve(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "resolve",
+		Short: "Resolve the current target",
+		Long:  "Resolve garden, seed, project or shoot for the current target",
+	}
+
+	cmd.AddCommand(newCmdResolveGarden(f, ioStreams))
+	cmd.AddCommand(newCmdResolveProject(f, ioStreams))
+	cmd.AddCommand(newCmdResolveSeed(f, ioStreams))
+	cmd.AddCommand(newCmdResolveShoot(f, ioStreams))
+
+	return cmd
+}
+
+// newCmdResolveGarden returns a new resolve garden command.
+func newCmdResolveGarden(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	o := newOptions(ioStreams, KindGarden)
+	cmd := &cobra.Command{
+		Use:   "garden",
+		Short: "Resolve garden for the current target",
+		RunE:  base.WrapRunE(o, f),
+	}
+
+	o.AddFlags(cmd.Flags())
+	o.RegisterCompletionsForOutputFlag(cmd)
+
+	f.TargetFlags().AddGardenFlag(cmd.Flags())
+	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, cmd.Flags())
+
+	return cmd
+}
+
+// newCmdResolveProject returns a new resolve seed command.
+func newCmdResolveProject(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	o := newOptions(ioStreams, KindProject)
+	cmd := &cobra.Command{
+		Use:   "project",
+		Short: "Resolve project for the current target",
+		RunE:  base.WrapRunE(o, f),
+	}
+
+	o.AddFlags(cmd.Flags())
+	o.RegisterCompletionsForOutputFlag(cmd)
+
+	f.TargetFlags().AddGardenFlag(cmd.Flags())
+	f.TargetFlags().AddProjectFlag(cmd.Flags())
+	f.TargetFlags().AddSeedFlag(cmd.Flags())
+	f.TargetFlags().AddShootFlag(cmd.Flags())
+	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, cmd.Flags())
+
+	return cmd
+}
+
+// newCmdResolveSeed returns a new resolve seed command.
+func newCmdResolveSeed(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	o := newOptions(ioStreams, KindSeed)
+	cmd := &cobra.Command{
+		Use:   "seed",
+		Short: "Resolve seed for the current target",
+		RunE:  base.WrapRunE(o, f),
+	}
+
+	o.AddFlags(cmd.Flags())
+	o.RegisterCompletionsForOutputFlag(cmd)
+
+	f.TargetFlags().AddGardenFlag(cmd.Flags())
+	f.TargetFlags().AddProjectFlag(cmd.Flags())
+	f.TargetFlags().AddSeedFlag(cmd.Flags())
+	f.TargetFlags().AddShootFlag(cmd.Flags())
+	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, cmd.Flags())
+
+	return cmd
+}
+
+// newCmdResolveShoot returns a new resolve shoot command.
+func newCmdResolveShoot(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	o := newOptions(ioStreams, KindShoot)
+	cmd := &cobra.Command{
+		Use:   "shoot",
+		Short: "Resolve shoot for the current target",
+		Long: `Resolve shoot for the current target.
+This command is particularly useful when you need to understand which shoot the current target translates to, regardless of whether a seed or a shoot is targeted.
+It fetches and displays information about its associated garden, project, seed, and shoot.
+A garden and either a seed or shoot must be specified, either from a previously saved target or directly via target flags. Target flags temporarily override the saved target for the current command run.`,
+		Example: `# Resolve shoot for managed seed
+gardenctl resolve shoot --garden mygarden --seed myseed
+
+# Resolve shoot. Output in json format
+gardenctl resolve shoot --garden mygarden --shoot myseed -ojson
+
+# Resolve shoot cluster details for a shoot that might have the same name as others across different projects
+# Use fully qualified target flags to specify the correct garden, project, and shoot
+gardenctl resolve shoot --garden mygarden --project myproject --shoot myshoot`,
+		RunE: base.WrapRunE(o, f),
+	}
+
+	o.AddFlags(cmd.Flags())
+	o.RegisterCompletionsForOutputFlag(cmd)
+
+	f.TargetFlags().AddGardenFlag(cmd.Flags())
+	f.TargetFlags().AddProjectFlag(cmd.Flags())
+	f.TargetFlags().AddSeedFlag(cmd.Flags())
+	f.TargetFlags().AddShootFlag(cmd.Flags())
+	f.TargetFlags().AddControlPlaneFlag(cmd.Flags())
+	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, cmd.Flags())
+
+	return cmd
+}

--- a/pkg/cmd/resolve/resolve_suite_test.go
+++ b/pkg/cmd/resolve/resolve_suite_test.go
@@ -1,0 +1,28 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resolve_test
+
+import (
+	"testing"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+func init() {
+	utilruntime.Must(gardencorev1beta1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(seedmanagementv1alpha1.AddToScheme(scheme.Scheme))
+}
+
+func TestResolveCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Resolve Command Test Suite")
+}

--- a/pkg/cmd/resolve/resolve_test.go
+++ b/pkg/cmd/resolve/resolve_test.go
@@ -1,0 +1,153 @@
+/*
+SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resolve_test
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	clientgarden "github.com/gardener/gardenctl-v2/internal/client/garden"
+	"github.com/gardener/gardenctl-v2/internal/fake"
+	"github.com/gardener/gardenctl-v2/internal/util"
+	utilmocks "github.com/gardener/gardenctl-v2/internal/util/mocks"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/resolve"
+	"github.com/gardener/gardenctl-v2/pkg/config"
+	"github.com/gardener/gardenctl-v2/pkg/target"
+	targetmocks "github.com/gardener/gardenctl-v2/pkg/target/mocks"
+)
+
+var _ = Describe("Resolve Command", func() {
+	var (
+		ctrl    *gomock.Controller
+		factory *utilmocks.MockFactory
+		manager *targetmocks.MockManager
+		cmd     *cobra.Command
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		factory = utilmocks.NewMockFactory(ctrl)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("given a ProviderEnv instance", func() {
+		var (
+			ctx     context.Context
+			cfg     *config.Config
+			streams util.IOStreams
+			t       target.Target
+			out     *util.SafeBytesBuffer
+
+			namespace string
+			project   *gardencorev1beta1.Project
+			seed      *gardencorev1beta1.Seed
+			shoot     *gardencorev1beta1.Shoot
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			factory.EXPECT().Context().Return(ctx)
+
+			manager = targetmocks.NewMockManager(ctrl)
+			factory.EXPECT().Manager().Return(manager, nil).AnyTimes()
+
+			t = target.NewTarget("test", "project", "seed", "shoot")
+			manager.EXPECT().CurrentTarget().Return(t, nil)
+
+			targetFlags := target.NewTargetFlags("", "", "", "", false)
+			factory.EXPECT().TargetFlags().Return(targetFlags).AnyTimes()
+
+			cfg = &config.Config{
+				Gardens: []config.Garden{
+					{
+						Name:  t.GardenName(),
+						Alias: "myalias",
+					},
+				},
+			}
+			manager.EXPECT().Configuration().Return(cfg)
+
+			streams, _, out, _ = util.NewTestIOStreams()
+
+			namespace = "garden-" + t.ProjectName()
+
+			project = &gardencorev1beta1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: t.ProjectName(),
+				},
+				Spec: gardencorev1beta1.ProjectSpec{
+					Namespace: pointer.String(namespace),
+				},
+			}
+
+			seed = &gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: t.SeedName(),
+				},
+			}
+
+			shoot = &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      t.ShootName(),
+					Namespace: namespace,
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: pointer.String(seed.Name),
+				},
+			}
+
+			client := clientgarden.NewClient(
+				nil,
+				fake.NewClientWithObjects(project, seed, shoot),
+				t.GardenName(),
+			)
+			manager.EXPECT().GardenClient(t.GardenName()).Return(client, nil)
+
+			cmd = resolve.NewCmdResolve(factory, streams)
+		})
+
+		Context("Resolve Garden", func() {
+			It("should succeed", func() {
+				cmd.SetArgs([]string{"garden"})
+				Expect(cmd.Execute()).To(Succeed())
+				Expect(out.String()).To(Equal(`garden:
+  alias: myalias
+  name: test
+`))
+			})
+		})
+
+		Context("Resolve Shoot", func() {
+			It("should succeed", func() {
+				cmd.SetArgs([]string{"shoot"})
+				Expect(cmd.Execute()).To(Succeed())
+				Expect(out.String()).To(Equal(`garden:
+  alias: myalias
+  name: test
+project:
+  name: project
+  namespace: garden-project
+seed:
+  name: seed
+shoot:
+  name: shoot
+  namespace: garden-project
+`))
+			})
+		})
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `resolve` command to resolve the current target.

With this command it is possible to resolve the target e.g. to `shoot`. 

```bash
$ gardenctl target --garden landscape-dev --seed myseed
Successfully targeted seed "myseed"
```
```bash
$ gardenctl target view -oyaml
garden: landscape-dev
seed: myseed
```

Resolving this target to a shoot is possible in case it is a managed seed
```bash
$ gardenctl resolve shoot
garden:
  alias: dev
  name: landscape-dev
project:
  name: garden
  namespace: garden
seed:
  name: my-soil
shoot:
  name: myseed
  namespace: garden
```


**Which issue(s) this PR fixes**:
Fixes #288 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added `resolve` command in order to resolve garden, seed, project or shoot for the current target. This command is particularly useful when you need to understand which shoot the current target translates to, regardless of whether a seed or a shoot is targeted.
```
