### PR TITLE
ci: harden GitHub Actions workflows with zizmor

### DIFF
--- a/.github/actions/prepare-release/action.yaml
+++ b/.github/actions/prepare-release/action.yaml
@@ -10,6 +10,8 @@ runs:
   steps:
     - name: write-latest-version
       shell: bash
+      env:
+        EFFECTIVE_VERSION: ${{ inputs.effective-version }}
       run: |
         set -euo pipefail
-        echo "${{ inputs.effective-version }}" > LATEST
+        echo "${EFFECTIVE_VERSION}" > LATEST

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prepare:
-    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     with:
       mode: ${{ inputs.mode }}
       version-commit-callback-action-path: ./.github/actions/prepare-release
@@ -45,9 +45,9 @@ jobs:
             runner: ubuntu-latest
     runs-on: ${{ matrix.args.runner }}
     steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
       - name: import-release-commit
-        uses: gardener/cc-utils/.github/actions/import-commit@v1
+        uses: gardener/cc-utils/.github/actions/import-commit@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         with:
           commit-objects-artefact: release-commit-objects
           after-import: rebase
@@ -66,7 +66,7 @@ jobs:
           GOARCH=${{ matrix.args.arch }} \
           out_file="/tmp/blobs.d/gardenctl-v2-${{ matrix.args.os }}-${{ matrix.args.arch }}${{ matrix.args.os == 'windows' && '.exe' || '' }}" \
             hack/build.sh
-      - uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1
+      - uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         with:
           blobs-directory: /tmp/blobs.d
           ocm-resources: |
@@ -112,9 +112,9 @@ jobs:
           - lint
           - go-test
     steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
       - name: import-release-commit
-        uses: gardener/cc-utils/.github/actions/import-commit@v1
+        uses: gardener/cc-utils/.github/actions/import-commit@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         with:
           commit-objects-artefact: release-commit-objects
           after-import: rebase
@@ -122,7 +122,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: ${{ inputs.mode != 'release' }}  # disable cache for release builds
-      - uses: gardener/cc-utils/.github/actions/setup-git-identity@v1
+      - uses: gardener/cc-utils/.github/actions/setup-git-identity@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         if: ${{ matrix.target == 'check-generate' }}
 
       - shell: bash
@@ -133,7 +133,7 @@ jobs:
           tar czf /tmp/blobs.d/logs.tar.gz -C/tmp/blobs.d logs.txt
       - name: add-reports-to-component-descriptor
         if: ${{ matrix.target == 'go-test' }}
-        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         with:
           blobs-directory: /tmp/blobs.d
           ocm-resources: |
@@ -148,7 +148,7 @@ jobs:
                   - test
 
   verify-sast:
-    uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     permissions:
       contents: read
     with:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: 'go.mod'
+          cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
 
   component-descriptor:
-    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
     permissions:

--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate-release-notes:
-    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     permissions:
       pull-requests: read
     with:

--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -13,6 +13,6 @@ permissions:
 
 jobs:
   call-dashboard-workflow:
-    uses: gardener/dashboard/.github/workflows/prepare-hotfix-branch.yaml@master
+    uses: gardener/dashboard/.github/workflows/prepare-hotfix-branch.yaml@master # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally tracks master as the trusted source for the latest hotfix preparation logic
     with:
       tag: ${{ inputs.tag }}

--- a/.github/workflows/publish-to-package-repositories.yaml
+++ b/.github/workflows/publish-to-package-repositories.yaml
@@ -12,6 +12,13 @@ on:
         required: true
         description: |
           the OCM-Component-Descriptor from which to publish built artefacts
+    secrets:
+      GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID:
+        required: false
+        description: App ID for the gardener-github-pkg-mngr GitHub App
+      GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_PRIVATE_KEY:
+        required: false
+        description: Private key for the gardener-github-pkg-mngr GitHub App
 
   # Manual / ad‑hoc trigger
   workflow_dispatch:

--- a/.github/workflows/publish-to-package-repositories.yaml
+++ b/.github/workflows/publish-to-package-repositories.yaml
@@ -61,17 +61,19 @@ jobs:
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
       - name: export-version-from-input
         if: ${{ inputs.version != '' && inputs.component-descriptor == '' }}
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           set -eu
-          echo "version=${{ inputs.version }}" >> ${GITHUB_ENV}
+          echo "version=${VERSION}" >> ${GITHUB_ENV}
       - name: Read-Digests
         if: ${{ inputs.component-descriptor != '' }}
+        env:
+          COMPONENT_DESCRIPTOR: ${{ inputs.component-descriptor }}
         run: |
           set -euo pipefail
 
-          cat <<"EOF" > /tmp/component-descriptor.yaml
-          ${{ inputs.component-descriptor }}
-          EOF
+          printenv COMPONENT_DESCRIPTOR > /tmp/component-descriptor.yaml
 
           source .github/workflows/export-digests-from-component-descriptor.sh \
             /tmp/component-descriptor.yaml
