### PR TITLE
docs: Change architecture option from amd64 to arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The other install methods do this for you.
 
 # set operating system and architecture
 os=darwin # choose between darwin, linux, windows
-arch=amd64 # choose between amd64, arm64
+arch=arm64 # choose between amd64, arm64
 
 # Get latest version. Alternatively set your desired version
 version=$(curl -s https://raw.githubusercontent.com/gardener/gardenctl-v2/master/LATEST)


### PR DESCRIPTION
**What this PR does / why we need it**:
Change default architecture option from `amd64` to `arm64`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
