### PR TITLE
`ssh`: List pending nodes

### DIFF
--- a/pkg/cmd/ssh/connect_information.go
+++ b/pkg/cmd/ssh/connect_information.go
@@ -92,9 +92,10 @@ func NewConnectInformation(
 	var nodeList []Node
 
 	for _, node := range nodes {
-		n := Node{}
-		n.Name = node.Name
-		n.Status = "Ready"
+		n := Node{
+			Name:   node.Name,
+			Status: "Ready",
+		}
 
 		if !isNodeReady(node) {
 			n.Status = "Not Ready"

--- a/pkg/cmd/ssh/connect_information.go
+++ b/pkg/cmd/ssh/connect_information.go
@@ -87,9 +87,17 @@ func NewConnectInformation(
 	sshPrivateKeyFile PrivateKeyFile,
 	nodePrivateKeyFiles []PrivateKeyFile,
 	nodes []corev1.Node,
+	pendingNodeNames []string,
 	user string,
 ) (*ConnectInformation, error) {
-	var nodeList []Node
+	nodeSet := make(map[string]Node)
+
+	for _, pendingNodeName := range pendingNodeNames {
+		nodeSet[pendingNodeName] = Node{
+			Name:   pendingNodeName,
+			Status: "Unknown",
+		}
+	}
 
 	for _, node := range nodes {
 		n := Node{
@@ -125,7 +133,12 @@ func NewConnectInformation(
 			}
 		}
 
-		nodeList = append(nodeList, n)
+		nodeSet[n.Name] = n
+	}
+
+	nodeList := make([]Node, 0, len(nodeSet))
+	for _, node := range nodeSet {
+		nodeList = append(nodeList, node)
 	}
 
 	return &ConnectInformation{

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -835,6 +835,8 @@ func getNodeNamesFromMachinesOrNodes(ctx context.Context, manager target.Manager
 
 	nodeNames, err := getNodeNamesFromMachines(ctx, manager, currentTarget)
 	if err != nil {
+		// Regular users do not have the permission to fetch the machines.
+		// However, in this case, we do not want to log an error message. Instead, we will fallback to read the node names.
 		if !apierrors.IsForbidden(err) {
 			logger.Info("failed to fetch node names from machine objects", "err", err)
 		}

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -647,10 +647,22 @@ func (o *SSHOptions) Run(f util.Factory) error {
 
 	if !o.Interactive {
 		var nodes []corev1.Node
+
+		var pendingNodeNames []string
+
 		if nodeHostname == "" {
 			nodes, err = getNodes(ctx, shootClient)
 			if err != nil {
 				return fmt.Errorf("failed to list shoot cluster nodes: %w", err)
+			}
+
+			// We also want to determine if there are nodes that have not yet joined the cluster.
+			// This is an optional step, as only Gardener operators have access to the Seeds.
+			// Regular users will receive a 'Forbidden' error when trying to fetch the Machines.
+			// However, we do not want to log an error message in this case.
+			pendingNodeNames, err = getNodeNamesFromMachines(ctx, manager, currentTarget)
+			if err != nil && !apierrors.IsForbidden(err) {
+				logger.Info("failed to get shoot cluster node names from machines", "err", err)
 			}
 		}
 
@@ -664,6 +676,7 @@ func (o *SSHOptions) Run(f util.Factory) error {
 			o.SSHPrivateKeyFile,
 			nodePrivateKeyFiles,
 			nodes,
+			pendingNodeNames,
 			o.User,
 		)
 		if err != nil {

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -107,7 +107,7 @@ var _ = Describe("SSH Command", func() {
 		testShoot            *gardencorev1beta1.Shoot
 		testNode             *corev1.Node
 		testMachine          *machinev1alpha1.Machine
-		monitoringMachine    *machinev1alpha1.Machine
+		pendingMachine       *machinev1alpha1.Machine
 		seedKubeconfigSecret *corev1.Secret
 		gardenClient         client.Client
 		shootClient          client.Client
@@ -277,7 +277,7 @@ var _ = Describe("SSH Command", func() {
 			},
 		}
 
-		monitoringMachine = &machinev1alpha1.Machine{
+		pendingMachine = &machinev1alpha1.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "monitoring1",
 				Namespace: "shoot--prod1--test-shoot",
@@ -286,7 +286,7 @@ var _ = Describe("SSH Command", func() {
 		}
 
 		shootClient = internalfake.NewClientWithObjects(testNode)
-		seedClient = internalfake.NewClientWithObjects(testMachine, monitoringMachine)
+		seedClient = internalfake.NewClientWithObjects(testMachine, pendingMachine)
 
 		streams, _, out, _ = util.NewTestIOStreams()
 

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -660,6 +660,10 @@ var _ = Describe("SSH Command", func() {
 			Expect(info.Bastion.SSHPublicKeyFile).To(Equal(options.SSHPublicKeyFile))
 			Expect(info.Nodes).To(ConsistOf([]ssh.Node{
 				{
+					Name:   pendingMachine.Labels[machinev1alpha1.NodeLabelKey],
+					Status: "Unknown",
+				},
+				{
 					Name:   testNode.Name,
 					Status: "Not Ready",
 					Address: ssh.Address{


### PR DESCRIPTION
**What this PR does / why we need it**:
#347 added support for the `ssh` command completion for pending nodes, in addition to the completion of nodes that have already joined the cluster.

This PR also outputs the pending nodes (along with the joined nodes) when executing the `ssh` command.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`ssh`: Now outputs pending `Node`s in addition to already joined `Node`s.
```
