### PR TITLE
openstack: improve credential handling

### DIFF
--- a/pkg/cmd/providerenv/options.go
+++ b/pkg/cmd/providerenv/options.go
@@ -345,8 +345,8 @@ func generateData(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Sec
 
 		data["authURL"] = authURL
 
-		_, ok := data["applicationCredentialSecret"]
-		if ok {
+		value, ok := data["applicationCredentialSecret"]
+		if ok && value != "" {
 			data["authType"] = "v3applicationcredential"
 			data["authStrategy"] = ""
 			data["tenantName"] = ""


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the openstack credential handling by considering the credential as `v3applicationcredential` when applicationCredentialSecret not empty

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Improved the openstack credential handling
```
