### PR TITLE
add sshuser flag

### DIFF
--- a/docs/help/gardenctl_ssh.md
+++ b/docs/help/gardenctl_ssh.md
@@ -58,7 +58,7 @@ gardenctl ssh --keep-bastion --bastion-name cli-xxxxxxxx --public-key-file /path
       --seed string                             target the given seed cluster
       --shoot string                            target the given shoot cluster
       --skip-availability-check                 Skip checking for SSH bastion host availability.
-      --ssh-user string                         ssh user is the name of the Shoot cluster node ssh login user name.
+      --user string                             user is the name of the Shoot cluster node ssh login user name. (default "gardener")
       --wait-timeout duration                   Maximum duration to wait for the bastion to become available. (default 10m0s)
 ```
 

--- a/docs/help/gardenctl_ssh.md
+++ b/docs/help/gardenctl_ssh.md
@@ -58,6 +58,7 @@ gardenctl ssh --keep-bastion --bastion-name cli-xxxxxxxx --public-key-file /path
       --seed string                             target the given seed cluster
       --shoot string                            target the given shoot cluster
       --skip-availability-check                 Skip checking for SSH bastion host availability.
+      --ssh-user string                         ssh user is the name of the Shoot cluster node ssh login user name.
       --wait-timeout duration                   Maximum duration to wait for the bastion to become available. (default 10m0s)
 ```
 

--- a/docs/help/gardenctl_ssh.md
+++ b/docs/help/gardenctl_ssh.md
@@ -58,7 +58,7 @@ gardenctl ssh --keep-bastion --bastion-name cli-xxxxxxxx --public-key-file /path
       --seed string                             target the given seed cluster
       --shoot string                            target the given shoot cluster
       --skip-availability-check                 Skip checking for SSH bastion host availability.
