### PR TITLE
Add seed information to `target view` command when targetting a shoot

### DIFF
--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Target Command", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(currentTarget.GardenName()).To(Equal(gardenName))
 			Expect(currentTarget.ProjectName()).To(Equal(projectName))
-			Expect(currentTarget.SeedName()).To(BeEmpty())
+			Expect(currentTarget.SeedName()).To(Equal(seedName))
 			Expect(currentTarget.ShootName()).To(Equal(shootName))
 		})
 
@@ -214,7 +214,7 @@ var _ = Describe("Target Command", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(currentTarget.GardenName()).To(Equal(gardenName))
 			Expect(currentTarget.ProjectName()).To(Equal(projectName))
-			Expect(currentTarget.SeedName()).To(BeEmpty())
+			Expect(currentTarget.SeedName()).To(Equal(seedName))
 			Expect(currentTarget.ShootName()).To(Equal(shootName))
 		})
 

--- a/pkg/cmd/target/view_test.go
+++ b/pkg/cmd/target/view_test.go
@@ -26,6 +26,7 @@ var _ = Describe("Target View Command", func() {
 	const (
 		gardenName  = "mygarden"
 		projectName = "myproject"
+		seedName    = "myseed"
 		shootName   = "myshoot"
 	)
 
@@ -85,6 +86,26 @@ var _ = Describe("Target View Command", func() {
 
 			// here we need the real manager
 			Expect(out.String()).To(Equal(fmt.Sprintf("garden: %s\nproject: %s\nshoot: %s\n", gardenName, projectName, "myshoot2")))
+		})
+	})
+
+	Context("when shoot has a seed assigned", func() {
+		BeforeEach(func() {
+			currentTarget = target.NewTarget(gardenName, projectName, seedName, shootName)
+			Expect(targetProvider.Write(currentTarget)).To(Succeed())
+		})
+
+		It("should include seed in yaml output", func() {
+			cmd := cmdtarget.NewCmdView(factory, streams)
+			Expect(cmd.RunE(cmd, nil)).To(Succeed())
+			Expect(out.String()).To(Equal(fmt.Sprintf("garden: %s\nproject: %s\nseed: %s\nshoot: %s\n", gardenName, projectName, seedName, shootName)))
+		})
+
+		It("should include seed in json output", func() {
+			cmd := cmdtarget.NewCmdView(factory, streams)
+			cmd.SetArgs([]string{"-ojson"})
+			Expect(cmd.Execute()).To(Succeed())
+			Expect(out.String()).To(Equal(fmt.Sprintf("{\n  \"garden\": \"%s\",\n  \"project\": \"%s\",\n  \"seed\": \"%s\",\n  \"shoot\": \"%s\"\n}\n", gardenName, projectName, seedName, shootName)))
 		})
 	})
 })

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -313,6 +313,7 @@ func (m *managerImpl) UnsetTargetShoot(ctx context.Context) (string, error) {
 
 	return targetedName, m.patchTarget(ctx, func(t *targetImpl) error {
 		t.Shoot = ""
+		t.Seed = ""
 		t.ControlPlaneFlag = false
 
 		return nil

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -305,7 +305,7 @@ var _ = Describe("Target Manager", func() {
 		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetShoot(ctx, prod1AmbiguousShoot.Name)).To(Succeed())
-		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1AmbiguousShoot.Name))
+		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1AmbiguousShoot.Name))
 	})
 
 	It("should be able to target valid shoots with a seed already targeted. Should drop seed and set shoot project instead", func() {
@@ -313,7 +313,7 @@ var _ = Describe("Target Manager", func() {
 		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetShoot(ctx, prod1GoldenShoot.Name)).To(Succeed())
-		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name))
+		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1GoldenShoot.Name))
 	})
 
 	It("should not be able to target valid shoots with another seed already targeted", func() {
@@ -325,13 +325,24 @@ var _ = Describe("Target Manager", func() {
 		assertTargetProvider(targetProvider, t)
 	})
 
+	It("should reject targeting a shoot when the specified seed does not match the shoot's actual seed", func() {
+		// current target has project and a wrong seed (as if the user provided --project and --seed flags)
+		t := target.NewTarget(gardenName, prod1Project.Name, "wrong-seed", prod1GoldenShoot.Name)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
+
+		err := manager.TargetShoot(ctx, prod1GoldenShoot.Name)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("does not match the actual seed"))
+		assertTargetProvider(targetProvider, t)
+	})
+
 	It("should be able to target valid shoots with only garden targeted", func() {
 		t := target.NewTarget(gardenName, "", "", "")
 		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetShoot(ctx, prod1GoldenShoot.Name)).To(Succeed())
 		// project should be inserted into the path, as it is preferred over a seed step
-		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name))
+		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1GoldenShoot.Name))
 	})
 
 	It("should error when multiple shoots match", func() {
@@ -353,7 +364,7 @@ var _ = Describe("Target Manager", func() {
 			manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 			Expect(manager.TargetMatchPattern(ctx, tf, fmt.Sprintf("%s/shoot--%s--%s", gardenName, prod1Project.Name, prod1GoldenShoot.Name))).To(Succeed())
-			assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name))
+			assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1GoldenShoot.Name))
 		})
 
 		It("should be able to target valid project shoot by matching a pattern if garden is set", func() {
@@ -361,7 +372,7 @@ var _ = Describe("Target Manager", func() {
 			manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 			Expect(manager.TargetMatchPattern(ctx, tf, fmt.Sprintf("shoot--%s--%s", prod1Project.Name, prod1GoldenShoot.Name))).To(Succeed())
-			assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name))
+			assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1GoldenShoot.Name))
 		})
 
 		It("should be able to target shoot by matching a pattern if garden is not set", func() {
@@ -369,7 +380,7 @@ var _ = Describe("Target Manager", func() {
 			manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 			Expect(manager.TargetMatchPattern(ctx, tf, fmt.Sprintf("shoot--%s--%s", prod1Project.Name, prod1GoldenShoot.Name))).To(Succeed())
-			assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name))
+			assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1GoldenShoot.Name))
 		})
 
 		It("should not target anything if target is not completely valid", func() {

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -308,7 +308,7 @@ var _ = Describe("Target Manager", func() {
 		assertTargetProvider(targetProvider, target.NewTarget(gardenName, prod1Project.Name, seed.Name, prod1AmbiguousShoot.Name))
 	})
 
-	It("should be able to target valid shoots with a seed already targeted. Should drop seed and set shoot project instead", func() {
+	It("should be able to target valid shoots with a seed already targeted and preserve the matching seed", func() {
 		t := target.NewTarget(gardenName, "", seed.Name, "")
 		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 

--- a/pkg/target/target.go
+++ b/pkg/target/target.go
@@ -94,8 +94,8 @@ func newTargetImpl(gardenName, projectName, seedName, shootName string, controlP
 // Validate checks that the target is not malformed and all required
 // steps are configured correctly.
 func (t *targetImpl) Validate() error {
-	if len(t.Project) > 0 && len(t.Seed) > 0 {
-		return errors.New("seed and project must not be configured at the same time")
+	if len(t.Project) > 0 && len(t.Seed) > 0 && len(t.Shoot) == 0 {
+		return errors.New("seed and project must not be configured at the same time without a shoot")
 	}
 
 	if t.Garden != "" {

--- a/pkg/target/target_builder.go
+++ b/pkg/target/target_builder.go
@@ -224,7 +224,16 @@ func (b *targetBuilderImpl) completeTargetForShoot(ctx context.Context, t *targe
 		t.Project = project.Name
 	}
 
-	t.Seed = ""
+	if shoot.Spec.SeedName != nil {
+		if t.Seed != "" && t.Seed != *shoot.Spec.SeedName {
+			return fmt.Errorf("the specified seed %q does not match the actual seed %q of shoot %q", t.Seed, *shoot.Spec.SeedName, name)
+		}
+
+		t.Seed = *shoot.Spec.SeedName
+	} else {
+		t.Seed = ""
+	}
+
 	t.Shoot = shoot.Name
 	t.ControlPlaneFlag = false
 

--- a/pkg/target/target_flags_test.go
+++ b/pkg/target/target_flags_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Target Flags", func() {
 	It("should validate target flags", func() {
 		Expect(target.NewTargetFlags("", "project", "", "shoot", false).IsTargetValid()).To(BeFalse())
 		Expect(target.NewTargetFlags("garden", "", "", "shoot", false).IsTargetValid()).To(BeTrue())
-		Expect(target.NewTargetFlags("garden", "project", "seed", "shoot", false).IsTargetValid()).To(BeFalse())
+		Expect(target.NewTargetFlags("garden", "project", "seed", "shoot", false).IsTargetValid()).To(BeTrue())
 		Expect(target.NewTargetFlags("garden", "", "", "", false).IsTargetValid()).To(BeTrue())
 		Expect(target.NewTargetFlags("garden", "project", "", "", false).IsTargetValid()).To(BeTrue())
 		Expect(target.NewTargetFlags("garden", "", "seed", "", false).IsTargetValid()).To(BeTrue())

--- a/pkg/target/target_provider.go
+++ b/pkg/target/target_provider.go
@@ -184,9 +184,13 @@ func merge(t Target, tf TargetFlags) (Target, error) {
 
 		if tf.SeedName() != "" {
 			// If a shoot is targeted via project and has a known seed,
-			// forbid specifying a different seed.
-			if t.ShootName() != "" && t.ProjectName() != "" && t.SeedName() != "" && tf.SeedName() != t.SeedName() {
-				return nil, fmt.Errorf("the specified seed %q does not match the actual seed %q of shoot %q", tf.SeedName(), t.SeedName(), t.ShootName())
+			// forbid specifying a different seed. Only check when the user
+			// is passing --seed alone (no garden/project/shoot flags that
+			// would retarget to something else entirely).
+			if tf.GardenName() == "" && tf.ProjectName() == "" && tf.ShootName() == "" &&
+				newTarget.ShootName() != "" && newTarget.ProjectName() != "" && newTarget.SeedName() != "" &&
+				tf.SeedName() != newTarget.SeedName() {
+				return nil, fmt.Errorf("the specified seed %q does not match the actual seed %q of shoot %q", tf.SeedName(), newTarget.SeedName(), newTarget.ShootName())
 			}
 
 			newTarget = newTarget.WithSeedName(tf.SeedName()).WithProjectName("").WithShootName("")

--- a/pkg/target/target_provider.go
+++ b/pkg/target/target_provider.go
@@ -169,19 +169,32 @@ func merge(t Target, tf TargetFlags) (Target, error) {
 	}
 
 	if tf.ProjectName() != "" && tf.SeedName() != "" {
-		return nil, errors.New("cannot specify --project and --seed at the same time")
-	}
+		if tf.ShootName() == "" {
+			return nil, errors.New("cannot specify --project and --seed at the same time")
+		}
 
-	if tf.ProjectName() != "" {
-		newTarget = newTarget.WithProjectName(tf.ProjectName()).WithSeedName("").WithShootName("")
-	}
+		// When project, seed, and shoot are all specified, keep all three
+		// so that the shoot is found via project and the seed is validated in
+		// completeTargetForShoot.
+		newTarget = newTarget.WithProjectName(tf.ProjectName()).WithSeedName(tf.SeedName()).WithShootName(tf.ShootName())
+	} else {
+		if tf.ProjectName() != "" {
+			newTarget = newTarget.WithProjectName(tf.ProjectName()).WithSeedName("").WithShootName("")
+		}
 
-	if tf.SeedName() != "" {
-		newTarget = newTarget.WithSeedName(tf.SeedName()).WithProjectName("").WithShootName("")
-	}
+		if tf.SeedName() != "" {
+			// If a shoot is targeted via project and has a known seed,
+			// forbid specifying a different seed.
+			if t.ShootName() != "" && t.ProjectName() != "" && t.SeedName() != "" && tf.SeedName() != t.SeedName() {
+				return nil, fmt.Errorf("the specified seed %q does not match the actual seed %q of shoot %q", tf.SeedName(), t.SeedName(), t.ShootName())
+			}
 
-	if tf.ShootName() != "" {
-		newTarget = newTarget.WithShootName(tf.ShootName())
+			newTarget = newTarget.WithSeedName(tf.SeedName()).WithProjectName("").WithShootName("")
+		}
+
+		if tf.ShootName() != "" {
+			newTarget = newTarget.WithShootName(tf.ShootName())
+		}
 	}
 
 	if tf.ControlPlane() {

--- a/pkg/target/target_provider.go
+++ b/pkg/target/target_provider.go
@@ -160,45 +160,42 @@ func merge(t Target, tf TargetFlags) (Target, error) {
 		return newTarget, nil
 	}
 
-	// Note that "deeper" levels of targets are reset, allowing the
-	// user to "move up". For example, when they have targeted a shoot, simply
-	// specifying "--garden mygarden" should target the garden, not the same
-	// shoot within the garden named mygarden.
+	// Setting a garden resets all deeper targeting levels, allowing
+	// the user to "move up". For example, when they have targeted a shoot,
+	// simply specifying "--garden mygarden" should target the garden, not
+	// the same shoot within the garden named mygarden.
 	if tf.GardenName() != "" {
 		newTarget = newTarget.WithGardenName(tf.GardenName()).WithProjectName("").WithSeedName("").WithShootName("")
 	}
 
-	if tf.ProjectName() != "" && tf.SeedName() != "" {
+	switch {
+	case tf.ProjectName() != "" && tf.SeedName() != "":
+		// --project and --seed together require --shoot; without it,
+		// the target would be ambiguous (seed and project are independent paths).
 		if tf.ShootName() == "" {
 			return nil, errors.New("cannot specify --project and --seed at the same time")
 		}
 
-		// When project, seed, and shoot are all specified, keep all three
-		// so that the shoot is found via project and the seed is validated in
-		// completeTargetForShoot.
+		// All three specified: the shoot is looked up via project and the
+		// seed is validated later in completeTargetForShoot.
 		newTarget = newTarget.WithProjectName(tf.ProjectName()).WithSeedName(tf.SeedName()).WithShootName(tf.ShootName())
-	} else {
-		if tf.ProjectName() != "" {
-			newTarget = newTarget.WithProjectName(tf.ProjectName()).WithSeedName("").WithShootName("")
-		}
 
-		if tf.SeedName() != "" {
-			// If a shoot is targeted via project and has a known seed,
-			// forbid specifying a different seed. Only check when the user
-			// is passing --seed alone (no garden/project/shoot flags that
-			// would retarget to something else entirely).
-			if tf.GardenName() == "" && tf.ProjectName() == "" && tf.ShootName() == "" &&
-				newTarget.ShootName() != "" && newTarget.ProjectName() != "" && newTarget.SeedName() != "" &&
-				tf.SeedName() != newTarget.SeedName() {
-				return nil, fmt.Errorf("the specified seed %q does not match the actual seed %q of shoot %q", tf.SeedName(), newTarget.SeedName(), newTarget.ShootName())
-			}
-
-			newTarget = newTarget.WithSeedName(tf.SeedName()).WithProjectName("").WithShootName("")
-		}
-
+	case tf.ProjectName() != "":
+		// Targeting a project resets seed and shoot.
+		newTarget = newTarget.WithProjectName(tf.ProjectName()).WithSeedName("").WithShootName("")
 		if tf.ShootName() != "" {
 			newTarget = newTarget.WithShootName(tf.ShootName())
 		}
+
+	case tf.SeedName() != "":
+		// Targeting a seed resets project and shoot.
+		newTarget = newTarget.WithSeedName(tf.SeedName()).WithProjectName("").WithShootName("")
+		if tf.ShootName() != "" {
+			newTarget = newTarget.WithShootName(tf.ShootName())
+		}
+
+	case tf.ShootName() != "":
+		newTarget = newTarget.WithShootName(tf.ShootName())
 	}
 
 	if tf.ControlPlane() {

--- a/pkg/target/target_provider_test.go
+++ b/pkg/target/target_provider_test.go
@@ -230,6 +230,7 @@ var _ = Describe("Dynamic Target Provider", func() {
 
 		readBack, err := dtp.Read()
 		Expect(err).NotTo(HaveOccurred())
+		Expect(readBack.GardenName()).To(Equal("mygarden"))
 		Expect(readBack.ProjectName()).To(Equal("newproject"))
 		Expect(readBack.SeedName()).To(Equal("newseed"))
 		Expect(readBack.ShootName()).To(Equal("newshoot"))

--- a/pkg/target/target_provider_test.go
+++ b/pkg/target/target_provider_test.go
@@ -90,10 +90,10 @@ var _ = Describe("Target Provider", func() {
 		Expect(t.ControlPlane()).To(BeTrue())
 	})
 
-	It("should fail to override a target", func() {
+	It("should allow to override a target", func() {
 		tf := target.NewTargetFlags("", "", "", "shoot", false)
 		_, err := target.Merge(target.NewTarget("", "b", "c", "d"), tf)
-		Expect(err).To(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 })
 
@@ -218,8 +218,46 @@ var _ = Describe("Dynamic Target Provider", func() {
 			Expect(readBack).To(BeNil())
 			Expect(err).To(HaveOccurred())
 		},
-		Entry("seed and project", target.NewTargetFlags("", "newproject", "newseed", "", false)),
+		Entry("seed and project without shoot", target.NewTargetFlags("", "newproject", "newseed", "", false)),
 	)
+
+	It("should allow --project, --seed, and --shoot together", func() {
+		dummy := target.NewTarget("mygarden", "myproject", "", "myshoot")
+		Expect(provider.Write(dummy)).To(Succeed())
+
+		tf := target.NewTargetFlags("", "newproject", "newseed", "newshoot", false)
+		dtp := target.NewTargetProvider(tmpFile.Name(), tf)
+
+		readBack, err := dtp.Read()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(readBack.ProjectName()).To(Equal("newproject"))
+		Expect(readBack.SeedName()).To(Equal("newseed"))
+		Expect(readBack.ShootName()).To(Equal("newshoot"))
+	})
+
+	It("should reject --seed when it does not match the shoot's actual seed", func() {
+		dummy := target.NewTarget("mygarden", "myproject", "actualseed", "myshoot")
+		Expect(provider.Write(dummy)).To(Succeed())
+
+		tf := target.NewTargetFlags("", "", "wrongseed", "", false)
+		dtp := target.NewTargetProvider(tmpFile.Name(), tf)
+
+		readBack, err := dtp.Read()
+		Expect(readBack).To(BeNil())
+		Expect(err).To(MatchError(ContainSubstring("does not match the actual seed")))
+	})
+
+	It("should allow --seed when it matches the shoot's actual seed", func() {
+		dummy := target.NewTarget("mygarden", "myproject", "actualseed", "myshoot")
+		Expect(provider.Write(dummy)).To(Succeed())
+
+		tf := target.NewTargetFlags("", "", "actualseed", "", false)
+		dtp := target.NewTargetProvider(tmpFile.Name(), tf)
+
+		readBack, err := dtp.Read()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(readBack.SeedName()).To(Equal("actualseed"))
+	})
 
 	It("should write changes as expected", func() {
 		// prepare target

--- a/pkg/target/target_provider_test.go
+++ b/pkg/target/target_provider_test.go
@@ -235,28 +235,19 @@ var _ = Describe("Dynamic Target Provider", func() {
 		Expect(readBack.ShootName()).To(Equal("newshoot"))
 	})
 
-	It("should reject --seed when it does not match the shoot's actual seed", func() {
+	It("should retarget to the specified seed and drop project and shoot", func() {
 		dummy := target.NewTarget("mygarden", "myproject", "actualseed", "myshoot")
 		Expect(provider.Write(dummy)).To(Succeed())
 
-		tf := target.NewTargetFlags("", "", "wrongseed", "", false)
-		dtp := target.NewTargetProvider(tmpFile.Name(), tf)
-
-		readBack, err := dtp.Read()
-		Expect(readBack).To(BeNil())
-		Expect(err).To(MatchError(ContainSubstring("does not match the actual seed")))
-	})
-
-	It("should allow --seed when it matches the shoot's actual seed", func() {
-		dummy := target.NewTarget("mygarden", "myproject", "actualseed", "myshoot")
-		Expect(provider.Write(dummy)).To(Succeed())
-
-		tf := target.NewTargetFlags("", "", "actualseed", "", false)
+		tf := target.NewTargetFlags("", "", "otherseed", "", false)
 		dtp := target.NewTargetProvider(tmpFile.Name(), tf)
 
 		readBack, err := dtp.Read()
 		Expect(err).NotTo(HaveOccurred())
-		Expect(readBack.SeedName()).To(Equal("actualseed"))
+		Expect(readBack.GardenName()).To(Equal("mygarden"))
+		Expect(readBack.SeedName()).To(Equal("otherseed"))
+		Expect(readBack.ProjectName()).To(BeEmpty())
+		Expect(readBack.ShootName()).To(BeEmpty())
 	})
 
 	It("should write changes as expected", func() {

--- a/pkg/target/target_test.go
+++ b/pkg/target/target_test.go
@@ -30,8 +30,11 @@ var _ = Describe("Target", func() {
 			Expect(target.NewTarget("a", "", "c", "d").Validate()).To(Succeed())
 			Expect(target.NewTarget("a", "", "", "d").Validate()).To(Succeed())
 
-			// invalid because both project and seed are defined
-			Expect(target.NewTarget("a", "b", "c", "d").Validate()).NotTo(Succeed())
+			// valid because shoot is also defined (seed is informational)
+			Expect(target.NewTarget("a", "b", "c", "d").Validate()).To(Succeed())
+
+			// invalid because both project and seed are defined without a shoot
+			Expect(target.NewTarget("a", "b", "c", "").Validate()).NotTo(Succeed())
 
 			// valid shoot names (DNS label compliant)
 			Expect(target.NewTarget("a", "b", "", "my-shoot").Validate()).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously project and seed information (at the same time) where mutually exclusive when you'd target a shoot.
Unfortunately this also results in `gardenctl target view` to not display seed information when targetting a shoot, although that shoot usually already has an assigned seed.

This PR relaxes this mutual exclusiveness validation: when you target a shoot, you are now allowed to specify both, project and seed, as long as the specified seed doesn't contradict the actual shoot's seed. Hence, although specifying the seed via command line would not have been necessary, you are allowed to do so.
This results in `gardenctl target view` to now also properly display a shoot's seed, if a seed is already existing for this shoot.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`gardenctl target view` now also displays the seed, if a shoot was targeted.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Validation now allows project+seed when a shoot is also specified; project+seed without shoot is rejected.
  * Flag merging now supports combined project+seed+shoot retargeting and partial seed-only retargeting that clears deeper levels.

* **Bug Fixes**
  * Seed name is preserved and populated when targeting shoots.
  * Unsetting a shoot now also clears any associated seed.

* **Tests**
  * Updated and added tests covering seed preservation, flag combinations, outputs, and mismatch rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->