### PR TITLE
[GEP-26] Add support for credentials binding

### DIFF
--- a/.gimps.yaml
+++ b/.gimps.yaml
@@ -55,6 +55,10 @@ aliasRules:
     expr: '^github.com/gardener/gardener/pkg/apis/core(/(v[a-z0-9-]+)(/([a-z0-9-]+))?)?$'
     alias: 'gardencore$2$4'
 
+  - name: gardener-garden-security
+    expr: '^github.com/gardener/gardener/pkg/apis/security/([a-z0-9-]+)'
+    alias: 'gardensecurity$1'
+
   - name: gardener-garden-other
     expr: '^github.com/gardener/gardener/pkg/apis/([a-z0-9-]+)(/(v[a-z0-9-]+)(/([a-z0-9-]+))?)?$'
     alias: '$1$3$5'

--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -23,6 +23,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	corev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	gardensecurityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -78,6 +79,9 @@ type Client interface {
 
 	// GetSecretBinding returns a Gardener secretbinding resource
 	GetSecretBinding(ctx context.Context, namespace, name string) (*gardencorev1beta1.SecretBinding, error)
+
+	// GetCredentialsBinding returns a Gardener credentialsbinding resource
+	GetCredentialsBinding(ctx context.Context, namespace, name string) (*gardensecurityv1alpha1.CredentialsBinding, error)
 
 	// GetCloudProfile returns a CloudProfileUnion resource which encapsulates the result of fetching a CloudProfile or NamespacedCloudProfile, depending on the given cloud profile reference
 	GetCloudProfile(ctx context.Context, ref gardencorev1beta1.CloudProfileReference) (*CloudProfileUnion, error)
@@ -260,6 +264,18 @@ func (g *clientImpl) GetSecretBinding(ctx context.Context, namespace, name strin
 	}
 
 	return secretBinding, nil
+}
+
+// GetCredentialsBinding returns a Gardener credentialsbinding resource.
+func (g *clientImpl) GetCredentialsBinding(ctx context.Context, namespace, name string) (*gardensecurityv1alpha1.CredentialsBinding, error) {
+	credentialsBinding := &gardensecurityv1alpha1.CredentialsBinding{}
+	key := types.NamespacedName{Namespace: namespace, Name: name}
+
+	if err := g.c.Get(ctx, key, credentialsBinding); err != nil {
+		return nil, fmt.Errorf("failed to get credentialsbinding %v: %w", key, err)
+	}
+
+	return credentialsBinding, nil
 }
 
 // GetSecret returns a Kubernetes secret resource.

--- a/internal/client/garden/mocks/mock_client.go
+++ b/internal/client/garden/mocks/mock_client.go
@@ -11,7 +11,8 @@ import (
 	garden "github.com/gardener/gardenctl-v2/internal/client/garden"
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
-	v1alpha10 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	v1alpha10 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	v1alpha11 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	clientcmd "k8s.io/client-go/tools/clientcmd"
@@ -104,6 +105,21 @@ func (m *MockClient) GetConfigMap(arg0 context.Context, arg1, arg2 string) (*v1.
 func (mr *MockClientMockRecorder) GetConfigMap(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigMap", reflect.TypeOf((*MockClient)(nil).GetConfigMap), arg0, arg1, arg2)
+}
+
+// GetCredentialsBinding mocks base method.
+func (m *MockClient) GetCredentialsBinding(arg0 context.Context, arg1, arg2 string) (*v1alpha10.CredentialsBinding, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCredentialsBinding", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*v1alpha10.CredentialsBinding)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCredentialsBinding indicates an expected call of GetCredentialsBinding.
+func (mr *MockClientMockRecorder) GetCredentialsBinding(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentialsBinding", reflect.TypeOf((*MockClient)(nil).GetCredentialsBinding), arg0, arg1, arg2)
 }
 
 // GetNamespace mocks base method.
@@ -242,10 +258,10 @@ func (mr *MockClientMockRecorder) GetShootClientConfig(arg0, arg1, arg2 interfac
 }
 
 // GetShootOfManagedSeed mocks base method.
-func (m *MockClient) GetShootOfManagedSeed(arg0 context.Context, arg1 string) (*v1alpha10.Shoot, error) {
+func (m *MockClient) GetShootOfManagedSeed(arg0 context.Context, arg1 string) (*v1alpha11.Shoot, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetShootOfManagedSeed", arg0, arg1)
-	ret0, _ := ret[0].(*v1alpha10.Shoot)
+	ret0, _ := ret[0].(*v1alpha11.Shoot)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ package main
 import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	gardensecurityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -18,6 +19,7 @@ import (
 
 func main() {
 	utilruntime.Must(gardencorev1beta1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(gardensecurityv1alpha1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(operationsv1alpha1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(seedmanagementv1alpha1.AddToScheme(scheme.Scheme))
 	utilruntime.Must(machinev1alpha1.AddToScheme(scheme.Scheme))


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Cloud provider credentials can now be extracted following a shoot reference to a credentials binding.
```
