### PR TITLE
Improve "gardenctl target view" formatting

### DIFF
--- a/pkg/cmd/rc/rc_test.go
+++ b/pkg/cmd/rc/rc_test.go
@@ -66,12 +66,12 @@ var _ = Describe("Env Commands", func() {
   export GCTL_SESSION_ID=$(uuidgen)
 fi
 alias g=gardenctl
-alias gtv='gardenctl target view -o yaml'
+alias gtv='gardenctl target view'
 alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
 alias gk='eval "$(gardenctl kubectl-env bash)"'
 alias gp='eval "$(gardenctl provider-env bash)"'
-alias gcv='gardenctl config view -o yaml'
+alias gcv='gardenctl config view'
 source <(gardenctl completion bash)
 complete -o default -F __start_gardenctl g
 gk
@@ -85,12 +85,12 @@ gk
   export GCTL_SESSION_ID=$(uuidgen)
 fi
 alias g=gardenctl
-alias gtv='gardenctl target view -o yaml'
+alias gtv='gardenctl target view'
 alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
 alias gk='eval "$(gardenctl kubectl-env zsh)"'
 alias gp='eval "$(gardenctl provider-env zsh)"'
-alias gcv='gardenctl config view -o yaml'
+alias gcv='gardenctl config view'
 if (( $+commands[gardenctl] )); then
   if [ -d "$ZSH_CACHE_DIR/completions" ] && (($fpath[(Ie)$ZSH_CACHE_DIR/completions])); then
     GCTL_COMPLETION_FILE="$ZSH_CACHE_DIR/completions/_gardenctl"
@@ -116,12 +116,12 @@ gk
   set -gx GCTL_SESSION_ID (uuidgen)
 end
 alias g=gardenctl
-alias gtv='gardenctl target view -o yaml'
+alias gtv='gardenctl target view'
 alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
 alias gk='eval (gardenctl kubectl-env fish)'
 alias gp='eval (gardenctl provider-env fish)'
-alias gcv='gardenctl config view -o yaml'
+alias gcv='gardenctl config view'
 gardenctl completion fish | source
 complete -c g -w gardenctl
 gk
@@ -136,7 +136,7 @@ gk
 }
 Set-Alias -Name g -Value (get-command gardenctl).Path -Option AllScope -Force
 function Gardenctl-Target-View {
-  gardenctl target view -o yaml
+  gardenctl target view
 }
 Set-Alias -Name gtv -Value Gardenctl-Target-View -Option AllScope -Force
 function Gardenctl-Target-ControlPlane {
@@ -156,7 +156,7 @@ function Gardenctl-ProviderEnv {
 }
 Set-Alias -Name gp -Value Gardenctl-ProviderEnv -Option AllScope -Force
 function Gardenctl-Config-View {
-  gardenctl config view -o yaml
+  gardenctl config view
 }
 Set-Alias -Name gcv -Value Gardenctl-Config-View -Option AllScope -Force
 function Gardenctl-Completion-Powershell {

--- a/pkg/cmd/target/view_test.go
+++ b/pkg/cmd/target/view_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Target View Command", func() {
 		// user has already targeted a garden, project and shoot
 		cmd := cmdtarget.NewCmdView(factory, streams)
 		Expect(cmd.RunE(cmd, nil)).To(Succeed())
-		Expect(out.String()).To(Equal(fmt.Sprintf("garden:\"%s\", project:\"%s\", shoot:\"%s\"", gardenName, projectName, shootName)))
+		Expect(out.String()).To(Equal(fmt.Sprintf("garden: \"%s\"\nproject: \"%s\"\nshoot: \"%s\"\n", gardenName, projectName, shootName)))
 	})
 
 	Context("when target flags given", func() {
@@ -84,7 +84,7 @@ var _ = Describe("Target View Command", func() {
 			Expect(cmd.Flag("shoot").Value.String()).To(Equal("myshoot2"))
 
 			// here we need the real manager
-			Expect(out.String()).To(Equal(fmt.Sprintf("garden:\"%s\", project:\"%s\", shoot:\"%s\"", gardenName, projectName, "myshoot2")))
+			Expect(out.String()).To(Equal(fmt.Sprintf("garden: \"%s\"\nproject: \"%s\"\nshoot: \"%s\"\n", gardenName, projectName, "myshoot2")))
 		})
 	})
 })