@@ -102,6 +104,8 @@ jobs:
       # ───── Homebrew tap dispatch ────────────────────────────────────────────
       - name: Send update to ${{ github.repository_owner }}/homebrew-tap
         if: ${{ inputs.dry_run == false }}
+        env:
+          GITHUB_APP_TOKEN: ${{ steps.gardener-github-workflows.outputs.token }}
         run: |
           set -euo pipefail
           data=$(jq -n \
@@ -121,13 +125,15 @@ jobs:
                 linux_sha_arm64:$linux_sha_arm64}}')
           curl -X POST \
             -H 'Accept: application/vnd.github.everest-preview+json' \
-            -H "Authorization: Bearer ${{ steps.gardener-github-workflows.outputs.token }}" \
+            -H "Authorization: Bearer ${GITHUB_APP_TOKEN}" \
             -d "$data" \
             "https://api.github.com/repos/${{ github.repository_owner }}/homebrew-tap/dispatches"
 
       # ───── Chocolatey dispatch ──────────────────────────────────────────────
       - name: Send update to ${{ github.repository_owner }}/chocolatey-packages
         if: ${{ inputs.dry_run == false }}
+        env:
+          GITHUB_APP_TOKEN: ${{ steps.gardener-github-workflows.outputs.token }}
         run: |
           set -euo pipefail
           data=$(jq -n \
@@ -141,6 +147,6 @@ jobs:
                 windows_sha:$windows_sha}}')
           curl -X POST \
             -H 'Accept: application/vnd.github.everest-preview+json' \
-            -H "Authorization: Bearer ${{ steps.gardener-github-workflows.outputs.token }}" \
+            -H "Authorization: Bearer ${GITHUB_APP_TOKEN}" \
             -d "$data" \
             "https://api.github.com/repos/${{ github.repository_owner }}/chocolatey-packages/dispatches"

--- a/.github/workflows/publish-to-package-repositories.yaml
+++ b/.github/workflows/publish-to-package-repositories.yaml
@@ -58,7 +58,7 @@ jobs:
             homebrew-tap
             chocolatey-packages
 
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
       - name: export-version-from-input
         if: ${{ inputs.version != '' && inputs.component-descriptor == '' }}
         env:

--- a/.github/workflows/publish-to-package-repositories.yaml
+++ b/.github/workflows/publish-to-package-repositories.yaml
@@ -67,13 +67,15 @@ jobs:
 
       - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
       - name: export-version-from-input
+        id: export-version
         if: ${{ inputs.version != '' && inputs.component-descriptor == '' }}
         env:
           VERSION: ${{ inputs.version }}
         run: |
           set -eu
-          echo "version=${VERSION}" >> ${GITHUB_ENV}
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
       - name: Read-Digests
+        id: read-digests
         if: ${{ inputs.component-descriptor != '' }}
         env:
           COMPONENT_DESCRIPTOR: ${{ inputs.component-descriptor }}
@@ -85,18 +87,19 @@ jobs:
           source .github/workflows/export-digests-from-component-descriptor.sh \
             /tmp/component-descriptor.yaml
 
-          echo "DARWIN_SHA_AMD64=${DARWIN_SHA_AMD64}" >> "${GITHUB_ENV}"
-          echo "DARWIN_SHA_ARM64=${DARWIN_SHA_ARM64}" >> "${GITHUB_ENV}"
-          echo "LINUX_SHA_AMD64=${LINUX_SHA_AMD64}" >> "${GITHUB_ENV}"
-          echo "LINUX_SHA_ARM64=${LINUX_SHA_ARM64}" >> "${GITHUB_ENV}"
-          echo "WINDOWS_SHA=${WINDOWS_SHA}" >> "${GITHUB_ENV}"
+          echo "DARWIN_SHA_AMD64=${DARWIN_SHA_AMD64}" >> "${GITHUB_OUTPUT}"
+          echo "DARWIN_SHA_ARM64=${DARWIN_SHA_ARM64}" >> "${GITHUB_OUTPUT}"
+          echo "LINUX_SHA_AMD64=${LINUX_SHA_AMD64}" >> "${GITHUB_OUTPUT}"
+          echo "LINUX_SHA_ARM64=${LINUX_SHA_ARM64}" >> "${GITHUB_OUTPUT}"
+          echo "WINDOWS_SHA=${WINDOWS_SHA}" >> "${GITHUB_OUTPUT}"
 
           version="$(cat /tmp/component-descriptor.yaml | \
             yq '.component.version'
           )"
-          echo "version=${version}" >> "${GITHUB_ENV}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
       - name: Use dummy hashes (skip‑build)
+        id: dummy-hashes
         if: ${{ inputs.component-descriptor == '' }}
         run: |
           set -euo pipefail
