### PR TITLE
Recommend installation using winget on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,16 @@ gardenctl is a command-line client for the Gardener. It facilitates the administ
 
 ## Installation
 
-Install the latest release from [Homebrew](https://brew.sh/), [Chocolatey](https://chocolatey.org/packages/gardenctl-v2) or [GitHub Releases](https://github.com/gardener/gardenctl-v2/releases).
+Install the latest release from [Homebrew](https://brew.sh/), [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/), [Chocolatey](https://chocolatey.org/packages/gardenctl-v2) or [GitHub Releases](https://github.com/gardener/gardenctl-v2/releases).
 
 ### Install using Package Managers
 
 ```sh
 # Homebrew (macOS and Linux)
 brew install gardener/tap/gardenctl-v2
+
+# winget (Windows)
+winget install -e --id Gardener.gardenctl
 
 # Chocolatey (Windows)
 # default location C:\ProgramData\chocolatey\bin\gardenctl-v2.exe


### PR DESCRIPTION
**What this PR does / why we need it**:
With winget being included by default in Windows 11 and Windows Server 2025, it no longer seems like a good idea to promote an installation using chocolatey on Windows.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
See also: gardener/gardenlogin#343

**Release note**:
```doc user
Describe installation using winget instead of chocolatey
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added winget as a new Windows package manager installation option alongside existing Homebrew, Chocolatey, and GitHub Releases choices for greater user flexibility.
  * Updated installation instructions with a new winget command example, enabling Windows users to install using their preferred package manager with enhanced convenience and choice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->