### PR TITLE
`ssh`: add flag to confirm access restrictions

### DIFF
--- a/docs/help/gardenctl_provider-env.md
+++ b/docs/help/gardenctl_provider-env.md
@@ -34,15 +34,16 @@ gardenctl provider-env [flags]
 ### Options
 
 ```
-      --control-plane    target control plane of shoot, use together with shoot argument
-  -f, --force            Generate the script even if there are access restrictions to be confirmed
-      --garden string    target the given garden cluster
-  -h, --help             help for provider-env
-  -o, --output string    One of 'yaml' or 'json'.
-      --project string   target the given project
-      --seed string      target the given seed cluster
-      --shoot string     target the given shoot cluster
-  -u, --unset            Generate the script to unset the cloud provider CLI environment variables and logout for 
+  -y, --confirm-access-restriction   Confirm any access restrictions. Set this flag only if you are completely aware of the access restrictions.
+      --control-plane                target control plane of shoot, use together with shoot argument
+  -f, --force                        Deprecated. Use --confirm-access-restriction instead. Generate the script even if there are access restrictions to be confirmed.
+      --garden string                target the given garden cluster
+  -h, --help                         help for provider-env
+  -o, --output string                One of 'yaml' or 'json'.
+      --project string               target the given project
+      --seed string                  target the given seed cluster
+      --shoot string                 target the given shoot cluster
+  -u, --unset                        Generate the script to unset the cloud provider CLI environment variables and logout for 
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_provider-env_bash.md
+++ b/docs/help/gardenctl_provider-env_bash.md
@@ -26,8 +26,9 @@ gardenctl provider-env bash [flags]
       --add-dir-header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
       --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+  -y, --confirm-access-restriction       Confirm any access restrictions. Set this flag only if you are completely aware of the access restrictions.
       --control-plane                    target control plane of shoot, use together with shoot argument
-  -f, --force                            Generate the script even if there are access restrictions to be confirmed
+  -f, --force                            Deprecated. Use --confirm-access-restriction instead. Generate the script even if there are access restrictions to be confirmed.
       --garden string                    target the given garden cluster
       --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_provider-env_fish.md
+++ b/docs/help/gardenctl_provider-env_fish.md
@@ -26,8 +26,9 @@ gardenctl provider-env fish [flags]
       --add-dir-header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
       --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+  -y, --confirm-access-restriction       Confirm any access restrictions. Set this flag only if you are completely aware of the access restrictions.
       --control-plane                    target control plane of shoot, use together with shoot argument
-  -f, --force                            Generate the script even if there are access restrictions to be confirmed
+  -f, --force                            Deprecated. Use --confirm-access-restriction instead. Generate the script even if there are access restrictions to be confirmed.
       --garden string                    target the given garden cluster
       --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_provider-env_powershell.md
+++ b/docs/help/gardenctl_provider-env_powershell.md
@@ -26,8 +26,9 @@ gardenctl provider-env powershell [flags]
       --add-dir-header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
       --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+  -y, --confirm-access-restriction       Confirm any access restrictions. Set this flag only if you are completely aware of the access restrictions.
       --control-plane                    target control plane of shoot, use together with shoot argument
-  -f, --force                            Generate the script even if there are access restrictions to be confirmed
+  -f, --force                            Deprecated. Use --confirm-access-restriction instead. Generate the script even if there are access restrictions to be confirmed.
       --garden string                    target the given garden cluster
       --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_provider-env_zsh.md
+++ b/docs/help/gardenctl_provider-env_zsh.md
@@ -26,8 +26,9 @@ gardenctl provider-env zsh [flags]
       --add-dir-header                   If true, adds the file directory to the header of the log messages
       --alsologtostderr                  log to standard error as well as files (no effect when -logtostderr=true)
       --config string                    config file (default is ~/.garden/gardenctl-v2.yaml)
+  -y, --confirm-access-restriction       Confirm any access restrictions. Set this flag only if you are completely aware of the access restrictions.
       --control-plane                    target control plane of shoot, use together with shoot argument
-  -f, --force                            Generate the script even if there are access restrictions to be confirmed
+  -f, --force                            Deprecated. Use --confirm-access-restriction instead. Generate the script even if there are access restrictions to be confirmed.
       --garden string                    target the given garden cluster
       --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                   If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_ssh.md
+++ b/docs/help/gardenctl_ssh.md
@@ -44,6 +44,7 @@ gardenctl ssh --keep-bastion --bastion-name cli-xxxxxxxx --public-key-file /path
       --bastion-port string                     SSH port of the bastion used for the SSH client command. Defaults to port 22 (default "22")
       --bastion-user-known-hosts-file strings   Path to a custom known hosts file for the SSH connection to the bastion. This file is used to verify the public keys of remote hosts when establishing a secure connection.
       --cidr stringArray                        CIDRs to allow access to the bastion host; if not given, your system's public IPs (v4 and v6) are auto-detected.
+  -y, --confirm-access-restriction              Bypasses the need for confirmation of any access restrictions. Set this flag only if you are fully aware of the access restrictions.
       --control-plane                           target control plane of shoot, use together with shoot argument
       --garden string                           target the given garden cluster
   -h, --help                                    help for ssh

--- a/pkg/cmd/providerenv/options_test.go
+++ b/pkg/cmd/providerenv/options_test.go
@@ -81,17 +81,22 @@ var _ = Describe("Env Commands - Options", func() {
 		})
 
 		Describe("completing the command options", func() {
-			var root,
+			var (
+				root,
 				parent,
 				child *cobra.Command
+				ctx context.Context
+			)
 
 			BeforeEach(func() {
+				ctx = context.Background()
 				root = &cobra.Command{Use: "root"}
 				parent = &cobra.Command{Use: "parent", Aliases: []string{"alias"}}
 				child = &cobra.Command{Use: "child"}
 				parent.AddCommand(child)
 				root.AddCommand(parent)
 				factory.EXPECT().GardenHomeDir().Return(gardenHomeDir)
+				factory.EXPECT().Context().Return(ctx)
 				root.SetArgs([]string{"alias", "child"})
 				Expect(root.Execute()).To(Succeed())
 				baseTemplate = nil

--- a/pkg/cmd/providerenv/providerenv_test.go
+++ b/pkg/cmd/providerenv/providerenv_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Env Commands", func() {
 				factory.EXPECT().GardenHomeDir().Return(gardenHomeDir)
 
 				ctx = context.Background()
-				factory.EXPECT().Context().Return(ctx)
+				factory.EXPECT().Context().Return(ctx).AnyTimes()
 
 				secretBindingName = "secret-binding"
 				cloudProfileName = "cloud-profile"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new flag called `--confirm-access-restriction` to the `ssh` command. It functions similarly to the now deprecated `--force` flag of the `provider-env` command.

The `provider-env` command has also been updated to include the `--confirm-access-restriction` flag, which replaces the deprecated `--force` flag. The `--force` flag will eventually be removed in a future version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`ssh`: Added flag `--confirm-access-restriction`. Using this flag bypasses the need for confirmation of any access restrictions. Set this flag only if you are fully aware of the access restrictions.
```

```other user
`provider-env`: ⚠️ The `--force` is now deprecated. Use `--confirm-access-restriction` flag instead. The `--force` flag will eventually be removed in a future version.
```
