### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -2,6 +2,9 @@ name: REUSE Compliance Check
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/gardenctl-v2/security/code-scanning/1](https://github.com/gardener/gardenctl-v2/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will explicitly set the permissions to `contents: read`, which is sufficient for the `actions/checkout` and `fsfe/reuse-action` steps. This change ensures that the workflow operates with the minimum required permissions, reducing the risk of unintended actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
