### PR TITLE
Add binaries as release assets to component descriptor

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -22,6 +22,8 @@ fi
 ###############################################################################
 
 "${MAIN_REPO_DIR}"/hack/build-linux-amd64.sh
+"${MAIN_REPO_DIR}"/hack/build-linux-arm64.sh
 "${MAIN_REPO_DIR}"/hack/build-darwin-amd64.sh
+"${MAIN_REPO_DIR}"/hack/build-darwin-arm64.sh
 "${MAIN_REPO_DIR}"/hack/build-windows-amd64.sh
 

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -37,6 +37,57 @@ gardenctl-v2:
           preprocess: 'finalize'
         release:
           release_callback: './.ci/update_latest_version'
+          assets:
+          - type: build-step-file
+            mode: single-file
+            step_name: build
+            step_output_dir: binary
+            path: linux-amd64/gardenctl_v2_linux_amd64
+            name: gardenctl-v2
+            artefact_type: executable
+            artefact_extra_id:
+              os: linux
+              architecture: amd64
+          - type: build-step-file
+            mode: single-file
+            step_name: build
+            step_output_dir: binary
+            path: linux-arm64/gardenctl_v2_linux_arm64
+            name: gardenctl-v2
+            artefact_type: executable
+            artefact_extra_id:
+              os: linux
+              architecture: arm64
+          - type: build-step-file
+            mode: single-file
+            step_name: build
+            step_output_dir: binary
+            path: darwin-amd64/gardenctl_v2_darwin_amd64
+            name: gardenctl-v2
+            artefact_type: executable
+            artefact_extra_id:
+              os: darwin
+              architecture: amd64
+          - type: build-step-file
+            mode: single-file
+            step_name: build
+            step_output_dir: binary
+            path: darwin-arm64/gardenctl_v2_darwin_arm64
+            name: gardenctl-v2
+            artefact_type: executable
+            artefact_extra_id:
+              os: darwin
+              architecture: arm64
+          - type: build-step-file
+            mode: single-file
+            step_name: build
+            step_output_dir: binary
+            path: windows-amd64/gardenctl_v2_windows_amd64.exe
+            name: gardenctl-v2
+            artefact_type: executable
+            artefact_extra_id:
+              os: windows
+              architecture: amd64
         slack:
           channel_cfgs:
           - channel_name: 'C01BKP30K1U' #sap-tech-gardenctl


### PR DESCRIPTION
**What this PR does / why we need it**:
To model the built gardenctl-v2 binaries as delivery relevant artefacts, they should be part of the component descriptor's resources. Since the binaries are already configured as output of the `build` step, this output can be used to create additional release assets.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This changes requires https://github.com/gardener/cc-utils/pull/1065 (i.e. cc-utils version >= `1.2535.0`) because of the newly added `artefact_extra_id` property.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
