### PR TITLE
Switch to OIDC Federation Service instead of GitHub App

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,7 +18,7 @@ jobs:
       mode: ${{ inputs.mode }}
       version-commit-callback-action-path: ./.github/actions/prepare-release
     permissions:
-      contents: read
+      id-token: write
 
   build-gardenctl:
     permissions:

--- a/.github/workflows/cherry-pick.yaml
+++ b/.github/workflows/cherry-pick.yaml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 permissions:
-  contents: none  # we rely on the GitHub App token instead
+  id-token: write # required for GitHub OIDC Federation Service token
 
 jobs:
   cherry-pick:
@@ -18,5 +18,3 @@ jobs:
     with:
       pr-number: ${{ github.event.issue.number }}
       comment-body: ${{ github.event.comment.body }}
-    secrets:
-      GARDENER_GITHUB_ACTIONS_PRIVATE_KEY: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -8,17 +8,14 @@ jobs:
     uses: ./.github/workflows/build.yaml
     with:
       mode: snapshot
-    secrets: inherit
     permissions:
-      contents: write
-      packages: write
+      contents: read
       id-token: write
 
   component-descriptor:
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build
-    secrets: inherit
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -9,12 +9,10 @@ on:
         type: string
 
 permissions:
-  contents: none  # we rely on the GitHub App token instead
+  id-token: write # required for GitHub OIDC Federation Service token
 
 jobs:
   call-dashboard-workflow:
     uses: gardener/dashboard/.github/workflows/prepare-hotfix-branch.yaml@master
     with:
       tag: ${{ inputs.tag }}
-    secrets:
-      GARDENER_GITHUB_ACTIONS_PRIVATE_KEY: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,8 @@ jobs:
   build:
     uses: ./.github/workflows/build.yaml
     permissions:
-      contents: write
+      contents: read
       id-token: write
-      packages: write
     with:
       mode: release
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the [Gardener GitHub-Actions App](https://github.com/apps/gardener-github-actions) is used to provide more privileged access than available via the default `GITHUB_TOKEN`, for example to circumvent branch protection rules (GitHub Apps can be configured as bypassers) or cross repository privileges. To prevent sharing the GitHub App secret with each and every repository/workflow which requires usage of it, the [GitHub OIDC Federation Service](https://github.com/gardener/github-oidc-federation) has been developed. In essence, it holds the credentials for a central GitHub App and creates short-lived access tokens with a configured scope based on a centrally configured OIDC configuration. See related changes which have been necessary for this repository:

- https://github.com/gardener/.github-oidc/commit/24948bd4a4f9e3a9d8aac298b496b6a5de3c68ec

**Special notes for your reviewer**:
This change requires the organisation variable `FEDERATED_GITHUB_ACCESS_TOKEN_SERVER` to be made accessible to this repository and https://github.com/gardener/dashboard/pull/2794 to be merged first.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
