### PR TITLE
docs: Mention including kubectl-env in the shell startup config

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for the specifi
 eval $(gardenctl kubectl-env bash)
 ```
 
-To load the kubectl configuration for each bash session add the following line at the end of the ~/.bashrc file:
+To load the kubectl configuration for each bash session add the following line at the end of the `~/.bashrc` file:
 
 ```bash
 eval "$(gardenctl kubectl-env bash)"

--- a/README.md
+++ b/README.md
@@ -161,6 +161,19 @@ Generate a script that points KUBECONFIG to the targeted cluster for the specifi
 eval $(gardenctl kubectl-env bash)
 ```
 
+To load the kubectl configuration for each bash session add the following line at the end of the ~/.bashrc file:
+
+```bash
+eval "$(gardenctl kubectl-env bash)"
+```
+
+You will need to start a new shell for this setup to take effect.
+Alternatively, you can run the following command to apply it to your current shell session:
+
+```bash
+source ~/.bashrc
+```
+
 ### Configure Cloud Provider CLIs
 
 Generate the cloud provider CLI configuration script for the specified shell. Use together with `eval` to configure your shell. Example for `bash`:

--- a/README.md
+++ b/README.md
@@ -158,12 +158,6 @@ Find more information in the [documentation](docs/usage/targeting.md).
 Generate a script that points KUBECONFIG to the targeted cluster for the specified shell. Use together with `eval` to configure your shell. Example for `bash`:
 
 ```bash
-eval $(gardenctl kubectl-env bash)
-```
-
-To load the kubectl configuration for each bash session add the following line at the end of the `~/.bashrc` file:
-
-```bash
 eval "$(gardenctl kubectl-env bash)"
 ```
 
@@ -179,7 +173,7 @@ source ~/.bashrc
 Generate the cloud provider CLI configuration script for the specified shell. Use together with `eval` to configure your shell. Example for `bash`:
 
 ```bash
-eval $(gardenctl provider-env bash)
+eval "$(gardenctl provider-env bash)"
 ```
 
 ### SSH

--- a/README.md
+++ b/README.md
@@ -161,12 +161,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for the specifi
 eval "$(gardenctl kubectl-env bash)"
 ```
 
-You will need to start a new shell for this setup to take effect.
-Alternatively, you can run the following command to apply it to your current shell session:
-
-```bash
-source ~/.bashrc
-```
+To load the kubectl configuration for each bash session add the command at the end of the `~/.bashrc` file.
 
 ### Configure Cloud Provider CLIs
 

--- a/docs/help/gardenctl_kubectl-env.md
+++ b/docs/help/gardenctl_kubectl-env.md
@@ -4,11 +4,10 @@ Generate a script that points KUBECONFIG to the targeted cluster for the specifi
 
 ### Synopsis
 
-Generate a script that points KUBECONFIG to the targeted cluster for the specified shell.
-See each sub-command's help for details on how to use the generated script.
+Generate a script that points KUBECONFIG to the currently targeted shoot, seed, or garden cluster for the specified shell.
+To apply this setting automatically in every shell session, consider adding the generated script to your shell's startup configuration.
 
-The generated script points the KUBECONFIG environment variable to the currently targeted shoot, seed or garden cluster.
-To point the KUBECONFIG to the targeted cluster in all shell sessions consider adding the script to your shell's startup configuration.
+See each sub-command's help for details on how to use the generated script.
 
 
 ### Options

--- a/docs/help/gardenctl_kubectl-env.md
+++ b/docs/help/gardenctl_kubectl-env.md
@@ -5,9 +5,9 @@ Generate a script that points KUBECONFIG to the targeted cluster for the specifi
 ### Synopsis
 
 Generate a script that points KUBECONFIG to the currently targeted shoot, seed, or garden cluster for the specified shell.
-To apply this setting automatically in every shell session, consider adding the generated script to your shell's startup configuration.
 
-See each sub-command's help for details on how to use the generated script.
+Each sub-command produces a shell-specific script.
+For details on how to use the printed shell script, such as applying it temporarily to your current session or permanently through your shell's startup file, refer to the corresponding sub-command's help.
 
 
 ### Options

--- a/docs/help/gardenctl_kubectl-env.md
+++ b/docs/help/gardenctl_kubectl-env.md
@@ -8,6 +8,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for the specifi
 See each sub-command's help for details on how to use the generated script.
 
 The generated script points the KUBECONFIG environment variable to the currently targeted shoot, seed or garden cluster.
