### PR TITLE
feat(ssh): enforce strict validation for SSH keys

### DIFF
--- a/pkg/cmd/ssh/export_test.go
+++ b/pkg/cmd/ssh/export_test.go
@@ -56,6 +56,11 @@ func SetRSAKeyBitsForTest(bits int) {
 	rsaKeyBits = bits
 }
 
+var (
+	ValidateSSHPrivateKey = validateSSHPrivateKey
+	ValidateSSHPublicKey  = validateSSHPublicKey
+)
+
 type TestArguments struct {
 	arguments
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds input validation for user-provided and shoot node SSH keys

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added sanity checks for user-provided and shoot node SSH keys
```
