### PR TITLE
Validate garden names and aliases against naming rules

### DIFF
--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -96,6 +96,16 @@ func (o *setGardenOptions) Validate() error {
 		return errors.New("garden identity is required")
 	}
 
+	if err := config.ValidateGardenName(o.Name); err != nil {
+		return fmt.Errorf("invalid garden name %q: %w", o.Name, err)
+	}
+
+	if o.Alias.Provided() {
+		if err := config.ValidateGardenName(o.Alias.Value()); err != nil {
+			return fmt.Errorf("invalid garden alias %q: %w", o.Alias.Value(), err)
+		}
+	}
+
 	return validatePatterns(o.Patterns)
 }
 

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -68,7 +68,9 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 					Expect(o.Validate()).To(matcher)
 				},
 				Entry("when garden is foo", "foo", Succeed()),
+				Entry("when garden is my-garden", "my-garden", Succeed()),
 				Entry("when garden empty", "", MatchError("garden identity is required")),
+				Entry("when garden starts with hyphen", "-garden", MatchError("invalid garden name \"-garden\": garden name must start and end with an alphanumeric character")),
 			)
 
 			DescribeTable("Validating Pattern Flag",
@@ -84,6 +86,22 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 				Entry("when all patterns are valid", []string{"^shoot--(?P<project>.+)--(?P<shoot>.+)$`"}, Succeed()),
 				Entry("when a pattern is not a valid regular expression", []string{"("}, MatchError(MatchRegexp(`^pattern\[0\] is not a valid regular expression`))),
 				Entry("when a pattern has an invalid subexpression name", []string{"^shoot--(?P<cluster>.+)$`"}, MatchError("pattern[0] contains an invalid subexpression \"cluster\"")),
+			)
+
+			DescribeTable("Validating Alias Flag",
+				func(alias string, shouldSetAlias bool, matcher types.GomegaMatcher) {
+					o := cmdconfig.NewSetGardenOptions()
+					o.Name = "foo"
+					if shouldSetAlias {
+						Expect(o.Alias.Set(alias)).To(Succeed())
+					}
+					Expect(o.Validate()).To(matcher)
+				},
+				Entry("when alias is not set", "", false, Succeed()),
+				Entry("when alias is bar", "bar", true, Succeed()),
+				Entry("when alias is my-alias", "my-alias", true, Succeed()),
+				Entry("when alias is set but empty", "", true, MatchError("invalid garden alias \"\": garden name must contain only alphanumeric characters, underscore or hyphen")),
+				Entry("when alias starts with hyphen", "-alias", true, MatchError("invalid garden alias \"-alias\": garden name must start and end with an alphanumeric character")),
 			)
 		})
 

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clientgarden "github.com/gardener/gardenctl-v2/internal/client/garden"
+	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
 /*
@@ -95,6 +96,12 @@ func newTargetImpl(gardenName, projectName, seedName, shootName string, controlP
 func (t *targetImpl) Validate() error {
 	if len(t.Project) > 0 && len(t.Seed) > 0 {
 		return errors.New("seed and project must not be configured at the same time")
+	}
+
+	if t.Garden != "" {
+		if err := config.ValidateGardenName(t.Garden); err != nil {
+			return err
+		}
 	}
 
 	if t.Shoot != "" {

--- a/pkg/target/target_test.go
+++ b/pkg/target/target_test.go
@@ -71,6 +71,12 @@ var _ = Describe("Target", func() {
 			Expect(target.NewTarget("a", "", "seed-", "").Validate()).NotTo(Succeed())     // ends with dash
 			Expect(target.NewTarget("a", "", "seed.name", "").Validate()).NotTo(Succeed()) // contains dot
 			Expect(target.NewTarget("a", "", "seed name", "").Validate()).NotTo(Succeed()) // contains space
+
+			// valid garden name
+			Expect(target.NewTarget("my-garden", "b", "", "d").Validate()).To(Succeed())
+
+			// invalid garden name (starts with hyphen)
+			Expect(target.NewTarget("-invalid", "b", "", "d").Validate()).NotTo(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds validation for garden names and aliases to ensure they follow consistent naming rules:
- Must contain only alphanumeric characters, underscore, or hyphen
- Must start and end with an alphanumeric character

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Garden names and aliases must now follow naming rules: only alphanumeric characters, underscore, or hyphen are allowed, and names must start and end with an alphanumeric character. Existing configurations with invalid names will be rejected when loading the configuration.
```
