### PR TITLE
Filter Non-Kube-Apiserver `AdvertisedAddresses`

### DIFF
--- a/internal/client/garden/client_test.go
+++ b/internal/client/garden/client_test.go
@@ -169,12 +169,16 @@ var _ = Describe("Client", func() {
 				Status: gardencorev1beta1.ShootStatus{
 					AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
 						{
-							Name: "shoot-address1",
+							Name: "external",
 							URL:  "https://api." + domain,
 						},
 						{
-							Name: "shoot-address2",
+							Name: "internal",
 							URL:  "https://api2." + domain,
+						},
+						{
+							Name: "service-account-issuer",
+							URL:  "https://foo.bar/projects/prod1/shoots/test-shoot1/issuer",
 						},
 					},
 				},

--- a/internal/client/garden/shoot_client.go
+++ b/internal/client/garden/shoot_client.go
@@ -40,6 +40,13 @@ const (
 	ShootProjectSecretSuffixCACluster = "ca-cluster"
 	// DataKeyCertificateCA is the key in a secret or config map data holding the CA certificate.
 	DataKeyCertificateCA = "ca.crt"
+
+	// AdvertisedAddressExternal is a constant that represents the name of the external kube-apiserver address.
+	AdvertisedAddressExternal = "external"
+	// AdvertisedAddressInternal is a constant that represents the name of the internal kube-apiserver address.
+	AdvertisedAddressInternal = "internal"
+	// AdvertisedAddressUnmanaged is a constant that represents the name of the unmanaged kube-apiserver address.
+	AdvertisedAddressUnmanaged = "unmanaged"
 )
 
 // shootKubeconfigRequest is a struct which holds information about a Kubeconfig to be generated.
@@ -56,7 +63,7 @@ type shootKubeconfigRequest struct {
 
 // cluster holds the data to describe and connect to a kubernetes cluster.
 type cluster struct {
-	// name is the name of the shoot advertised address, usually "external", "internal" or "unmanaged"
+	// name is the name of the shoot advertised address. Either "external", "internal" or "unmanaged"
 	name string
 	// apiServerHost is the host of the kube-apiserver
 	apiServerHost string
@@ -258,6 +265,13 @@ func (g *clientImpl) GetShootClientConfig(ctx context.Context, namespace, name s
 	}
 
 	for _, address := range shoot.Status.AdvertisedAddresses {
+		isKubeApiserverAddress := address.Name == AdvertisedAddressExternal ||
+			address.Name == AdvertisedAddressInternal ||
+			address.Name == AdvertisedAddressUnmanaged
+		if !isKubeApiserverAddress {
+			continue
+		}
+
 		u, err := url.Parse(address.URL)
 		if err != nil {
 			return nil, fmt.Errorf("could not parse shoot server url: %w", err)

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -195,7 +195,7 @@ var _ = Describe("SSH Command", func() {
 			Status: gardencorev1beta1.ShootStatus{
 				AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
 					{
-						Name: "shoot-address1",
+						Name: "external",
 						URL:  "https://api.bar.baz",
 					},
 				},

--- a/pkg/cmd/sshpatch/sshpatch_test.go
+++ b/pkg/cmd/sshpatch/sshpatch_test.go
@@ -122,7 +122,7 @@ var _ = Describe("SSH Patch Command", func() {
 			Status: gardencorev1beta1.ShootStatus{
 				AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
 					{
-						Name: "shoot-address1",
+						Name: "external",
 						URL:  "https://api.bar.baz",
 					},
 				},

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -63,7 +63,7 @@ func createTestShoot(name string, namespace string, seedName *string) *gardencor
 		Status: gardencorev1beta1.ShootStatus{
 			AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
 				{
-					Name: "shoot-address1",
+					Name: "external",
 					URL:  "https://api.bar.baz",
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the generation process of the `gardenlogin` kubeconfig to filter the `Shoot.status.advertisedAddresses` and only include the kube-apiserver addresses. This change is necessary because, as of `gardener/gardener` `v1.91.0`, the `advertisedAddresses` might also include the `service-account-issuer` url.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The `gardenlogin` kubeconfig now only includes kube-apiserver addresses from `Shoot.status.advertisedAddresses`. This ensures compatibility with `gardener/gardener` version `v1.91.0` and later.
```
