### PR TITLE
Clean up unused printing verb (`%s`) from a log statement

### DIFF
--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -839,7 +839,7 @@ func (o *SSHOptions) bastionIngressPolicies(logger klog.Logger, providerType str
 					return nil, fmt.Errorf("GCP only supports IPv4: %s", cidr)
 				}
 
-				logger.Info("GCP only supports IPv4, skipped CIDR: %s", "cidr", cidr)
+				logger.Info("GCP only supports IPv4, skipped CIDR", "cidr", cidr)
 
 				continue // skip
 			}


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Currently, `g ssh` outputs the following log entry:
```
% g ssh

I1118 14:10:04.023082   62207 options.go:842] "GCP only supports IPv4, skipped CIDR: %s" cidr="2a00:1728:2f:2841::/64"
```

We could clean up the unused printing verb (`%s`) as printing verbs are no longer used in structured logging.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
