### PR TITLE
[hotfix-2.6] `exe` file ending should be added for windows builds

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -31,6 +31,10 @@ fi
 
 out_file="${BINARY_PATH}/${GOOS}-${GOARCH}/gardenctl_v2_${GOOS}_${GOARCH}"
 
+if [[ "${GOOS}" == "windows" ]]; then
+  out_file="${out_file}.exe"
+fi
+
 echo "building for ${GOOS}-${GOARCH}: ${out_file}"
 CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} GO111MODULE=on go build \
 		-ldflags "${LD_FLAGS}" \


### PR DESCRIPTION
(cherry picked from commit efbd79d4f99b633ce80b2eca508697c3a17adfaa)

**What this PR does / why we need it**:
`exe` file ending should be added for windows builds
Bug introduced with https://github.com/gardener/gardenctl-v2/pull/358

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed: Windows build not being uploaded to GitHub release and to Chocolatey.
```
