### PR TITLE
Alias providerType `stackit` to `openstack`

### DIFF
--- a/pkg/cmd/providerenv/options.go
+++ b/pkg/cmd/providerenv/options.go
@@ -337,6 +337,11 @@ func generateData(o *options, shoot *gardencorev1beta1.Shoot, secret *corev1.Sec
 		data["credentials"] = credentials
 		data["serviceaccount.json"] = string(serviceaccountJSON)
 		data["allowedPatterns"] = o.MergedGCPAllowedPatterns
+	// For now, support type `stackit` as an alias to openstack.
+	// TODO(maboehm): add full support once the provider extension is open sourced.
+	case "stackit":
+		providerType = "openstack"
+		fallthrough
 	case "openstack":
 		authURL, err := getKeyStoneURL(cloudProfile, shoot.Spec.Region)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Support type `stackit` as an alias to `openstack`.

STACKIT used to give customers access to the Openstack API, but that will be replaced by its own [infrastructure API](https://docs.stackit.cloud/stackit/en/release-notes-23101442.html#ReleaseNotes-29072025InfrastructureAPIDeprecationNotice) . We are also in the process of writing and later open-sourcing the required `cloud-provider-stackit` and `gardener-extension-provider-stackit`.

Once the providers are ready (and the API stable), we will add full support in gardenctl. In the meantime esp. during our internal migrations, it would be convenient to still have a working gardenctl without having to distribute a fork.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
