### PR TITLE
`ssh`: improve ssh command description

### DIFF
--- a/pkg/cmd/ssh/connect_information.go
+++ b/pkg/cmd/ssh/connect_information.go
@@ -147,8 +147,11 @@ func (p *ConnectInformation) String() string {
 	buf := bytes.Buffer{}
 
 	nodeHostname := p.NodeHostname
+	placeholderHostname := false
+
 	if nodeHostname == "" {
 		nodeHostname = "IP_OR_HOSTNAME"
+		placeholderHostname = true
 
 		table := &metav1beta1.Table{
 			ColumnDefinitions: []metav1.TableColumnDefinition{
@@ -179,8 +182,7 @@ func (p *ConnectInformation) String() string {
 			})
 		}
 
-		fmt.Fprintln(&buf, "The shoot cluster has the following nodes:")
-		fmt.Fprintln(&buf, "")
+		fmt.Fprintf(&buf, "> The shoot cluster has the following nodes:\n\n")
 
 		printer := printers.NewTablePrinter(printers.PrintOptions{})
 		if err := printer.PrintObj(table, &buf); err != nil {
@@ -200,10 +202,14 @@ func (p *ConnectInformation) String() string {
 		p.NodePrivateKeyFiles,
 	)
 
-	fmt.Fprintln(&buf, "Connect to shoot nodes by using the bastion as a proxy/jump host, for example:")
-	fmt.Fprintln(&buf, "")
-	fmt.Fprintf(&buf, "ssh %s\n", connectArgs.String())
-	fmt.Fprintln(&buf, "")
+	fmt.Fprintf(&buf, "> Connect to shoot nodes by using the bastion as a proxy/jump host.\n")
+	fmt.Fprintf(&buf, "> Run the following command in a separate terminal:\n")
+
+	if placeholderHostname {
+		fmt.Fprintf(&buf, "> Note: The command includes a placeholder (IP_OR_HOSTNAME). Replace it with the actual IP or hostname before running the command.\n\n")
+	}
+
+	fmt.Fprintf(&buf, "ssh %s\n\n", connectArgs.String())
 
 	return buf.String()
 }

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -155,7 +155,7 @@ var (
 	// bastion alive until gardenctl exits.
 	waitForSignal = func(ctx context.Context, o *SSHOptions, signalChan <-chan struct{}) {
 		if o.Output == "" {
-			fmt.Fprintln(o.IOStreams.Out, "Press Ctrl-C to stop gardenctl, after which the bastion will be removed.")
+			fmt.Fprintln(o.IOStreams.Out, "> Press Ctrl-C to stop gardenctl, after which the bastion will be removed.")
 		}
 
 		// keep the bastion alive until gardenctl exits
@@ -539,7 +539,7 @@ func (o *SSHOptions) Run(f util.Factory) error {
 
 	workersSettings := shoot.Spec.Provider.WorkersSettings
 	if workersSettings != nil && workersSettings.SSHAccess != nil && !workersSettings.SSHAccess.Enabled {
-		return errors.New("Node SSH access disabled, SSH not allowed")
+		return errors.New("node SSH access disabled, SSH not allowed")
 	}
 
 	// fetch the SSH key(s) for the shoot nodes
@@ -957,10 +957,8 @@ func remoteShell(
 		nodePrivateKeyFiles,
 	)
 
-	fmt.Fprintln(ioStreams.Out, "You can open additional SSH sessions using the command below:")
-	fmt.Fprintln(ioStreams.Out, "")
-	fmt.Fprintf(ioStreams.Out, "ssh %s\n", commandArgs.String())
-	fmt.Fprintln(ioStreams.Out, "")
+	fmt.Fprintf(ioStreams.Out, "> You can open additional SSH sessions by running the following command in a separate terminal:\n\n")
+	fmt.Fprintf(ioStreams.Out, "ssh %s\n\n", commandArgs.String())
 
 	var args []string
 

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -602,7 +602,7 @@ var _ = Describe("SSH Command", func() {
 			testShoot.Spec.Provider.WorkersSettings.SSHAccess.Enabled = false
 			Expect(gardenClient.Patch(ctx, testShoot, client.MergeFrom(testShootBase))).To(Succeed())
 
-			Expect(cmd.RunE(cmd, nil)).To(MatchError("Node SSH access disabled, SSH not allowed"))
+			Expect(cmd.RunE(cmd, nil)).To(MatchError("node SSH access disabled, SSH not allowed"))
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Improved text which describes how to manually connect using ssh
- Execute command in a separate terminal window
- If the command includes a placeholder, the user is hinted to replace it accordingly
- Added `> ` prefix to better distinguish regular regular output from the ssh-command to copy

**Which issue(s) this PR fixes**:
Fixes #315

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Improved text which describes how to manually connect using ssh
```
