### PR TITLE
Nix flake enablement for gardenctl-v2

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -28,6 +28,7 @@ Files:
   go.sum
   LATEST
   VERSION
+  flake.lock
 Copyright: 2020-2021 SAP SE or an SAP affiliate company and Gardener contributors
 License: Apache-2.0
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ gardenctl is a command-line client for the Gardener. It facilitates the administ
 
 ## Installation
 
-Install the latest release from [Homebrew](https://brew.sh/), [Chocolatey](https://chocolatey.org/packages/gardenctl-v2) or [GitHub Releases](https://github.com/gardener/gardenctl-v2/releases).
+Install the latest release from [Homebrew](https://brew.sh/), [Chocolatey](https://chocolatey.org/packages/gardenctl-v2), [Nix](https://nixos.org), or [GitHub Releases](https://github.com/gardener/gardenctl-v2/releases).
 
 ### Install using Package Managers
 
@@ -26,6 +26,25 @@ choco install gardenctl-v2
 ```
 
 Attention `brew` users: `gardenctl-v2` uses the same binary name as the legacy `gardenctl` (`gardener/gardenctl`) CLI. If you have an existing installation you should remove it with `brew uninstall gardenctl` before attempting to install `gardenctl-v2`. Alternatively, you can choose to link the binary using a different name. If you try to install without removing or relinking the old installation, brew will run into an error and provide instructions how to resolve it.
+
+### Install using Nix (with [Flakes](https://nixos.wiki/wiki/Flakes))
+
+```bash
+# Nix (macOS, Linux, and Windows)
+# ad hoc cmd execution
+nix run github:gardener/gardenctl-v2 -- --help
+
+# install development version
+nix profile install github:gardener/gardenctl-v2
+# or release <version>
+nix profile install github:gardener/gardenctl-v2/<version>
+
+#check installation
+nix profile list | grep gardenctl
+
+# optionally, open a new shell and verify that cmd completion works
+gardenctl --help
+```
 
 ### Install from Github Release
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1704732714,
+        "narHash": "sha256-ABqK/HggMYA/jMUXgYyqVAcQ8QjeMyr1jcXfTpSHmps=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6723fa4e4f1a30d42a633bef5eb01caeb281adc3",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-23.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,18 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704732714,
-        "narHash": "sha256-ABqK/HggMYA/jMUXgYyqVAcQ8QjeMyr1jcXfTpSHmps=",
+        "lastModified": 1704874635,
+        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6723fa4e4f1a30d42a633bef5eb01caeb281adc3",
+        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "NixOS",
         "ref": "nixos-23.11",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,103 +7,114 @@ SPDX-License-Identifier: Apache-2.0
   description = "Nix flake for gardenctl-v2";
 
   inputs = {
-    # NixPkgs (nixos-23.11)
-    nixpkgs.url = "nixpkgs/nixos-23.11"; #"github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
   };
 
-  outputs = { self, nixpkgs, ... }:
-    let
-      pname = "gardenctl";
+  outputs = {
+    self,
+    nixpkgs,
+    ...
+  }: let
+    pname = "gardenctl";
 
-      # System types to support.
-      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+    # System types to support.
+    supportedSystems = ["x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin"];
 
-      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+    # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+    forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
-      # Nixpkgs instantiated for supported system types.
-      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
-    in
-    {
-      # Provide some binary packages for selected system types.
-      packages = forAllSystems (system:
-        let
-          pkgs = nixpkgsFor.${system};
-          inherit (pkgs) stdenv lib;
-        in
-        {
-          ${pname} = pkgs.buildGo121Module rec {
-            inherit pname self;
-            version = lib.fileContents ./VERSION;
-            splitVersion = lib.versions.splitVersion version;
-            major = if ((lib.elemAt splitVersion 0) == "v") then lib.elemAt splitVersion 1 else lib.elemAt splitVersion 0;
-            minor = if ((lib.elemAt splitVersion 0) == "v") then lib.elemAt splitVersion 2 else lib.elemAt splitVersion 1;
-            gitCommit = if (self ? rev) then self.rev else self.dirtyRev;
-            state = if (self ? rev) then "clean" else "dirty";
+    # Nixpkgs instantiated for supported system types.
+    nixpkgsFor = forAllSystems (system: import nixpkgs {inherit system;});
+  in {
+    # Provide some binary packages for selected system types.
+    packages = forAllSystems (system: let
+      pkgs = nixpkgsFor.${system};
+      inherit (pkgs) stdenv lib;
+    in {
+      ${pname} = pkgs.buildGo121Module rec {
+        inherit pname self;
+        version = lib.fileContents ./VERSION;
+        splitVersion = lib.versions.splitVersion version;
+        major = if ((lib.elemAt splitVersion 0) == "v") then 
+          lib.elemAt splitVersion 1
+        else 
+          lib.elemAt splitVersion 0;
+        minor = if ((lib.elemAt splitVersion 0) == "v") then
+          lib.elemAt splitVersion 2
+        else
+          lib.elemAt splitVersion 1;
+        gitCommit = if (self ? rev) then
+          self.rev
+        else
+          self.dirtyRev;
+        state = if (self ? rev) then
+          "clean"
+        else
+          "dirty";
 
-            # This vendorHash represents a dervative of all go.mod dependancies and needs to be adjusted with every change
-            vendorHash = "sha256-YE6Xtm7OsY82AxnHuJFaV5tpOqMKftZr1Xiws+43uVA=";
+        # This vendorHash represents a dervative of all go.mod dependancies and needs to be adjusted with every change
+        vendorHash = "sha256-YE6Xtm7OsY82AxnHuJFaV5tpOqMKftZr1Xiws+43uVA=";
 
-            src = ./.;
+        src = ./.;
 
-            ldflags = [
-              "-s" "-w"
-              "-X k8s.io/component-base/version.gitMajor=${major}"
-              "-X k8s.io/component-base/version.gitMinor=${minor}"
-              "-X k8s.io/component-base/version.gitVersion=${version}"
-              "-X k8s.io/component-base/version.gitTreeState=${state}"
-              "-X k8s.io/component-base/version.gitCommit=${gitCommit}"
-              "-X k8s.io/component-base/version/verflag.programName=${pname}"
-            # "-X k8s.io/component-base/version.buildDate=1970-01-01T0:00:00+0000"
-            ];
+        ldflags = [
+          "-s"
+          "-w"
+          "-X k8s.io/component-base/version.gitMajor=${major}"
+          "-X k8s.io/component-base/version.gitMinor=${minor}"
+          "-X k8s.io/component-base/version.gitVersion=${version}"
+          "-X k8s.io/component-base/version.gitTreeState=${state}"
+          "-X k8s.io/component-base/version.gitCommit=${gitCommit}"
+          "-X k8s.io/component-base/version/verflag.programName=${pname}"
+          # "-X k8s.io/component-base/version.buildDate=1970-01-01T0:00:00+0000"
+        ];
 
-            CGO_ENABLED = 0;
-            doCheck = false;
-            subPackages = [
-              "/"
-            ];
-            nativeBuildInputs = [ pkgs.installShellFiles ];
+        CGO_ENABLED = 0;
+        doCheck = false;
+        subPackages = [
+          "/"
+        ];
+        nativeBuildInputs = [pkgs.installShellFiles];
 
-            postInstall = ''
-              mv $out/bin/${pname}-v2 $out/bin/${pname}
-              installShellCompletion --cmd ${pname} --zsh  <($out/bin/${pname} completion zsh)
-              installShellCompletion --cmd ${pname} --bash <($out/bin/${pname} completion bash)
-              installShellCompletion --cmd ${pname} --fish <($out/bin/${pname} completion fish)
-            '';
+        postInstall = ''
+          mv $out/bin/${pname}-v2 $out/bin/${pname}
+          installShellCompletion --cmd ${pname} \
+              --zsh  <($out/bin/${pname} completion zsh) \
+              --bash <($out/bin/${pname} completion bash) \
+              --fish <($out/bin/${pname} completion fish)
+        '';
 
-            meta = with lib; {
-              description = "gardenctl facilitates the administration of one or many garden, seed and shoot clusters";
-              longDescription = ''
-                gardenctl is a command-line client for the Gardener.
-                It facilitates the administration of one or many garden, seed and shoot clusters.
-                Use this tool to configure access to clusters and configure cloud provider CLI tools. 
-                It also provides support for accessing cluster nodes via ssh.
-             '';
-              homepage = "https://github.com/gardener/gardenctl-v2";
-              license = licenses.asl20;
-              platforms = supportedSystems;
-            };
-          };
-        });
-      
-      # Add dependencies that are only needed for development
-      devShells = forAllSystems (system:
-        let 
-          pkgs = nixpkgsFor.${system};
-        in
-        {
-          default = pkgs.mkShell {
-            buildInputs = with pkgs; [ 
-              go_1_21 
-              gopls 
-              gotools 
-              go-tools
-              gnumake
-            ];
-          };
-        });
+        meta = with lib; {
+          description = "gardenctl facilitates the administration of one or many garden, seed and shoot clusters";
+          longDescription = ''
+            gardenctl is a command-line client for the Gardener.
+            It facilitates the administration of one or many garden, seed and shoot clusters.
+            Use this tool to configure access to clusters and configure cloud provider CLI tools.
+            It also provides support for accessing cluster nodes via ssh.
+          '';
+          homepage = "https://github.com/gardener/gardenctl-v2";
+          license = licenses.asl20;
+          platforms = supportedSystems;
+        };
+      };
+    });
 
-      # The default package for 'nix build'
-      defaultPackage = forAllSystems (system: self.packages.${system}.${pname});
-    };
+    # Add dependencies that are only needed for development
+    devShells = forAllSystems (system: let
+      pkgs = nixpkgsFor.${system};
+    in {
+      default = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          go_1_21   # golang 1.21
+          gopls     # go language server
+          gotools   # go imports
+          go-tools  # static checks
+          gnumake   # standard make
+        ];
+      };
+    });
+
+    # The default package for 'nix build'
+    defaultPackage = forAllSystems (system: self.packages.${system}.${pname});
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,109 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+{
+  description = "Nix flake for gardenctl-v2";
+
+  inputs = {
+    # NixPkgs (nixos-23.11)
+    nixpkgs.url = "nixpkgs/nixos-23.11"; #"github:NixOS/nixpkgs/nixos-23.11";
+  };
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      pname = "gardenctl";
+
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in
+    {
+      # Provide some binary packages for selected system types.
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+          inherit (pkgs) stdenv lib;
+        in
+        {
+          ${pname} = pkgs.buildGo121Module rec {
+            inherit pname self;
+            version = lib.fileContents ./VERSION;
+            splitVersion = lib.versions.splitVersion version;
+            major = if ((lib.elemAt splitVersion 0) == "v") then lib.elemAt splitVersion 1 else lib.elemAt splitVersion 0;
+            minor = if ((lib.elemAt splitVersion 0) == "v") then lib.elemAt splitVersion 2 else lib.elemAt splitVersion 1;
+            gitCommit = if (self ? rev) then self.rev else self.dirtyRev;
+            state = if (self ? rev) then "clean" else "dirty";
+
+            # This vendorHash represents a dervative of all go.mod dependancies and needs to be adjusted with every change
+            vendorHash = "sha256-YE6Xtm7OsY82AxnHuJFaV5tpOqMKftZr1Xiws+43uVA=";
+
+            src = ./.;
+
+            ldflags = [
+              "-s" "-w"
+              "-X k8s.io/component-base/version.gitMajor=${major}"
+              "-X k8s.io/component-base/version.gitMinor=${minor}"
+              "-X k8s.io/component-base/version.gitVersion=${version}"
+              "-X k8s.io/component-base/version.gitTreeState=${state}"
+              "-X k8s.io/component-base/version.gitCommit=${gitCommit}"
+              "-X k8s.io/component-base/version/verflag.programName=${pname}"
+            # "-X k8s.io/component-base/version.buildDate=1970-01-01T0:00:00+0000"
+            ];
+
+            CGO_ENABLED = 0;
+            doCheck = false;
+            subPackages = [
+              "/"
+            ];
+            nativeBuildInputs = [ pkgs.installShellFiles ];
+
+            postInstall = ''
+              mv $out/bin/${pname}-v2 $out/bin/${pname}
+              installShellCompletion --cmd ${pname} --zsh  <($out/bin/${pname} completion zsh)
+              installShellCompletion --cmd ${pname} --bash <($out/bin/${pname} completion bash)
+              installShellCompletion --cmd ${pname} --fish <($out/bin/${pname} completion fish)
+            '';
+
+            meta = with lib; {
+              description = "gardenctl facilitates the administration of one or many garden, seed and shoot clusters";
+              longDescription = ''
+                gardenctl is a command-line client for the Gardener.
+                It facilitates the administration of one or many garden, seed and shoot clusters.
+                Use this tool to configure access to clusters and configure cloud provider CLI tools. 
+                It also provides support for accessing cluster nodes via ssh.
+             '';
+              homepage = "https://github.com/gardener/gardenctl-v2";
+              license = licenses.asl20;
+              platforms = supportedSystems;
+            };
+          };
+        });
+      
+      # Add dependencies that are only needed for development
+      devShells = forAllSystems (system:
+        let 
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [ 
+              go_1_21 
+              gopls 
+              gotools 
+              go-tools
+              gnumake
+            ];
+          };
+        });
+
+      # The default package for 'nix build'
+      defaultPackage = forAllSystems (system: self.packages.${system}.${pname});
+    };
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

We want to enable gardenctl for the nix community.

```feature user
# with Nix (macOS, Linux, and Windows)
nix run github:gardener/gardenctl-v2 -- version

# development version
nix profile install github:gardener/gardenctl-v2

gardenctl --help
```