@@ -106,13 +109,18 @@ jobs:
             "DARWIN_SHA_ARM64=$dummy" \
             "LINUX_SHA_AMD64=$dummy"  \
             "LINUX_SHA_ARM64=$dummy"  \
-            "WINDOWS_SHA=$dummy" >> "$GITHUB_ENV"
+            "WINDOWS_SHA=$dummy" >> "$GITHUB_OUTPUT"
 
       # ───── Homebrew tap dispatch ────────────────────────────────────────────
       - name: Send update to ${{ github.repository_owner }}/homebrew-tap
         if: ${{ inputs.dry_run == false }}
         env:
           GITHUB_APP_TOKEN: ${{ steps.gardener-github-workflows.outputs.token }}
+          version: ${{ steps.read-digests.outputs.version || steps.export-version.outputs.version }}
+          DARWIN_SHA_AMD64: ${{ steps.read-digests.outputs.DARWIN_SHA_AMD64 || steps.dummy-hashes.outputs.DARWIN_SHA_AMD64 }}
+          DARWIN_SHA_ARM64: ${{ steps.read-digests.outputs.DARWIN_SHA_ARM64 || steps.dummy-hashes.outputs.DARWIN_SHA_ARM64 }}
+          LINUX_SHA_AMD64: ${{ steps.read-digests.outputs.LINUX_SHA_AMD64 || steps.dummy-hashes.outputs.LINUX_SHA_AMD64 }}
+          LINUX_SHA_ARM64: ${{ steps.read-digests.outputs.LINUX_SHA_ARM64 || steps.dummy-hashes.outputs.LINUX_SHA_ARM64 }}
         run: |
           set -euo pipefail
           data=$(jq -n \
@@ -141,6 +149,8 @@ jobs:
         if: ${{ inputs.dry_run == false }}
         env:
           GITHUB_APP_TOKEN: ${{ steps.gardener-github-workflows.outputs.token }}
+          version: ${{ steps.read-digests.outputs.version || steps.export-version.outputs.version }}
+          WINDOWS_SHA: ${{ steps.read-digests.outputs.WINDOWS_SHA || steps.dummy-hashes.outputs.WINDOWS_SHA }}
         run: |
           set -euo pipefail
           data=$(jq -n \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,8 @@ jobs:
     uses: gardener/cc-utils/.github/workflows/release.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
-    secrets: inherit
+    secrets:
+      slack-token: ${{ secrets.SLACK_APP_TOKEN_GARDENER_CICD }}
     permissions:
       contents: write
       id-token: write
@@ -68,7 +69,9 @@ jobs:
       actions: read
     needs:
       - release-to-github-and-bump
-    secrets: inherit
+    secrets:
+      GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID: ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID }}
+      GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_PRIVATE_KEY: ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_PRIVATE_KEY }}
     uses: ./.github/workflows/publish-to-package-repositories.yaml
     with:
       component-descriptor: ${{ needs.release-to-github-and-bump.outputs.component-descriptor }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       mode: release
 
   release-to-github-and-bump:
-    uses: gardener/cc-utils/.github/workflows/release.yaml@v1
+    uses: gardener/cc-utils/.github/workflows/release.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
     secrets: inherit

--- a/.github/workflows/reuse-tool-lint.yaml
+++ b/.github/workflows/reuse-tool-lint.yaml
@@ -10,5 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: REUSE Compliance Check
         uses: fsfe/reuse-action@676e2d560c9a403aa252096d99fcab3e1132b0f5 # v6.0.0

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,33 @@
+name: Zizmor Workflow Lint
+
+on:
+  push:
+    branches:
+    - master
+    - hotfix-*
+    paths:
+    - '.github/**'
+  pull_request:
+    paths:
+    - '.github/**'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          # renovate: datasource=github-releases depName=zizmorcore/zizmor
+          version: v1.24.1
+          min-severity: low
+          min-confidence: low
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area security
/kind enhancement

**What this PR does / why we need it**:

Hardens all GitHub Actions workflows based on findings from [zizmor](https://docs.zizmor.sh/):

- Add zizmor workflow lint as a new CI check
- Replace `secrets: inherit` with explicit secret passing
- Avoid direct use of expression contexts in `run:` scripts
- Disable `persist-credentials` for checkout steps
- Disable setup-go cache in golangci-lint workflow (golangci-lint-action manages its own cache)
- Suppress `unpinned-uses` for same-org actions via inline annotations
- Replace `GITHUB_ENV` with `GITHUB_OUTPUT` in publish workflow

**Which issue(s) this PR fixes**:

**Release note**:
```other developer
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated linting for GitHub Actions workflows to catch security and best-practice issues.
  * Enhanced build pipeline with artifact export capabilities.

* **Chores**
  * Improved CI/CD security by disabling unnecessary credential persistence in workflows.
  * Refined secret management in release workflows to follow principle of least privilege.
  * Updated workflow configurations for stability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->