### PR TITLE
fix "stored" spelling in gardenctl tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The state of gardenctl is bound to a shell session and is not shared across wind
 A shell session is defined by the environment variable `GCTL_SESSION_ID`. If this is not defined,
 the value of the `TERM_SESSION_ID` environment variable is used instead. If both are not defined,
 this leads to an error and gardenctl cannot be executed. The `target.yaml` and temporary
-`kubeconfig.*.yaml` files are store in the following directory `${TMPDIR}/garden/${GCTL_SESSION_ID}`.
+`kubeconfig.*.yaml` files are stored in the following directory `${TMPDIR}/garden/${GCTL_SESSION_ID}`.
 
 You can make sure that `GCTL_SESSION_ID` or `TERM_SESSION_ID` is always present by adding
 the following code to your terminal profile `~/.profile`, `~/.bashrc` or comparable file.

--- a/docs/help/gardenctl.md
+++ b/docs/help/gardenctl.md
@@ -10,7 +10,7 @@ The state of gardenctl is bound to a shell session and is not shared across wind
 A shell session is defined by the environment variable GCTL_SESSION_ID. If this is not defined,
 the value of the TERM_SESSION_ID environment variable is used instead. If both are not defined,
 this leads to an error and gardenctl cannot be executed. The target.yaml and temporary
-kubeconfig.*.yaml files are store in the following directory ${TMPDIR}/garden/${GCTL_SESSION_ID}.
+kubeconfig.*.yaml files are stored in the following directory ${TMPDIR}/garden/${GCTL_SESSION_ID}.
 
 You can make sure that GCTL_SESSION_ID or TERM_SESSION_ID is always present by adding
 the following code to your terminal profile ~/.profile, ~/.bashrc or comparable file.

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -73,7 +73,7 @@ The state of gardenctl is bound to a shell session and is not shared across wind
 A shell session is defined by the environment variable GCTL_SESSION_ID. If this is not defined,
 the value of the TERM_SESSION_ID environment variable is used instead. If both are not defined,
 this leads to an error and gardenctl cannot be executed. The target.yaml and temporary
-kubeconfig.*.yaml files are store in the following directory ${TMPDIR}/garden/${GCTL_SESSION_ID}.
+kubeconfig.*.yaml files are stored in the following directory ${TMPDIR}/garden/${GCTL_SESSION_ID}.
 
 You can make sure that GCTL_SESSION_ID or TERM_SESSION_ID is always present by adding
 the following code to your terminal profile ~/.profile, ~/.bashrc or comparable file.


### PR DESCRIPTION
**What this PR does / why we need it**:

fix verb: store to stored 

**Which issue(s) this PR fixes**:
Fixes #
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
