### PR TITLE
Bump golangci-lint to `1.56.1`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,5 +20,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # pin@v4.0.0
         with:
-          version: v1.54.2
+          version: v1.56.1
           args: --verbose --timeout 5m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -24,7 +24,6 @@ linters-settings:
   revive:
     rules:
       - name: dot-imports
-        disabled: true # remove/enable once golangci-lint 1.55.3 is released where allowedPackages is supported
         arguments:
           - allowedPackages:
             - "github.com/onsi/ginkgo/v2"

--- a/hack/golangci-lint.sh
+++ b/hack/golangci-lint.sh
@@ -17,7 +17,7 @@ else
 fi
 
 # Install golangci-lint (linting tool)
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.55.2
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.56.1
 
 cd "$SOURCE_PATH"
 

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -155,6 +155,7 @@ func initConfig(f *util.FactoryImpl) {
 		if ok {
 			envHomeDir, err = homedir.Expand(envHomeDir)
 			cobra.CheckErr(err)
+
 			configFile = envHomeDir
 			viper.AddConfigPath(envHomeDir)
 		}

--- a/pkg/cmd/providerenv/options.go
+++ b/pkg/cmd/providerenv/options.go
@@ -211,6 +211,7 @@ func printProviderEnv(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1
 			}
 
 			s := env.Shell(o.Shell)
+
 			return o.Template.ExecuteTemplate(o.IOStreams.Out, "printf", map[string]interface{}{
 				"format": messages.String() + "\n%s %s\n%s\n",
 				"arguments": []string{

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -721,6 +721,7 @@ func createOrPatchBastion(ctx context.Context, gardenClient client.Client, key c
 		if len(bastion.Annotations) == 0 {
 			bastion.Annotations = map[string]string{}
 		}
+
 		bastion.Annotations[corev1beta1constants.GardenerOperation] = corev1beta1constants.GardenerOperationKeepalive
 		bastion.Spec.ShootRef = corev1.LocalObjectReference{
 			Name: shoot.Name,
@@ -965,6 +966,7 @@ func waitForBastion(ctx context.Context, o *SSHOptions, gardenClient client.Clie
 		case cond.Status != gardencorev1beta1.ConditionTrue:
 			lastCheckErr = errors.New(cond.Message)
 			logger.Error(lastCheckErr, "Still waiting")
+
 			return false, nil
 		}
 

--- a/pkg/cmd/version/version_test.go
+++ b/pkg/cmd/version/version_test.go
@@ -13,12 +13,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
-	. "github.com/gardener/gardenctl-v2/pkg/cmd/version"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/version"
 )
 
 var _ = Describe("Version Command", func() {
 	var (
-		o       *VersionOptions
+		o       *version.VersionOptions
 		factory util.Factory
 		streams util.IOStreams
 		buf     *util.SafeBytesBuffer
@@ -27,13 +27,13 @@ var _ = Describe("Version Command", func() {
 
 	BeforeEach(func() {
 		streams, _, buf, _ = util.NewTestIOStreams()
-		o = NewVersionOptions(streams)
+		o = version.NewVersionOptions(streams)
 		factory = &util.FactoryImpl{}
 		args = make([]string, 0, 5)
 	})
 
 	It("should run the command without any flags", func() {
-		cmd := NewCmdVersion(factory, o)
+		cmd := version.NewCmdVersion(factory, o)
 		cmd.SetArgs(args)
 		Expect(cmd.Execute()).To(Succeed())
 		Expect(o.Short).To(BeFalse())
@@ -42,7 +42,7 @@ var _ = Describe("Version Command", func() {
 	})
 
 	It("should run the command with flags --short", func() {
-		cmd := NewCmdVersion(factory, o)
+		cmd := version.NewCmdVersion(factory, o)
 		cmd.SetArgs(append(args, "--short"))
 		Expect(cmd.Execute()).To(Succeed())
 		Expect(o.Short).To(BeTrue())
@@ -51,7 +51,7 @@ var _ = Describe("Version Command", func() {
 	})
 
 	It("should run the command with flags --output json", func() {
-		cmd := NewCmdVersion(factory, o)
+		cmd := version.NewCmdVersion(factory, o)
 		cmd.SetArgs(append(args, "--output", "json"))
 		Expect(o.Short).To(BeFalse())
 		Expect(cmd.Execute()).To(Succeed())
@@ -62,7 +62,7 @@ var _ = Describe("Version Command", func() {
 	})
 
 	It("should run the command with flags --short --output json", func() {
-		cmd := NewCmdVersion(factory, o)
+		cmd := version.NewCmdVersion(factory, o)
 		cmd.SetArgs(append(args, "--short", "--output", "json"))
 		Expect(cmd.Execute()).To(Succeed())
 		Expect(o.Short).To(BeTrue())


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps golangci-lint to `1.56.1`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