+To point the KUBECONFIG to the targeted cluster in all shell sessions consider adding the script to your shell's startup configuration.
 
 
 ### Options

--- a/docs/help/gardenctl_kubectl-env_bash.md
+++ b/docs/help/gardenctl_kubectl-env_bash.md
@@ -9,6 +9,12 @@ Generate a script that points KUBECONFIG to the targeted cluster for bash.
 To load the kubectl configuration script in your current shell session:
 $ eval "$(gardenctl kubectl-env bash)"
 
+To load the kubectl configuration for each bash session add the following line at the end of the ~/.bashrc file:
+
+    eval "$(gardenctl kubectl-env bash)"
+
+You will need to start a new shell for this setup to take effect.
+
 
 ```
 gardenctl kubectl-env bash [flags]

--- a/docs/help/gardenctl_kubectl-env_bash.md
+++ b/docs/help/gardenctl_kubectl-env_bash.md
@@ -9,7 +9,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for bash.
 To load the kubectl configuration script in your current shell session:
 $ eval "$(gardenctl kubectl-env bash)"
 
-To load the kubectl configuration for each bash session add the following line at the end of the ~/.bashrc file:
+To load the kubectl configuration for each shell session add the following line at the end of the ~/.bashrc file:
 
     eval "$(gardenctl kubectl-env bash)"
 

--- a/docs/help/gardenctl_kubectl-env_bash.md
+++ b/docs/help/gardenctl_kubectl-env_bash.md
@@ -9,7 +9,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for bash.
 To load the kubectl configuration script in your current shell session:
 $ eval "$(gardenctl kubectl-env bash)"
 
-To load the kubectl configuration for each shell session add the command at the end of the ~/.bashrc file.
+To apply this setting automatically in every shell session, consider adding the command at the end of your ~/.bashrc file.
 
 
 ```

--- a/docs/help/gardenctl_kubectl-env_bash.md
+++ b/docs/help/gardenctl_kubectl-env_bash.md
@@ -9,11 +9,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for bash.
 To load the kubectl configuration script in your current shell session:
 $ eval "$(gardenctl kubectl-env bash)"
 
-To load the kubectl configuration for each shell session add the following line at the end of the ~/.bashrc file:
-
-    eval "$(gardenctl kubectl-env bash)"
-
-You will need to start a new shell for this setup to take effect.
+To load the kubectl configuration for each shell session add the command at the end of the ~/.bashrc file.
 
 
 ```

--- a/docs/help/gardenctl_kubectl-env_fish.md
+++ b/docs/help/gardenctl_kubectl-env_fish.md
@@ -9,11 +9,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for fish.
 To load the kubectl configuration script in your current shell session:
 $ eval (gardenctl kubectl-env fish)
 
-To load the kubectl configuration for each shell session add the following line at the end of the ~/.config/fish/config.fish file:
-
-    eval (gardenctl kubectl-env fish)
-
-You will need to start a new shell for this setup to take effect.
+To load the kubectl configuration for each shell session add the command at the end of the ~/.config/fish/config.fish file.
 
 
 ```

--- a/docs/help/gardenctl_kubectl-env_fish.md
+++ b/docs/help/gardenctl_kubectl-env_fish.md
@@ -9,9 +9,9 @@ Generate a script that points KUBECONFIG to the targeted cluster for fish.
 To load the kubectl configuration script in your current shell session:
 $ eval (gardenctl kubectl-env fish)
 
-To load the kubectl configuration for each bash session add the following line at the end of the ~/.config/fish/config.fish file:
+To load the kubectl configuration for each shell session add the following line at the end of the ~/.config/fish/config.fish file:
 
-    eval "$(gardenctl kubectl-env fish)"
+    eval (gardenctl kubectl-env fish)
 
 You will need to start a new shell for this setup to take effect.
 

--- a/docs/help/gardenctl_kubectl-env_fish.md
+++ b/docs/help/gardenctl_kubectl-env_fish.md
@@ -9,6 +9,12 @@ Generate a script that points KUBECONFIG to the targeted cluster for fish.
 To load the kubectl configuration script in your current shell session:
 $ eval (gardenctl kubectl-env fish)
 
