### PR TITLE
Support ssh to IPv6 addresses.

### DIFF
--- a/pkg/cmd/ssh/arguments.go
+++ b/pkg/cmd/ssh/arguments.go
@@ -111,7 +111,7 @@ func sshProxyCmdArguments(
 ) arguments {
 	args := []argument{
 		{value: "ssh", shellEscapeDisabled: true},
-		{value: "-W%h:%p", shellEscapeDisabled: true},
+		{value: "-W[%h]:%p"},
 		{value: fmt.Sprintf("-oStrictHostKeyChecking=%s", bastionStrictHostKeyChecking), shellEscapeDisabled: true},
 	}
 

--- a/pkg/cmd/ssh/arguments_test.go
+++ b/pkg/cmd/ssh/arguments_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Arguments", func() {
 					"-oIdentitiesOnly=yes",
 					"-oStrictHostKeyChecking=ask",
 					"'-ipath/to/node/private/key'",
-					`'-oProxyCommand=ssh -W%h:%p -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '"'"'-ipath/to/private/key'"'"' '"'"'gardener@bastion.example.com'"'"' '"'"'-p22'"'"''`,
+					`'-oProxyCommand=ssh '"'"'-W[%h]:%p'"'"' -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '"'"'-ipath/to/private/key'"'"' '"'"'gardener@bastion.example.com'"'"' '"'"'-p22'"'"''`,
 					"'gardener@node.example.com'",
 				}
 				return tc
