### PR TITLE
ci(renovate): use shared gardener/gardener grouping preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,7 @@
     'config:recommended',
     ':semanticCommitsDisabled',
     'customManagers:githubActionsVersions',
+    'github>gardener/ci-infra//config/renovate/group-gardener-updates.json5',
   ],
   labels: [
     'kind/enhancement',
@@ -72,7 +73,6 @@
         'github.com/Masterminds/semver',
         'github.com/Masterminds/sprig/v3',
         'github.com/fatih/color',
-        'github.com/gardener/gardener',
         'github.com/gardener/gardener-extension-provider-openstack',
         'github.com/gardener/machine-controller-manager',
         'github.com/golang/mock',


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the shared Renovate preset from gardener/ci-infra to group
gardener/gardener and gardener/gardener/pkg/apis module updates
together, replacing the local package rule.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The reusable preset lives at:
https://github.com/gardener/ci-infra/blob/master/config/renovate/group-gardener-updates.json5

**Release note**:
```other dependency
NONE
```