+To load the kubectl configuration for each bash session add the following line at the end of the ~/.config/fish/config.fish file:
+
+    eval "$(gardenctl kubectl-env fish)"
+
+You will need to start a new shell for this setup to take effect.
+
 
 ```
 gardenctl kubectl-env fish [flags]

--- a/docs/help/gardenctl_kubectl-env_fish.md
+++ b/docs/help/gardenctl_kubectl-env_fish.md
@@ -9,7 +9,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for fish.
 To load the kubectl configuration script in your current shell session:
 $ eval (gardenctl kubectl-env fish)
 
-To load the kubectl configuration for each shell session add the command at the end of the ~/.config/fish/config.fish file.
+To apply this setting automatically in every shell session, consider adding the command at the end of your ~/.config/fish/config.fish file.
 
 
 ```

--- a/docs/help/gardenctl_kubectl-env_powershell.md
+++ b/docs/help/gardenctl_kubectl-env_powershell.md
@@ -9,11 +9,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for powershell.
 To load the kubectl configuration script in your current shell session:
 PS /> & gardenctl kubectl-env powershell | Invoke-Expression
 
-To load the kubectl configuration for each shell session add the following line at the end of the $profile file:
-
-    & gardenctl kubectl-env powershell | Invoke-Expression
-
-You will need to start a new shell for this setup to take effect.
+To load the kubectl configuration for each shell session add the command at the end of the $profile file.
 
 
 ```

--- a/docs/help/gardenctl_kubectl-env_powershell.md
+++ b/docs/help/gardenctl_kubectl-env_powershell.md
@@ -9,6 +9,12 @@ Generate a script that points KUBECONFIG to the targeted cluster for powershell.
 To load the kubectl configuration script in your current shell session:
 PS /> & gardenctl kubectl-env powershell | Invoke-Expression
 
+To load the kubectl configuration for each powershell session add the following line at the end of the $profile file:
+
+    gardenctl kubectl-env powershell | Invoke-Expression
+
+You will need to start a new powershell session for this setup to take effect.
+
 
 ```
 gardenctl kubectl-env powershell [flags]

--- a/docs/help/gardenctl_kubectl-env_powershell.md
+++ b/docs/help/gardenctl_kubectl-env_powershell.md
@@ -9,7 +9,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for powershell.
 To load the kubectl configuration script in your current shell session:
 PS /> & gardenctl kubectl-env powershell | Invoke-Expression
 
-To load the kubectl configuration for each shell session add the command at the end of the $profile file.
+To apply this setting automatically in every shell session, consider adding the command at the end of your $profile file.
 
 
 ```

--- a/docs/help/gardenctl_kubectl-env_powershell.md
+++ b/docs/help/gardenctl_kubectl-env_powershell.md
@@ -9,11 +9,11 @@ Generate a script that points KUBECONFIG to the targeted cluster for powershell.
 To load the kubectl configuration script in your current shell session:
 PS /> & gardenctl kubectl-env powershell | Invoke-Expression
 
-To load the kubectl configuration for each powershell session add the following line at the end of the $profile file:
+To load the kubectl configuration for each shell session add the following line at the end of the $profile file:
 
-    gardenctl kubectl-env powershell | Invoke-Expression
+    & gardenctl kubectl-env powershell | Invoke-Expression
 
-You will need to start a new powershell session for this setup to take effect.
+You will need to start a new shell for this setup to take effect.
 
 
 ```

--- a/docs/help/gardenctl_kubectl-env_zsh.md
+++ b/docs/help/gardenctl_kubectl-env_zsh.md
@@ -9,7 +9,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for zsh.
 To load the kubectl configuration script in your current shell session:
 $ eval "$(gardenctl kubectl-env zsh)"
 
-To load the kubectl configuration for each bash session add the following line at the end of the ~/.zshrc file:
+To load the kubectl configuration for each shell session add the following line at the end of the ~/.zshrc file:
 
     eval "$(gardenctl kubectl-env zsh)"
 

--- a/docs/help/gardenctl_kubectl-env_zsh.md
+++ b/docs/help/gardenctl_kubectl-env_zsh.md
@@ -9,11 +9,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for zsh.
 To load the kubectl configuration script in your current shell session:
 $ eval "$(gardenctl kubectl-env zsh)"
 
