### PR TITLE
Add hint for `kubelogin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ gardens:
 ```
 
 > [!NOTE]  
-> - To use the kubeconfigs for **shoot clusters** provided by gardenctl, you need to have [gardenlogin](https://github.com/gardener/gardenlogin) installed as a `kubectl` auth plugin.
+> - To use the kubeconfigs for **shoot clusters** provided by `gardenctl`, you need to have [gardenlogin](https://github.com/gardener/gardenlogin) installed as a `kubectl` auth plugin.
 > - If your **garden cluster** kubeconfig uses OIDC authentication, ensure that you have the [kubelogin](https://github.com/int128/kubelogin) `kubectl` auth plugin installed.
 
 ### Config Path Overwrite

--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ gardens:
 # patterns: ~ # List of regex patterns for pattern targeting
 ```
 
-Note: You need to have [gardenlogin](https://github.com/gardener/gardenlogin) installed as `kubectl` plugin in order to use the `kubeconfig`s for `Shoot` clusters provided by `gardenctl`.
+> [!NOTE]  
+> - To use the kubeconfigs for **shoot clusters** provided by gardenctl, you need to have [gardenlogin](https://github.com/gardener/gardenlogin) installed as a `kubectl` auth plugin.
+> - If your **garden cluster** kubeconfig uses OIDC authentication, ensure that you have the [kubelogin](https://github.com/int128/kubelogin) `kubectl` auth plugin installed.
 
 ### Config Path Overwrite
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the README.md for gardenctl-v2 by adding a hint about the potential need for the kubelogin kubectl auth plugin when using an OIDC-configured kubeconfig for the garden cluster. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @RaphaelVogel 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
