### PR TITLE
`ssh` - Default user known hosts file

### DIFF
--- a/internal/fake/factory.go
+++ b/internal/fake/factory.go
@@ -38,9 +38,12 @@ type Factory struct {
 
 	// GardenHomeDirectory is the home directory for all gardenctl
 	// related files. While some files can be explicitly loaded from
-	// different locations, cache files will always be placed inside
-	// the garden home.
+	// different locations, persistent cache files will always be placed
+	// inside the garden home.
 	GardenHomeDirectory string
+
+	// GardenTempDirectory is the base directory for temporary data.
+	GardenTempDirectory string
 }
 
 var _ util.Factory = &Factory{}
@@ -91,6 +94,10 @@ func (f *Factory) Context() context.Context {
 
 func (f *Factory) GardenHomeDir() string {
 	return f.GardenHomeDirectory
+}
+
+func (f *Factory) GardenTempDir() string {
+	return f.GardenTempDirectory
 }
 
 func (f *Factory) Clock() util.Clock {

--- a/internal/util/mocks/mock_factory.go
+++ b/internal/util/mocks/mock_factory.go
@@ -78,6 +78,20 @@ func (mr *MockFactoryMockRecorder) GardenHomeDir() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GardenHomeDir", reflect.TypeOf((*MockFactory)(nil).GardenHomeDir))
 }
 
+// GardenTempDir mocks base method.
+func (m *MockFactory) GardenTempDir() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GardenTempDir")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GardenTempDir indicates an expected call of GardenTempDir.
+func (mr *MockFactoryMockRecorder) GardenTempDir() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GardenTempDir", reflect.TypeOf((*MockFactory)(nil).GardenTempDir))
+}
+
 // Manager mocks base method.
 func (m *MockFactory) Manager() (target.Manager, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cmd/cmd_suite_test.go
+++ b/pkg/cmd/cmd_suite_test.go
@@ -47,7 +47,7 @@ var _ = BeforeSuite(func() {
 	configFile = filepath.Join(gardenHomeDir, cmd.ConfigName+".yaml")
 	sessionID := uuid.New().String()
 	Expect(os.Setenv(cmd.EnvSessionID, sessionID)).To(Succeed())
-	sessionDir = filepath.Join(os.TempDir(), "garden", sessionID)
+	sessionDir = filepath.Join(os.TempDir(), "garden", "sessions", sessionID)
 	Expect(os.MkdirAll(sessionDir, os.ModePerm))
 	cfg = &config.Config{
 		Filename:       configFile,

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -836,7 +836,7 @@ func (o *SSHOptions) bastionIngressPolicies(logger klog.Logger, providerType str
 					return nil, fmt.Errorf("GCP only supports IPv4: %s", cidr)
 				}
 
-				logger.Info("GCP only supports IPv4, skipped CIDR: %s\n", "cidr", cidr)
+				logger.Info("GCP only supports IPv4, skipped CIDR: %s", "cidr", cidr)
 
 				continue // skip
 			}
@@ -1166,6 +1166,8 @@ func keepBastionAlive(ctx context.Context, cancel context.CancelFunc, gardenClie
 				}
 
 				logger.Error(err, "Failed to keep bastion alive.")
+
+				continue
 			}
 
 			// add the keepalive annotation

--- a/pkg/cmd/target/view_test.go
+++ b/pkg/cmd/target/view_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Target View Command", func() {
 		factory.EXPECT().TargetFlags().Return(targetFlags).AnyTimes()
 
 		sessionID := uuid.New().String()
-		sessionDir = filepath.Join(os.TempDir(), "garden", sessionID)
+		sessionDir = filepath.Join(os.TempDir(), "garden", "sessions", sessionID)
 		Expect(os.MkdirAll(sessionDir, os.ModePerm))
 		currentTarget = target.NewTarget(gardenName, projectName, "", shootName)
 		targetProvider = target.NewTargetProvider(filepath.Join(sessionDir, "target.yaml"), targetFlags)

--- a/pkg/flags/flags_suite_test.go
+++ b/pkg/flags/flags_suite_test.go
@@ -52,7 +52,7 @@ var _ = BeforeSuite(func() {
 	configFile = filepath.Join(gardenHomeDir, configName+".yaml")
 	sessionID := uuid.New().String()
 	Expect(os.Setenv(envSessionID, sessionID)).To(Succeed())
-	sessionDir = filepath.Join(os.TempDir(), "garden", sessionID)
+	sessionDir = filepath.Join(os.TempDir(), "garden", "sessions", sessionID)
 	Expect(os.MkdirAll(sessionDir, os.ModePerm))
 	cfg = &config.Config{
 		Filename:       configFile,

--- a/pkg/target/target_suite_test.go
+++ b/pkg/target/target_suite_test.go
@@ -46,7 +46,7 @@ var _ = BeforeSuite(func() {
 
 	dir, err := os.MkdirTemp("", "garden-*")
 	Expect(err).NotTo(HaveOccurred())
-	sessionDir = filepath.Join(dir, uuid.New().String())
+	sessionDir = filepath.Join(dir, "sessions", uuid.New().String())
 	Expect(os.MkdirAll(sessionDir, 0o700)).To(Succeed())
 	gardenHomeDir = dir
 	gardenKubeconfig = filepath.Join(gardenHomeDir, "kubeconfig.yaml")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR sets default paths for `known_hosts` files for SSH connections to bastions and shoot nodes when none are provided, reducing host key conflicts from IP reuse and keeping the user's default SSH `known_hosts` file (`~/.ssh/known_hosts`) clean.

- `--bastion-user-known-hosts-file` default: `<temp_dir>/garden/cache/<bastion_uid>/.ssh/known_hosts`
- `--node-user-known-hosts-file` default: `<garden_home_dir>/cache/<shoot_uid>/.ssh/known_hosts`

**Release note:**
```feature user
Default paths for `known_hosts` files are set for bastions and shoot nodes. Bastion keys are stored in temporary directories, while shoot node keys persist in the garden home directory.
```

```breaking user
The session directory has been moved to a `sessions` subfolder, changing from `<temp_dir>/garden/<session_id>` to `<temp_dir>/garden/sessions/<session_id>`. The current session will be migrated on the next run of a `gardenctl` command.
```
