### PR TITLE
Automatic golang and golangci-lint version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,10 @@ updates:
       # gardener/gardener dictates the k8s dependency
       - dependency-name: "k8s.io*"
       - dependency-name: "sigs.k8s.io/controller-runtime"
+  - package-ecosystem: "docker"
+    # Dependabot monitors images defined in /hack/values-dependabot.yaml.
+    # This configuration serves as a workaround to trick Dependabot into thinking it's monitoring a Helm chart (https://github.com/dependabot/dependabot-core/blob/c676f5980bcd905fbb1367b3de5e9181b8f89b7d/docker/lib/dependabot/docker/file_fetcher.rb#L86).
+    # If a new PR is created by Dependabot, some workflows (like e.g. /.github./workflows/bump-golang.yaml) will proceed to update the version definitions across various files.
+    directory: "/hack"
+    schedule:
+      interval: weekly

--- a/.github/workflows/bump-golang.yaml
+++ b/.github/workflows/bump-golang.yaml
@@ -1,0 +1,41 @@
+name: bump golang
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  bump-golang:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && contains(github.event.pull_request.title, 'Bump golang from')
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@c9c4182bf1b97f5224aee3906fd373f6b61b4526 # pin@v1.6.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Update Golang version in pipeline_definition
+        run: |
+          NEW_VERSION=${{ steps.dependabot-metadata.outputs.new-version }}
+          sed -i "s/golang:[0-9]*\.[0-9]*\.[0-9]*/golang:$NEW_VERSION/g" .ci/pipeline_definitions
+      - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@v5.0.0
+        with:
+          go-version: ${{ steps.dependabot-metadata.outputs.new-version }}
+      - name: Update Golang version in go.mod
+        run: |
+          FULL_VERSION=${{ steps.dependabot-metadata.outputs.new-version }}
+          MAJOR_MINOR_VERSION=$(echo $FULL_VERSION | cut -d. -f1,2)
+          go mod edit -go=$MAJOR_MINOR_VERSION
+          go mod tidy
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          if git diff --quiet; then
+            echo "Skip - No changes detected"
+            exit 0
+          fi
+          git commit -am "[dependabot-skip] Update Golang version to ${{ steps.dependabot-metadata.outputs.new-version }}"
+          git push

--- a/.github/workflows/bump-golangci-lint.yaml
+++ b/.github/workflows/bump-golangci-lint.yaml
@@ -1,0 +1,43 @@
+name: bump golangci-lint
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  bump-golangci-lint:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && contains(github.event.pull_request.title, 'Bump golangci/golangci-lint from')
+    steps:
+      - uses: actions/create-github-app-token@f4c6bf6752984b3a29fcc135a5e70eb792c40c6b # pin@1.8.0
+        id: app-token
+        with:
+          # required
+          app-id: ${{ secrets.GARDENER_GITHUB_WORKFLOW_WRITER_APP_ID }}
+          private-key: ${{ secrets.GARDENER_GITHUB_WORKFLOW_WRITER_APP_PRIVATE_KEY }}
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@c9c4182bf1b97f5224aee3906fd373f6b61b4526 # pin@v1.6.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Update Golangci-lint version in golangci-lint.yml
+        run: |
+          NEW_VERSION=${{ steps.dependabot-metadata.outputs.new-version }}
+          sed -i "s/version: v[0-9]*\.[0-9]*\.[0-9]*/version: $NEW_VERSION/g" .github/workflows/golangci-lint.yml
+      - name: Update Golangci-lint version in golangci-lint.sh
+        run: |
+          NEW_VERSION=${{ steps.dependabot-metadata.outputs.new-version }}
+          sed -i "s/v[0-9]*\.[0-9]*\.[0-9]*/$NEW_VERSION/g" hack/golangci-lint.sh
+      - name: Commit and push changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          if git diff --quiet; then
+            echo "Skip - No changes detected"
+            exit 0
+          fi
+          git commit -am "[dependabot-skip] Update golangci-lint version to ${{ steps.dependabot-metadata.outputs.new-version }}"
+          git push

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,10 +13,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # pin@v5.0.0
         with:
-          go-version: '1.21'
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4.1.1
+          go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 # pin@v4.0.0
         with:

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -13,6 +13,7 @@ Files:
   logo/*
   *.tmpl
   */mocks/*.go
+  hack/values-dependabot.yaml
   pkg/env/testdata/*/*.fish
   pkg/env/testdata/*/*.bash
   pkg/env/testdata/*/*.pwsh

--- a/hack/values-dependabot.yaml
+++ b/hack/values-dependabot.yaml
@@ -1,0 +1,8 @@
+golang:
+  image:
+    repository: golang
+    tag: "1.21.6"
+golangci-lint:
+  image:
+    repository: golangci/golangci-lint
+    tag: "v1.56.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, dependabot will create new update PRs for golang and golangci-lint version updates.

**Details:**
This PR introduces a configuration that tricks Dependabot into monitoring images of a Helm chart as defined in `/hack/values-dependabot.yaml`.
When Dependabot creates a new PR, certain workflows, such as `/.github./workflows/bump-golang.yaml`, will automatically update the version definitions across various files.

This PR requires a Github App to be created and installed for this repository with the following scopes:
- `contents:write`
- `workflows:write`
- `metadata:read`

Create the following action `secrets`:
- `GARDENER_GITHUB_WORKFLOW_WRITER_APP_ID`
- `GARDENER_GITHUB_WORKFLOW_WRITER_APP_PRIVATE_KEY`

More info can be found here on how to authenticate with a github app https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow#authenticating-with-a-github-app

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I have already created the app and the action secrets. The app is installed into the following repositories:
- gardener/gardenctl-v2
- gardener/gardenlogin
- gardener/terminal-controller-manager

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
