### PR TITLE
Set controller-runtime logger

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -18,6 +18,8 @@ import (
 	"github.com/spf13/viper"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
@@ -100,6 +102,8 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 	cobra.OnInitialize(func() {
 		initConfig(f)
 	})
+
+	controllerruntime.SetLogger(klogr.NewWithOptions(klogr.WithFormat(klogr.FormatKlog)))
 
 	flags := cmd.PersistentFlags()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If after 30seconds the controller-runtime logger is not set, a warning message and a stacktrace is printed

```bash
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
	>  goroutine 1 [running]:
	>  runtime/debug.Stack()
	>  	/usr/local/go/src/runtime/debug/stack.go:24 +0x64
	>  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
...
```

This PR initialises the controller-runtime logger

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