@@ -82,7 +82,7 @@ var _ = Describe("Arguments", func() {
 					"-oIdentitiesOnly=yes",
 					"-oStrictHostKeyChecking=ask",
 					"'-ipath/to/node/private/key'",
-					`'-oProxyCommand=ssh -W%h:%p -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '"'"'-ipath/to/private/key'"'"' '"'"'gardener@bastion.example.com'"'"' '"'"'-p22'"'"''`,
+					`'-oProxyCommand=ssh '"'"'-W[%h]:%p'"'"' -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '"'"'-ipath/to/private/key'"'"' '"'"'gardener@bastion.example.com'"'"' '"'"'-p22'"'"''`,
 					"'aaa@node.example.com'",
 				}
 				return tc
@@ -94,7 +94,7 @@ var _ = Describe("Arguments", func() {
 					"-oIdentitiesOnly=yes",
 					"-oStrictHostKeyChecking=ask",
 					"'-ipath/to/node/private/key'",
-					`'-oProxyCommand=ssh -W%h:%p -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '"'"'-ipath/to/private/key'"'"' '"'"'gardener@bastion.example.com'"'"''`,
+					`'-oProxyCommand=ssh '"'"'-W[%h]:%p'"'"' -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '"'"'-ipath/to/private/key'"'"' '"'"'gardener@bastion.example.com'"'"''`,
 					"'gardener@node.example.com'",
 				}
 				return tc
@@ -110,7 +110,7 @@ var _ = Describe("Arguments", func() {
 					"-oStrictHostKeyChecking=yes",
 					`'-oUserKnownHostsFile='"'"'path/to/node_known_hosts'"'"''`,
 					"'-ipath/to/node/private/key'",
-					`'-oProxyCommand=ssh -W%h:%p -oStrictHostKeyChecking=no -oIdentitiesOnly=yes '"'"'-ipath/to/private/key'"'"' '"'"'-oUserKnownHostsFile='"'"'"'"'"'"'"'"'path/to/known_hosts1'"'"'"'"'"'"'"'"' '"'"'"'"'"'"'"'"'path/to/known_hosts2'"'"'"'"'"'"'"'"''"'"' '"'"'gardener@bastion.example.com'"'"' '"'"'-p22'"'"''`,
+					`'-oProxyCommand=ssh '"'"'-W[%h]:%p'"'"' -oStrictHostKeyChecking=no -oIdentitiesOnly=yes '"'"'-ipath/to/private/key'"'"' '"'"'-oUserKnownHostsFile='"'"'"'"'"'"'"'"'path/to/known_hosts1'"'"'"'"'"'"'"'"' '"'"'"'"'"'"'"'"'path/to/known_hosts2'"'"'"'"'"'"'"'"''"'"' '"'"'gardener@bastion.example.com'"'"' '"'"'-p22'"'"''`,
 					"'gardener@node.example.com'",
 				}
 				return tc
@@ -122,7 +122,7 @@ var _ = Describe("Arguments", func() {
 				tc.expectedArgs = []string{
 					"-oIdentitiesOnly=yes",
 					"-oStrictHostKeyChecking=ask",
-					`'-oProxyCommand=ssh -W%h:%p -oStrictHostKeyChecking=ask '"'"'gardener@bastion.example.com'"'"' '"'"'-p22'"'"''`,
+					`'-oProxyCommand=ssh '"'"'-W[%h]:%p'"'"' -oStrictHostKeyChecking=ask '"'"'gardener@bastion.example.com'"'"' '"'"'-p22'"'"''`,
 					"'gardener@node.example.com'",
 				}
 				return tc

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -426,7 +426,7 @@ var _ = Describe("SSH Command", func() {
 					fmt.Sprintf("-oUserKnownHostsFile='%s'", defaultNodeKnownHostsFile),
 					fmt.Sprintf("-i%s", nodePrivateKeyFile),
 					fmt.Sprintf(
-						"-oProxyCommand=ssh -W%%h:%%p -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '-i%s' '-oUserKnownHostsFile='\"'\"'%s'\"'\"'' '%s@%s' '-p22'",
+						"-oProxyCommand=ssh '-W[%%h]:%%p' -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '-i%s' '-oUserKnownHostsFile='\"'\"'%s'\"'\"'' '%s@%s' '-p22'",
 						options.SSHPrivateKeyFile,
 						defaultBastionKnownHostsFile,
 						ssh.SSHBastionUsername,
@@ -495,7 +495,7 @@ var _ = Describe("SSH Command", func() {
 					fmt.Sprintf("-oUserKnownHostsFile='%s'", defaultNodeKnownHostsFile),
 					fmt.Sprintf("-i%s", nodePrivateKeyFile),
 					fmt.Sprintf(
-						"-oProxyCommand=ssh -W%%h:%%p -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '-i%s' '-oUserKnownHostsFile='\"'\"'%s'\"'\"'' '%s@%s' '-p22'",
+						"-oProxyCommand=ssh '-W[%%h]:%%p' -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '-i%s' '-oUserKnownHostsFile='\"'\"'%s'\"'\"'' '%s@%s' '-p22'",
 						options.SSHPrivateKeyFile,
 						defaultBastionKnownHostsFile,
 						ssh.SSHBastionUsername,
@@ -753,7 +753,7 @@ var _ = Describe("SSH Command", func() {
 					"-oUserKnownHostsFile='/custom/node/known_hosts'",
 					fmt.Sprintf("-i%s", nodePrivateKeyFile),
 					fmt.Sprintf(
-						"-oProxyCommand=ssh -W%%h:%%p -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '-i%s' '-oUserKnownHostsFile='\"'\"'/custom/bastion/known_hosts'\"'\"'' '%s@%s' '-p22'",
+						"-oProxyCommand=ssh '-W[%%h]:%%p' -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '-i%s' '-oUserKnownHostsFile='\"'\"'/custom/bastion/known_hosts'\"'\"'' '%s@%s' '-p22'",
 						options.SSHPrivateKeyFile,
 						ssh.SSHBastionUsername,
 						bastionIP,


### PR DESCRIPTION
**What this PR does / why we need it**:
When connecting to nodes that have IPv6 addresses, the address must be in brackets in order to not confuse the colons in the address with  the port specification.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
ssh to nodes that have IPv6 addresses is now supported. 
```
