### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-gardenctl-v2.yaml
+++ b/.github/workflows/update-gardenctl-v2.yaml
@@ -1,5 +1,10 @@
 name: gardenctl-updater
 
+permissions:
+  contents: write
+  actions: read
+  repository-projects: write
+
 on:
   release:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/gardener/gardenctl-v2/security/code-scanning/2](https://github.com/gardener/gardenctl-v2/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the operations in the workflow:
- `contents: read` is needed to read repository contents.
- `contents: write` is required for uploading release assets.
- `actions: read` is needed to interact with GitHub Actions metadata.
- `repository-projects: write` is required for dispatching events to other repositories.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