-      --user string                             user is the name of the Shoot cluster node ssh login user name. (default "gardener")
+      --user string                             user is the name of the Shoot cluster node ssh login username. (default "gardener")
       --wait-timeout duration                   Maximum duration to wait for the bastion to become available. (default 10m0s)
 ```
 

--- a/pkg/cmd/ssh/arguments.go
+++ b/pkg/cmd/ssh/arguments.go
@@ -66,6 +66,7 @@ func sshCommandArguments(
 	bastionUserKnownHostsFiles []string,
 	nodeHostname string,
 	nodePrivateKeyFiles []PrivateKeyFile,
+	user string,
 ) arguments {
 	bastionUserKnownHostsFilesArg := userKnownHostsFilesArgument(bastionUserKnownHostsFiles)
 
@@ -87,7 +88,7 @@ func sshCommandArguments(
 
 	args = append(args, argument{value: fmt.Sprintf("-oProxyCommand=%s", proxyCmdArgs.String())})
 
-	args = append(args, argument{value: fmt.Sprintf("%s@%s", SSHNodeUsername, nodeHostname)})
+	args = append(args, argument{value: fmt.Sprintf("%s@%s", user, nodeHostname)})
 
 	return arguments{list: args}
 }

--- a/pkg/cmd/ssh/arguments_test.go
+++ b/pkg/cmd/ssh/arguments_test.go
@@ -23,6 +23,7 @@ type testCase struct {
 	nodeHostname               string
 	nodePrivateKeyFiles        []ssh.PrivateKeyFile
 	expectedArgs               []string
+	user                       string
 }
 
 func newTestCase() testCase {
@@ -32,6 +33,7 @@ func newTestCase() testCase {
 		sshPrivateKeyFile:   "path/to/private/key",
 		nodeHostname:        "node.example.com",
 		nodePrivateKeyFiles: []ssh.PrivateKeyFile{"path/to/node/private/key"},
+		user:                "gardener",
 	}
 }
 
@@ -46,6 +48,7 @@ var _ = Describe("Arguments", func() {
 					tc.bastionUserKnownHostsFiles,
 					tc.nodeHostname,
 					tc.nodePrivateKeyFiles,
+					tc.user,
 				)
 				Expect(args.String()).To(Equal(strings.Join(tc.expectedArgs, " ")))
 			},
@@ -57,6 +60,18 @@ var _ = Describe("Arguments", func() {
 					"'-ipath/to/node/private/key'",
 					`'-oProxyCommand=ssh -W%h:%p -oStrictHostKeyChecking=no -oIdentitiesOnly=yes '"'"'-ipath/to/private/key'"'"' '"'"'gardener@bastion.example.com'"'"' '"'"'-p22'"'"''`,
 					"'gardener@node.example.com'",
+				}
+				return tc
+			}()),
+			Entry("basic case with other ssh username", func() testCase {
+				tc := newTestCase()
+				tc.user = "aaa"
+				tc.expectedArgs = []string{
+					"-oStrictHostKeyChecking=no",
+					"-oIdentitiesOnly=yes",
+					"'-ipath/to/node/private/key'",
+					`'-oProxyCommand=ssh -W%h:%p -oStrictHostKeyChecking=no -oIdentitiesOnly=yes '"'"'-ipath/to/private/key'"'"' '"'"'gardener@bastion.example.com'"'"' '"'"'-p22'"'"''`,
+					"'aaa@node.example.com'",
 				}
 				return tc
 			}()),

--- a/pkg/cmd/ssh/connect_information.go
+++ b/pkg/cmd/ssh/connect_information.go
@@ -32,6 +32,7 @@ type ConnectInformation struct {
 
 	// Nodes is a list of Node objects containing information about the worker nodes.
 	Nodes []Node `json:"nodes"`
+
 	// User is the name of the Shoot cluster node ssh login username
 	User string
 }
@@ -86,6 +87,7 @@ func NewConnectInformation(
 	sshPrivateKeyFile PrivateKeyFile,
 	nodePrivateKeyFiles []PrivateKeyFile,
 	nodes []corev1.Node,
+	user string,
 ) (*ConnectInformation, error) {
 	var nodeList []Node
 
@@ -142,6 +144,7 @@ func NewConnectInformation(
 		NodeHostname:        nodeHostname,
 		NodePrivateKeyFiles: nodePrivateKeyFiles,
 		Nodes:               nodeList,
+		User:                user,
 	}, nil
 }
 

--- a/pkg/cmd/ssh/connect_information.go
+++ b/pkg/cmd/ssh/connect_information.go
@@ -200,6 +200,7 @@ func (p *ConnectInformation) String() string {
 		p.Bastion.UserKnownHostsFiles,
 		nodeHostname,
 		p.NodePrivateKeyFiles,
+		"",
 	)
 
 	fmt.Fprintf(&buf, "> Connect to shoot nodes by using the bastion as a proxy/jump host.\n")

--- a/pkg/cmd/ssh/connect_information.go
+++ b/pkg/cmd/ssh/connect_information.go
@@ -32,6 +32,8 @@ type ConnectInformation struct {
 
 	// Nodes is a list of Node objects containing information about the worker nodes.
 	Nodes []Node `json:"nodes"`
+	// User is the name of the Shoot cluster node ssh login username
+	User string
 }
 
 var _ fmt.Stringer = &ConnectInformation{}
@@ -200,7 +202,7 @@ func (p *ConnectInformation) String() string {
 		p.Bastion.UserKnownHostsFiles,
 		nodeHostname,
 		p.NodePrivateKeyFiles,
-		"",
+		p.User,
 	)
 
 	fmt.Fprintf(&buf, "> Connect to shoot nodes by using the bastion as a proxy/jump host.\n")

--- a/pkg/cmd/ssh/export_test.go
+++ b/pkg/cmd/ssh/export_test.go
@@ -60,6 +60,7 @@ func SSHCommandArguments(
 	bastionUserKnownHostsFiles []string,
 	nodeHostname string,
 	nodePrivateKeyFiles []PrivateKeyFile,
+	user string,
 ) TestArguments {
 	return TestArguments{
 		sshCommandArguments(
@@ -69,6 +70,7 @@ func SSHCommandArguments(
 			bastionUserKnownHostsFiles,
 			nodeHostname,
 			nodePrivateKeyFiles,
+			user,
 		),
 	}
 }

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -55,11 +55,14 @@ import (
 const (
 	// SSHBastionUsername is the system username on the bastion host.
 	SSHBastionUsername = "gardener"
-	// SSHNodeUsername is the system username on any of the shoot cluster nodes.
-	SSHNodeUsername = "gardener"
+	// DefaultUsername is the default system username on any of the shoot cluster nodes.
+	DefaultUsername = "gardener"
 	// SSHPort is the TCP port on a bastion instance that allows incoming SSH.
 	SSHPort = 22
 )
+
+// SSHNodeUsername is ssh login user name.
+var SSHNodeUsername string
 
 // wrappers used for unit tests only.
 var (
@@ -194,6 +197,9 @@ type SSHOptions struct {
 	// bastion host, but leave it up to the user to SSH themselves.
 	NodeName string
 
+	// SSHUser is the name of the Shoot cluster node ssh login user name
+	SSHUser string
+
 	// SSHPublicKeyFile is the full path to the file containing the user's
 	// public SSH key. If not given, gardenctl will create a new temporary keypair.
 	SSHPublicKeyFile PublicKeyFile
@@ -258,7 +264,7 @@ func (o *SSHOptions) AddFlags(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&o.BastionPort, "bastion-port", o.BastionPort, "SSH port of the bastion used for the SSH client command. Defaults to port 22")
 	flagSet.StringSliceVar(&o.BastionUserKnownHostsFiles, "bastion-user-known-hosts-file", o.BastionUserKnownHostsFiles, "Path to a custom known hosts file for the SSH connection to the bastion. This file is used to verify the public keys of remote hosts when establishing a secure connection.")
 	flagSet.BoolVarP(&o.ConfirmAccessRestriction, "confirm-access-restriction", "y", o.ConfirmAccessRestriction, "Bypasses the need for confirmation of any access restrictions. Set this flag only if you are fully aware of the access restrictions.")
-
+	flagSet.StringVar(&o.SSHUser, "ssh-user", o.SSHUser, "ssh user is the name of the Shoot cluster node ssh login user name.")
 	o.Options.AddFlags(flagSet)
 }
 
@@ -308,6 +314,12 @@ func (o *SSHOptions) Complete(f util.Factory, cmd *cobra.Command, args []string)
 		}
 
 		o.BastionName = name
+	}
+
+	if o.SSHUser == "" {
+		SSHNodeUsername = DefaultUsername
+	} else {
+		SSHNodeUsername = o.SSHUser
 	}
 
 	return nil

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -262,7 +262,7 @@ func (o *SSHOptions) AddFlags(flagSet *pflag.FlagSet) {
 	flagSet.StringVar(&o.BastionPort, "bastion-port", o.BastionPort, "SSH port of the bastion used for the SSH client command. Defaults to port 22")
 	flagSet.StringSliceVar(&o.BastionUserKnownHostsFiles, "bastion-user-known-hosts-file", o.BastionUserKnownHostsFiles, "Path to a custom known hosts file for the SSH connection to the bastion. This file is used to verify the public keys of remote hosts when establishing a secure connection.")
 	flagSet.BoolVarP(&o.ConfirmAccessRestriction, "confirm-access-restriction", "y", o.ConfirmAccessRestriction, "Bypasses the need for confirmation of any access restrictions. Set this flag only if you are fully aware of the access restrictions.")
-	flagSet.StringVar(&o.User, "user", o.User, "user is the name of the Shoot cluster node ssh login user name.")
+	flagSet.StringVar(&o.User, "user", o.User, "user is the name of the Shoot cluster node ssh login username.")
 	o.Options.AddFlags(flagSet)
 }
 

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -663,6 +663,7 @@ func (o *SSHOptions) Run(f util.Factory) error {
 			o.SSHPrivateKeyFile,
 			nodePrivateKeyFiles,
 			nodes,
+			o.User,
 		)
 		if err != nil {
 			return err

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -353,7 +353,7 @@ var _ = Describe("SSH Command", func() {
 						ssh.SSHBastionUsername,
 						bastionIP,
 					),
-					fmt.Sprintf("%s@%s", ssh.SSHNodeUsername, nodeHostname),
+					fmt.Sprintf("%s@%s", options.User, nodeHostname),
 				}))
 
 				return nil
@@ -407,7 +407,7 @@ var _ = Describe("SSH Command", func() {
 						ssh.SSHBastionUsername,
 						bastionIP,
 					),
-					fmt.Sprintf("%s@%s", ssh.SSHNodeUsername, nodeName),
+					fmt.Sprintf("%s@%s", options.User, nodeName),
 				}))
 
 				return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
add `--ssh-user` flag to override the default ssh login username

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardenctl-v2/issues/322

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
add `--ssh-user` flag to override the default ssh login username
```