-To load the kubectl configuration for each shell session add the following line at the end of the ~/.zshrc file:
-
-    eval "$(gardenctl kubectl-env zsh)"
-
-You will need to start a new shell for this setup to take effect.
+To load the kubectl configuration for each shell session add the command at the end of the ~/.zshrc file.
 
 
 ```

--- a/docs/help/gardenctl_kubectl-env_zsh.md
+++ b/docs/help/gardenctl_kubectl-env_zsh.md
@@ -9,7 +9,7 @@ Generate a script that points KUBECONFIG to the targeted cluster for zsh.
 To load the kubectl configuration script in your current shell session:
 $ eval "$(gardenctl kubectl-env zsh)"
 
-To load the kubectl configuration for each shell session add the command at the end of the ~/.zshrc file.
+To apply this setting automatically in every shell session, consider adding the command at the end of your ~/.zshrc file.
 
 
 ```

--- a/docs/help/gardenctl_kubectl-env_zsh.md
+++ b/docs/help/gardenctl_kubectl-env_zsh.md
@@ -9,6 +9,12 @@ Generate a script that points KUBECONFIG to the targeted cluster for zsh.
 To load the kubectl configuration script in your current shell session:
 $ eval "$(gardenctl kubectl-env zsh)"
 
+To load the kubectl configuration for each bash session add the following line at the end of the ~/.zshrc file:
+
+    eval "$(gardenctl kubectl-env zsh)"
+
+You will need to start a new shell for this setup to take effect.
+
 
 ```
 gardenctl kubectl-env zsh [flags]

--- a/pkg/cmd/kubectlenv/kubectlenv.go
+++ b/pkg/cmd/kubectlenv/kubectlenv.go
@@ -29,9 +29,9 @@ func NewCmdKubectlEnv(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
 		Use:   "kubectl-env",
 		Short: "Generate a script that points KUBECONFIG to the targeted cluster for the specified shell",
 		Long: `Generate a script that points KUBECONFIG to the currently targeted shoot, seed, or garden cluster for the specified shell.
-To apply this setting automatically in every shell session, consider adding the generated script to your shell's startup configuration.
 
-See each sub-command's help for details on how to use the generated script.
+Each sub-command produces a shell-specific script.
+For details on how to use the printed shell script, such as applying it temporarily to your current session or permanently through your shell's startup file, refer to the corresponding sub-command's help.
 `,
 		Aliases: []string{"k-env", "cluster-env"},
 	}

--- a/pkg/cmd/kubectlenv/kubectlenv.go
+++ b/pkg/cmd/kubectlenv/kubectlenv.go
@@ -28,11 +28,10 @@ func NewCmdKubectlEnv(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "kubectl-env",
 		Short: "Generate a script that points KUBECONFIG to the targeted cluster for the specified shell",
-		Long: `Generate a script that points KUBECONFIG to the targeted cluster for the specified shell.
-See each sub-command's help for details on how to use the generated script.
+		Long: `Generate a script that points KUBECONFIG to the currently targeted shoot, seed, or garden cluster for the specified shell.
+To apply this setting automatically in every shell session, consider adding the generated script to your shell's startup configuration.
 
-The generated script points the KUBECONFIG environment variable to the currently targeted shoot, seed or garden cluster.
-To point the KUBECONFIG to the targeted cluster in all shell sessions consider adding the script to your shell's startup configuration.
+See each sub-command's help for details on how to use the generated script.
 `,
 		Aliases: []string{"k-env", "cluster-env"},
 	}

--- a/pkg/cmd/kubectlenv/kubectlenv.go
+++ b/pkg/cmd/kubectlenv/kubectlenv.go
@@ -46,7 +46,7 @@ See each sub-command's help for details on how to use the generated script.
 To load the kubectl configuration script in your current shell session:
 %s
 
