### PR TITLE
Ensure credential type for GCP

### DIFF
--- a/pkg/env/testdata/azure/export.json
+++ b/pkg/env/testdata/azure/export.json
@@ -9,7 +9,7 @@
   "clientSecret": "client-secret",
   "configDir": "%s",
   "region": "europe",
-  "serviceaccount.json": "{\n  \"project_id\": \"test\",\n  \"client_email\": \"test@example.org\"\n}",
+  "serviceaccount.json": "{\n  \"type\": \"service_account\",\n  \"project_id\": \"test\",\n  \"client_email\": \"test@example.org\"\n}\n",
   "subscriptionID": "subscription-id",
   "tenantID": "tenant-id",
   "testToken": "token"

--- a/pkg/env/testdata/gcp/export.bash
+++ b/pkg/env/testdata/gcp/export.bash
@@ -1,4 +1,4 @@
-export GOOGLE_CREDENTIALS='{"client_email":"test@example.org","project_id":"test"}';
+export GOOGLE_CREDENTIALS='{"client_email":"test@example.org","project_id":"test","type":"service_account"}';
 export GOOGLE_CREDENTIALS_ACCOUNT='test@example.org';
 export CLOUDSDK_CORE_PROJECT='test';
 export CLOUDSDK_COMPUTE_REGION='europe';

--- a/pkg/env/testdata/gcp/export.seed.bash
+++ b/pkg/env/testdata/gcp/export.seed.bash
@@ -1,4 +1,4 @@
-export GOOGLE_CREDENTIALS='{"client_email":"test@example.org","project_id":"test"}';
+export GOOGLE_CREDENTIALS='{"client_email":"test@example.org","project_id":"test","type":"service_account"}';
 export GOOGLE_CREDENTIALS_ACCOUNT='test@example.org';
 export CLOUDSDK_CORE_PROJECT='test';
 export CLOUDSDK_COMPUTE_REGION='europe';

--- a/pkg/env/testdata/gcp/export.yaml
+++ b/pkg/env/testdata/gcp/export.yaml
@@ -7,5 +7,6 @@ configDir: %s
 credentials:
   client_email: test@example.org
   project_id: test
+  type: service_account
 region: europe
-serviceaccount.json: '{"client_email":"test@example.org","project_id":"test"}'
+serviceaccount.json: '{"client_email":"test@example.org","project_id":"test","type":"service_account"}'

--- a/pkg/env/testdata/gcp/serviceaccount.json
+++ b/pkg/env/testdata/gcp/serviceaccount.json
@@ -1,4 +1,5 @@
 {
+  "type": "service_account",
   "project_id": "test",
   "client_email": "test@example.org"
 }

--- a/pkg/env/testdata/openstack/export.json
+++ b/pkg/env/testdata/openstack/export.json
@@ -14,7 +14,7 @@
   "domainName": "domain",
   "password": "secret",
   "region": "europe",
-  "serviceaccount.json": "{\n  \"project_id\": \"test\",\n  \"client_email\": \"test@example.org\"\n}",
+  "serviceaccount.json": "{\n  \"type\": \"service_account\",\n  \"project_id\": \"test\",\n  \"client_email\": \"test@example.org\"\n}\n",
   "tenantName": "tenant",
   "testToken": "token",
   "username": "user"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds validation to ensure the GCP credential type is properly set, similar to the validation in `extension-provider-gcp`. This improves robustness by preventing authentication failures due to missing credential configuration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Added validation to ensure credential type is properly set for GCP authentication, preventing potential connection failures due to incomplete configuration.
```