--- a/pkg/cmd/target/view_test.go
+++ b/pkg/cmd/target/view_test.go
@@ -69,29 +69,29 @@ var _ = Describe("Target View Command", func() {
 		ctrl.Finish()
 	})
 
-	It("should print current target information", func() {
+	It("should print current target information in yaml format", func() {
 		// user has already targeted a garden, project and shoot
 		cmd := cmdtarget.NewCmdView(factory, streams)
 		Expect(cmd.RunE(cmd, nil)).To(Succeed())
-		Expect(out.String()).To(Equal(fmt.Sprintf("garden: \"%s\"\nproject: \"%s\"\nshoot: \"%s\"\n", gardenName, projectName, shootName)))
+		Expect(out.String()).To(Equal(fmt.Sprintf("garden: %s\nproject: %s\nshoot: %s\n", gardenName, projectName, shootName)))
 	})
 
 	Context("when target flags given", func() {
-		It("should print current target information", func() {
+		It("should print current target information in yaml format", func() {
 			cmd := cmdtarget.NewCmdView(factory, streams)
 			cmd.SetArgs([]string{"--shoot", "myshoot2"})
 			Expect(cmd.Execute()).To(Succeed())
 			Expect(cmd.Flag("shoot").Value.String()).To(Equal("myshoot2"))
 
 			// here we need the real manager
-			Expect(out.String()).To(Equal(fmt.Sprintf("garden: \"%s\"\nproject: \"%s\"\nshoot: \"%s\"\n", gardenName, projectName, "myshoot2")))
+			Expect(out.String()).To(Equal(fmt.Sprintf("garden: %s\nproject: %s\nshoot: %s\n", gardenName, projectName, "myshoot2")))
 		})
 	})
 })
 
 var _ = Describe("Target View Options", func() {
 	It("should validate", func() {
-		o := &cmdtarget.ViewOptions{}
+		o := &cmdtarget.TargetViewOptions{}
 		Expect(o.Validate()).ToNot(HaveOccurred())
 	})
 })

--- a/pkg/env/templates/rc.tmpl
+++ b/pkg/env/templates/rc.tmpl
@@ -3,12 +3,12 @@ if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
 alias {{.prefix}}=gardenctl
-alias {{.prefix}}tv='gardenctl target view -o yaml'
+alias {{.prefix}}tv='gardenctl target view'
 alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval "$(gardenctl kubectl-env {{.shell}})"'
 alias {{.prefix}}p='eval "$(gardenctl provider-env {{.shell}})"'
-alias {{.prefix}}cv='gardenctl config view -o yaml'
+alias {{.prefix}}cv='gardenctl config view'
 {{if not .noCompletion -}}
 source <(gardenctl completion {{.shell}})
 complete -o default -F __start_gardenctl {{.prefix}}
@@ -23,12 +23,12 @@ if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ]; then
   export GCTL_SESSION_ID=$(uuidgen)
 fi
 alias {{.prefix}}=gardenctl
-alias {{.prefix}}tv='gardenctl target view -o yaml'
+alias {{.prefix}}tv='gardenctl target view'
 alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval "$(gardenctl kubectl-env {{.shell}})"'
 alias {{.prefix}}p='eval "$(gardenctl provider-env {{.shell}})"'
-alias {{.prefix}}cv='gardenctl config view -o yaml'
+alias {{.prefix}}cv='gardenctl config view'
 {{if not .noCompletion -}}
 if (( $+commands[gardenctl] )); then
   if [ -d "$ZSH_CACHE_DIR/completions" ] && (($fpath[(Ie)$ZSH_CACHE_DIR/completions])); then
@@ -55,12 +55,12 @@ if [ -z "$GCTL_SESSION_ID" ] && [ -z "$TERM_SESSION_ID" ];
   set -gx GCTL_SESSION_ID (uuidgen)
 end
 alias {{.prefix}}=gardenctl
-alias {{.prefix}}tv='gardenctl target view -o yaml'
+alias {{.prefix}}tv='gardenctl target view'
 alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval (gardenctl kubectl-env {{.shell}})'
 alias {{.prefix}}p='eval (gardenctl provider-env {{.shell}})'
-alias {{.prefix}}cv='gardenctl config view -o yaml'
+alias {{.prefix}}cv='gardenctl config view'
 {{if not .noCompletion -}}
 gardenctl completion {{.shell}} | source
 complete -c {{.prefix}} -w gardenctl
@@ -76,7 +76,7 @@ if ( !(Test-Path Env:GCTL_SESSION_ID) -and !(Test-Path Env:TERM_SESSION_ID) ) {
 }
 Set-Alias -Name {{.prefix}} -Value (get-command gardenctl).Path -Option AllScope -Force
 function Gardenctl-Target-View {
-  gardenctl target view -o yaml
+  gardenctl target view
 }
 Set-Alias -Name {{.prefix}}tv -Value Gardenctl-Target-View -Option AllScope -Force
 function Gardenctl-Target-ControlPlane {
@@ -96,7 +96,7 @@ function Gardenctl-ProviderEnv {
 }
 Set-Alias -Name {{.prefix}}p -Value Gardenctl-ProviderEnv -Option AllScope -Force
 function Gardenctl-Config-View {
-  gardenctl config view -o yaml
+  gardenctl config view
 }
 Set-Alias -Name {{.prefix}}cv -Value Gardenctl-Config-View -Option AllScope -Force
 {{if not .noCompletion -}}

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -8,8 +8,6 @@ package target
 
 import (
 	"errors"
-	"fmt"
-	"strings"
 
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -154,37 +152,6 @@ func (t *targetImpl) WithShootName(name string) Target {
 // The returned target can be invalid.
 func (t *targetImpl) WithControlPlane(controlPlane bool) Target {
 	return newTargetImpl(t.Garden, t.Project, t.Seed, t.Shoot, controlPlane)
-}
-
-// String returns a readable representation of the target.
-func (t *targetImpl) String() string {
-	steps := []string{}
-
-	if t.Garden != "" {
-		steps = append(steps, fmt.Sprintf("garden: %q", t.Garden))
-	}
-
-	if t.Project != "" {
-		steps = append(steps, fmt.Sprintf("project: %q", t.Project))
-	}
-
-	if t.Seed != "" {
-		steps = append(steps, fmt.Sprintf("seed: %q", t.Seed))
-	}
-
-	if t.Shoot != "" {
-		steps = append(steps, fmt.Sprintf("shoot: %q", t.Shoot))
-	}
-
-	if t.ControlPlaneFlag {
-		steps = append(steps, "control plane targeted")
-	}
-
-	if len(steps) == 0 {
-		return "<empty>\n"
-	}
-
-	return strings.Join(steps, "\n") + "\n"
 }
 
 func (t *targetImpl) IsEmpty() bool {

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -161,19 +161,19 @@ func (t *targetImpl) String() string {
 	steps := []string{}
 
 	if t.Garden != "" {
-		steps = append(steps, fmt.Sprintf("garden:%q", t.Garden))
+		steps = append(steps, fmt.Sprintf("garden: %q", t.Garden))
 	}
 
 	if t.Project != "" {
-		steps = append(steps, fmt.Sprintf("project:%q", t.Project))
+		steps = append(steps, fmt.Sprintf("project: %q", t.Project))
 	}
 
 	if t.Seed != "" {
-		steps = append(steps, fmt.Sprintf("seed:%q", t.Seed))
+		steps = append(steps, fmt.Sprintf("seed: %q", t.Seed))
 	}
 
 	if t.Shoot != "" {
-		steps = append(steps, fmt.Sprintf("shoot:%q", t.Shoot))
+		steps = append(steps, fmt.Sprintf("shoot: %q", t.Shoot))
 	}
 
 	if t.ControlPlaneFlag {
@@ -181,10 +181,10 @@ func (t *targetImpl) String() string {
 	}
 
 	if len(steps) == 0 {
-		return "<empty>"
+		return "<empty>\n"
 	}
 
-	return strings.Join(steps, ", ")
+	return strings.Join(steps, "\n") + "\n"
 }
 
 func (t *targetImpl) IsEmpty() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve the format of the "gardenctl target view" subcommand output for better readability.

Before:
```
garden:"local", project:"local", shoot:"local"
```

After:
```
garden: local
project: local
shoot: local
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