-To load the kubectl configuration for each shell session add the command at the end of the %s file.
+To apply this setting automatically in every shell session, consider adding the command at the end of your %s file.
 `,
 				s, s.Prompt(runtime.GOOS)+s.EvalCommand(fmt.Sprintf("gardenctl %s %s", cmd.Name(), s)), s.Config(),
 			),

--- a/pkg/cmd/kubectlenv/kubectlenv.go
+++ b/pkg/cmd/kubectlenv/kubectlenv.go
@@ -32,18 +32,30 @@ func NewCmdKubectlEnv(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
 See each sub-command's help for details on how to use the generated script.
 
 The generated script points the KUBECONFIG environment variable to the currently targeted shoot, seed or garden cluster.
+To point the KUBECONFIG to the targeted cluster in all shell sessions consider adding the script to your shell's startup configuration.
 `,
 		Aliases: []string{"k-env", "cluster-env"},
 	}
 	o.AddFlags(cmd.PersistentFlags())
 
 	for _, s := range env.ValidShells() {
+		prompt := s.Prompt(runtime.GOOS)
+		evalCommand := s.EvalCommand(fmt.Sprintf("gardenctl %s %s", cmd.Name(), s))
 		cmd.AddCommand(&cobra.Command{
 			Use:   string(s),
 			Short: fmt.Sprintf("Generate a script that points KUBECONFIG to the targeted cluster for %s", s),
-			Long: fmt.Sprintf("Generate a script that points KUBECONFIG to the targeted cluster for %s.\n\n"+
-				"To load the kubectl configuration script in your current shell session:\n%s\n",
-				s, s.Prompt(runtime.GOOS)+s.EvalCommand(fmt.Sprintf("gardenctl %s %s", cmd.Name(), s)),
+			Long: fmt.Sprintf(`Generate a script that points KUBECONFIG to the targeted cluster for %s.
+
+To load the kubectl configuration script in your current shell session:
+%s
+
+To load the kubectl configuration for each shell session add the following line at the end of the %s file:
+
+    %s
+
+You will need to start a new shell for this setup to take effect.
+`,
+				s, prompt+evalCommand, s.Config(), evalCommand,
 			),
 			RunE: runE,
 		})

--- a/pkg/cmd/kubectlenv/kubectlenv.go
+++ b/pkg/cmd/kubectlenv/kubectlenv.go
@@ -38,8 +38,6 @@ See each sub-command's help for details on how to use the generated script.
 	o.AddFlags(cmd.PersistentFlags())
 
 	for _, s := range env.ValidShells() {
-		prompt := s.Prompt(runtime.GOOS)
-		evalCommand := s.EvalCommand(fmt.Sprintf("gardenctl %s %s", cmd.Name(), s))
 		cmd.AddCommand(&cobra.Command{
 			Use:   string(s),
 			Short: fmt.Sprintf("Generate a script that points KUBECONFIG to the targeted cluster for %s", s),
@@ -48,13 +46,9 @@ See each sub-command's help for details on how to use the generated script.
 To load the kubectl configuration script in your current shell session:
 %s
 
-To load the kubectl configuration for each shell session add the following line at the end of the %s file:
-
-    %s
-
-You will need to start a new shell for this setup to take effect.
+To load the kubectl configuration for each shell session add the command at the end of the %s file.
 `,
-				s, prompt+evalCommand, s.Config(), evalCommand,
+				s, s.Prompt(runtime.GOOS)+s.EvalCommand(fmt.Sprintf("gardenctl %s %s", cmd.Name(), s)), s.Config(),
 			),
 			RunE: runE,
 		})

--- a/pkg/env/shell.go
+++ b/pkg/env/shell.go
@@ -56,6 +56,22 @@ func (s Shell) Prompt(goos string) string {
 	}
 }
 
+// Config returns the typical config file for the shell.
+func (s Shell) Config() string {
+	switch s {
+	case bash:
+		return "~/.bashrc"
+	case zsh:
+		return "~/.zshrc"
+	case fish:
+		return "~/.config/fish/config.fish"
+	case powershell:
+		return "$profile"
+	default:
+		return ""
+	}
+}
+
 // Validate checks if the shell is valid.
 func (s Shell) Validate() error {
 	for _, shell := range ValidShells() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Depending on your experience working with shells, when setting up `gardenctl` for the first time, it may not be immediately obvious that the script generated by `gardenctl kubectl-env` could be added to the shell startup configuration.

Running any sub-command of `gardenctl rc <shell> --help` guides the user in properly configuring the shell startup script. However, when using `gardenctl target ...` you may receive the following warning:

```shell
Successfully targeted shoot "..."
WARN The KUBECONFIG environment variable does not point to the current target of gardenctl. Run `gardenctl kubectl-env --help` on how to configure the KUBECONFIG environment variable accordingly
```

If you're not aware of `gardenctl rc` you'll follow the suggestion of the warning message and use `gardenctl kubectl-env` for configuring your shell.

This PR extends the `--help` output of `gardenctl kubectl-env` and all its sub-commands `gardenctl kubectl-env <shell>`. The extended synopsis suggests the possibility of integrating the script generated by the command in the respective shell startup configuration.

**Which issue(s) this PR fixes**:

_n.a._

**Special notes for your reviewer**:

/cc @petersutter 

I've considered adding a note about `gardenctl rc` as well for advertising it or to note that it's not necessary to have both `gardenctl rc` and `gardenctl kubectl-env` in your shell startup configuration. However, for simplicity reasons, I decided against it. Let me know what you think!

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
