### PR TITLE
feat(garden): use SelfSubjectReview to resolve current user

### DIFF
--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -7,15 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package garden
 
 import (
-	"bytes"
 	"context"
-	"crypto/x509"
-	"encoding/json"
-	"encoding/pem"
 	"errors"
 	"fmt"
-	"os/exec"
-	"path"
 
 	openstackinstall "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/install"
 	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
@@ -35,9 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/pkg/apis/clientauthentication"
 	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -104,6 +96,7 @@ type Client interface {
 	// PatchBastion patches an existing bastion to match newBastion using the merge patch strategy
 	PatchBastion(ctx context.Context, newBastion, oldBastion *operationsv1alpha1.Bastion) error
 
+	// CurrentUser returns the username of the caller as seen by the garden cluster
 	CurrentUser(ctx context.Context) (string, error)
 
 	// RuntimeClient returns the underlying kubernetes runtime client
@@ -344,101 +337,18 @@ func (g *clientImpl) PatchBastion(ctx context.Context, newBastion, oldBastion *o
 }
 
 func (g *clientImpl) CurrentUser(ctx context.Context) (string, error) {
-	rawConfig, err := g.config.RawConfig()
-	if err != nil {
-		return "", fmt.Errorf("could not retrieve raw config: %w", err)
+	if g.c == nil {
+		return "", fmt.Errorf("runtime client is not configured")
 	}
 
-	currentContext, ok := rawConfig.Contexts[rawConfig.CurrentContext]
-	if !ok {
-		return "", fmt.Errorf("no context found for current context %s", rawConfig.CurrentContext)
+	selfSubjectReview := &authenticationv1.SelfSubjectReview{}
+
+	if err := g.c.Create(ctx, selfSubjectReview); err != nil {
+		return "", fmt.Errorf("failed to create SelfSubjectReview: %w", err)
 	}
 
-	authInfo, ok := rawConfig.AuthInfos[currentContext.AuthInfo]
-	if !ok {
-		return "", fmt.Errorf("no auth info found with name %s", currentContext.AuthInfo)
-	}
-
-	baseDir, err := clientcmdapi.MakeAbs(path.Dir(authInfo.LocationOfOrigin), "")
-	if err != nil {
-		return "", fmt.Errorf("could not parse location of kubeconfig origin: %v", err)
-	}
-
-	switch {
-	case len(authInfo.ClientCertificateData) == 0 && len(authInfo.ClientCertificate) > 0:
-		err := clientcmdapi.FlattenContent(&authInfo.ClientCertificate, &authInfo.ClientCertificateData, baseDir)
-		if err != nil {
-			return "", err
-		}
-	case len(authInfo.Token) == 0 && len(authInfo.TokenFile) > 0:
-		var tmpValue []byte
-
-		err := clientcmdapi.FlattenContent(&authInfo.TokenFile, &tmpValue, baseDir)
-		if err != nil {
-			return "", err
-		}
-
-		authInfo.Token = string(tmpValue)
-	case authInfo.Exec != nil && len(authInfo.Exec.Command) > 0:
-		var out bytes.Buffer
-
-		// #nosec G204 -- Command and arguments are sourced from the user's kubeconfig file, which should be from a trusted source or inspected carefully. See Kubernetes docs: https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
-		execCmd := exec.Command(authInfo.Exec.Command, authInfo.Exec.Args...)
-		execCmd.Stdout = &out
-
-		err := execCmd.Run()
-		if err != nil {
-			return "", err
-		}
-
-		var execCredential clientauthentication.ExecCredential
-
-		err = json.Unmarshal(out.Bytes(), &execCredential)
-		if err != nil {
-			return "", err
-		}
-
-		if token := execCredential.Status.Token; len(token) > 0 {
-			authInfo.Token = token
-		} else if cert := execCredential.Status.ClientCertificateData; len(cert) > 0 {
-			authInfo.ClientCertificateData = []byte(cert)
-		}
-	}
-
-	if len(authInfo.ClientCertificateData) > 0 {
-		block, _ := pem.Decode(authInfo.ClientCertificateData) // does not return an error, just nil
-		if block == nil {
-			return "", fmt.Errorf("could not decode PEM certificate")
-		}
-
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return "", err
-		}
-
-		user := cert.Subject.CommonName
-		if len(user) > 0 {
-			return user, nil
-		}
-	}
-
-	if len(authInfo.Token) > 0 {
-		tokenReview := &authenticationv1.TokenReview{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "foo",
-			},
-			Spec: authenticationv1.TokenReviewSpec{
-				Token: authInfo.Token,
-			},
-		}
-
-		if err := g.c.Create(ctx, tokenReview); err != nil {
-			return "", err
-		}
-
-		if user := tokenReview.Status.User.Username; user != "" {
-			return user, nil
-		}
+	if user := selfSubjectReview.Status.UserInfo.Username; user != "" {
+		return user, nil
 	}
 
 	return "", fmt.Errorf("could not detect current user")


### PR DESCRIPTION
**What this PR does / why we need it**:
Simplify `CurrentUser()` to use `SelfSubjectReview` (stable since k8s 1.28) instead of parsing kubeconfig, handling multiple auth methods, or creating `TokenReview` objects. This delegates user identification to the cluster, which sees the actual authenticated identity.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
