### PR TITLE
Publish OCM component-descriptor to `gardener-project`

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,6 +7,8 @@ gardenctl-v2:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
     steps:
       check:
         image: 'golang:1.23.2'
@@ -27,7 +29,8 @@ gardenctl-v2:
         pull-request: ~
     release:
       traits:
-        component_descriptor: ~
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         version:
           preprocess: 'finalize'
         release:


### PR DESCRIPTION
**What this PR does / why we need it**:
Publish OCM component-descriptor to `gardener-project`. Also set default to snapshots repository to prepare (potential) future pipeline changes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Changes taken from https://github.com/gardener/chaos-engineering/pull/14

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
