### PR TITLE
feat: Allow configuration of Kubeconfig access level (config + flags)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ gardens:
 # name: my-name # An alternative, unique garden name for targeting
 # context: different-context # Overrides the current-context of the garden cluster kubeconfig
 # patterns: ~ # List of regex patterns for pattern targeting
-# defaultKubeconfigAccessLevel: # Default access level requested per target scope
+# kubeconfigAccessLevelDefaults: # Default access level requested per target scope
 #   shoots: viewer              # admin (default) | viewer | auto
 #   managedSeeds: admin         # admin (default) | viewer | auto
 ```
@@ -107,10 +107,10 @@ For shoots and managed seeds, `gardenctl` requests a kubeconfig from `gardenlogi
 - `viewer` - read-only credentials with no access to encrypted resources (e.g. Secrets).
 - `auto` - try admin first; fall back to viewer if admin is denied. Convenient when you don't know your RBAC up front; for users who *do* have admin, this is effectively the same as `admin`.
 
-Set per-scope defaults per garden under `defaultKubeconfigAccessLevel`. The `shoots` and `managedSeeds` fields are independent - for example, an admin who wants least-privilege access to customer shoots while still keeping admin access for seed-level debugging would set:
+Set per-scope defaults per garden under `kubeconfigAccessLevelDefaults`. The `shoots` and `managedSeeds` fields are independent - for example, an admin who wants least-privilege access to customer shoots while still keeping admin access for seed-level debugging would set:
 
 ```yaml
-defaultKubeconfigAccessLevel:
+kubeconfigAccessLevelDefaults:
   shoots: viewer
   managedSeeds: admin
 ```

--- a/README.md
+++ b/README.md
@@ -115,15 +115,18 @@ kubeconfigAccessLevelDefaults:
   managedSeeds: admin
 ```
 
-Override per invocation with `--kubeconfig-access-level` (or the `--admin` / `--viewer` shorthands), available on commands that produce a kubeconfig (`target`, `kubeconfig`):
+Override per invocation with `--access-level` (or the `--admin` / `--viewer` shorthands), available on commands that produce a kubeconfig (`target`, `kubeconfig`):
 
 ```bash
-gardenctl kubeconfig --admin                                    # one-off escalation
-gardenctl target --shoot my-shoot --viewer                      # one-off de-escalation
-gardenctl kubeconfig --kubeconfig-access-level=auto             # explicit auto (no shorthand)
+gardenctl kubeconfig --admin                       # one-off escalation
+gardenctl target --shoot my-shoot --viewer         # one-off de-escalation
+gardenctl kubeconfig --access-level=auto           # explicit auto (no shorthand)
 ```
 
 The shorthands and the full form are mutually exclusive — pass at most one.
+
+> [!NOTE]
+> Flag overrides apply only to the invocation they're passed to. They are not persisted on disk, so a subsequent `gardenctl kubeconfig` (without a flag) re-resolves from the per-garden config defaults, not from the flag you passed to an earlier `gardenctl target`. For persistent changes set them via `gardenctl config set-garden`. You may also repeat the flags on `gardenctl kubeconfig`.
 
 The same defaults can be set via the CLI rather than hand-editing the YAML:
 
@@ -146,7 +149,7 @@ The access level only applies to **shoots and managed seeds**, where Gardener pr
 When `gardenctl` explicitly chose an access level (via flag or per-garden config), it surfaces it inline after `target` and on stderr after `kubeconfig`:
 
 ```console
-$ gardenctl target shoot prod-cluster --kubeconfig-access-level=viewer
+$ gardenctl target shoot prod-cluster --access-level=viewer
 Successfully targeted shoot "prod-cluster" (access level: viewer)
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ defaultKubeconfigAccessLevel:
   managedSeeds: admin
 ```
 
-Override per invocation with the `--kubeconfig-access-level` flag, available on commands that produce a kubeconfig (`target`, `kubeconfig`, `kubectl-env`):
+Override per invocation with the `--kubeconfig-access-level` flag, available on commands that produce a kubeconfig (`target`, `kubeconfig`):
 
 ```bash
 gardenctl kubeconfig --kubeconfig-access-level=admin            # one-off escalation

--- a/README.md
+++ b/README.md
@@ -140,15 +140,16 @@ The access level only applies to **shoots and managed seeds**, where Gardener pr
 
 #### Verifying which access level is in use
 
-`gardenctl` prints the access level after `target` and `kubeconfig` (stderr):
+When `gardenctl` explicitly chose an access level (via flag or per-garden config), it surfaces it inline after `target` and on stderr after `kubeconfig`:
 
-```
-$ gardenctl target shoot prod-cluster
-Successfully targeted shoot "prod-cluster"
-Kubeconfig access level: viewer
+```console
+$ gardenctl target shoot prod-cluster --kubeconfig-access-level=viewer
+Successfully targeted shoot "prod-cluster" (access level: viewer)
 ```
 
-For an explicit check, the access level is also embedded as a `--access-level=…` argument in the produced kubeconfig's exec plugin section:
+When neither a flag nor a per-garden config is set, `gardenctl` stays silent and lets `gardenlogin`'s own default apply (currently `auto`).
+
+For an explicit check, the access level is also embedded as a `--access-level=…` argument in the produced kubeconfig's exec plugin section (omitted when `gardenctl` deferred to `gardenlogin`'s default):
 
 ```bash
 gardenctl kubeconfig | grep -- '--access-level='

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ defaultKubeconfigAccessLevel:
   managedSeeds: admin
 ```
 
-Override per invocation with the `--kubeconfig-access-level` flag, available on commands that produce a kubeconfig (`target`, `kubeconfig`, `kubectl-env`, `ssh`, `ssh-patch`):
+Override per invocation with the `--kubeconfig-access-level` flag, available on commands that produce a kubeconfig (`target`, `kubeconfig`, `kubectl-env`):
 
 ```bash
 gardenctl kubeconfig --kubeconfig-access-level=admin            # one-off escalation

--- a/README.md
+++ b/README.md
@@ -115,12 +115,15 @@ kubeconfigAccessLevelDefaults:
   managedSeeds: admin
 ```
 
-Override per invocation with the `--kubeconfig-access-level` flag, available on commands that produce a kubeconfig (`target`, `kubeconfig`):
+Override per invocation with `--kubeconfig-access-level` (or the `--admin` / `--viewer` shorthands), available on commands that produce a kubeconfig (`target`, `kubeconfig`):
 
 ```bash
-gardenctl kubeconfig --kubeconfig-access-level=admin            # one-off escalation
-gardenctl target --shoot my-shoot --kubeconfig-access-level=viewer
+gardenctl kubeconfig --admin                                    # one-off escalation
+gardenctl target --shoot my-shoot --viewer                      # one-off de-escalation
+gardenctl kubeconfig --kubeconfig-access-level=auto             # explicit auto (no shorthand)
 ```
+
+The shorthands and the full form are mutually exclusive — pass at most one.
 
 The same defaults can be set via the CLI rather than hand-editing the YAML:
 

--- a/README.md
+++ b/README.md
@@ -90,11 +90,69 @@ gardens:
 # name: my-name # An alternative, unique garden name for targeting
 # context: different-context # Overrides the current-context of the garden cluster kubeconfig
 # patterns: ~ # List of regex patterns for pattern targeting
+# defaultKubeconfigAccessLevel: # Default access level requested per target scope
+#   shoots: viewer              # admin (default) | viewer | auto
+#   managedSeeds: admin         # admin (default) | viewer | auto
 ```
 
 > [!NOTE]
 > - To use the kubeconfigs for **shoot clusters** provided by `gardenctl`, you need to have [gardenlogin](https://github.com/gardener/gardenlogin) installed as a `kubectl` auth plugin.
 > - If your **garden cluster** kubeconfig uses OIDC authentication, ensure that you have the [kubelogin](https://github.com/int128/kubelogin) `kubectl` auth plugin installed.
+
+### Kubeconfig Access Level
+
+For shoots and managed seeds, `gardenctl` requests a kubeconfig from `gardenlogin` with a configurable access level:
+
+- `admin` (default) - full cluster-admin credentials.
+- `viewer` - read-only credentials with no access to encrypted resources (e.g. Secrets).
+- `auto` - try admin first; fall back to viewer if admin is denied. Convenient when you don't know your RBAC up front; for users who *do* have admin, this is effectively the same as `admin`.
+
+Set per-scope defaults per garden under `defaultKubeconfigAccessLevel`. The `shoots` and `managedSeeds` fields are independent - for example, an admin who wants least-privilege access to customer shoots while still keeping admin access for seed-level debugging would set:
+
+```yaml
+defaultKubeconfigAccessLevel:
+  shoots: viewer
+  managedSeeds: admin
+```
+
+Override per invocation with the `--kubeconfig-access-level` flag, available on commands that produce a kubeconfig (`target`, `kubeconfig`, `kubectl-env`, `ssh`, `ssh-patch`):
+
+```bash
+gardenctl kubeconfig --kubeconfig-access-level=admin            # one-off escalation
+gardenctl target --shoot my-shoot --kubeconfig-access-level=viewer
+```
+
+The same defaults can be set via the CLI rather than hand-editing the YAML:
+
+```bash
+gardenctl config set-garden prd-garden \
+  --default-shoot-access-level viewer \
+  --default-managed-seed-access-level admin
+```
+
+The access level only applies to **shoots and managed seeds**, where Gardener provides admin/viewer kubeconfig subresources that gardenlogin requests on demand. It does not apply to:
+
+- The **garden cluster itself** - gardenctl uses the user's own kubeconfig file as configured. There is no API to "downgrade" those credentials; if you want viewer-only access to the garden, point gardenctl at a kubeconfig whose underlying RBAC is read-only.
+- **Non-managed seeds** - credentials come from a static `<name>.login` Secret in the garden cluster, which only contains admin credentials. Requesting `viewer` or `auto` for a non-managed seed (via flag or the `managedSeeds` default) returns an error.
+
+> [!NOTE]
+> `auto` returns admin whenever your RBAC allows it. If you want guaranteed read-only access, configure `viewer` explicitly.
+
+#### Verifying which access level is in use
+
+`gardenctl` prints the access level after `target` and `kubeconfig` (stderr):
+
+```
+$ gardenctl target shoot prod-cluster
+Successfully targeted shoot "prod-cluster"
+Kubeconfig access level: viewer
+```
+
+For an explicit check, the access level is also embedded as a `--access-level=…` argument in the produced kubeconfig's exec plugin section:
+
+```bash
+gardenctl kubeconfig | grep -- '--access-level='
+```
 
 ### Config Path Overwrite
 

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ gardens:
 # context: different-context # Overrides the current-context of the garden cluster kubeconfig
 # patterns: ~ # List of regex patterns for pattern targeting
 # kubeconfigAccessLevelDefaults: # Default access level requested per target scope
-#   shoots: viewer              # admin (default) | viewer | auto
-#   managedSeeds: admin         # admin (default) | viewer | auto
+#   shoots: viewer              # admin | viewer | auto (empty = gardenlogin's default)
+#   seeds: admin                # admin | viewer | auto (empty = gardenlogin's default)
 ```
 
 > [!NOTE]
@@ -101,65 +101,7 @@ gardens:
 
 ### Kubeconfig Access Level
 
-For shoots and managed seeds, `gardenctl` requests a kubeconfig from `gardenlogin` with a configurable access level:
-
-- `admin` (default) - full cluster-admin credentials.
-- `viewer` - read-only credentials with no access to encrypted resources (e.g. Secrets).
-- `auto` - try admin first; fall back to viewer if admin is denied. Convenient when you don't know your RBAC up front; for users who *do* have admin, this is effectively the same as `admin`.
-
-Set per-scope defaults per garden under `kubeconfigAccessLevelDefaults`. The `shoots` and `managedSeeds` fields are independent - for example, an admin who wants least-privilege access to customer shoots while still keeping admin access for seed-level debugging would set:
-
-```yaml
-kubeconfigAccessLevelDefaults:
-  shoots: viewer
-  managedSeeds: admin
-```
-
-Override per invocation with `--access-level` (or the `--admin` / `--viewer` shorthands), available on commands that produce a kubeconfig (`target`, `kubeconfig`):
-
-```bash
-gardenctl kubeconfig --admin                       # one-off escalation
-gardenctl target --shoot my-shoot --viewer         # one-off de-escalation
-gardenctl kubeconfig --access-level=auto           # explicit auto (no shorthand)
-```
-
-The shorthands and the full form are mutually exclusive — pass at most one.
-
-> [!NOTE]
-> Flag overrides apply only to the invocation they're passed to. They are not persisted on disk, so a subsequent `gardenctl kubeconfig` (without a flag) re-resolves from the per-garden config defaults, not from the flag you passed to an earlier `gardenctl target`. For persistent changes set them via `gardenctl config set-garden`. You may also repeat the flags on `gardenctl kubeconfig`.
-
-The same defaults can be set via the CLI rather than hand-editing the YAML:
-
-```bash
-gardenctl config set-garden prd-garden \
-  --default-shoot-access-level viewer \
-  --default-managed-seed-access-level admin
-```
-
-The access level only applies to **shoots and managed seeds**, where Gardener provides admin/viewer kubeconfig subresources that gardenlogin requests on demand. It does not apply to:
-
-- The **garden cluster itself** - gardenctl uses the user's own kubeconfig file as configured. There is no API to "downgrade" those credentials; if you want viewer-only access to the garden, point gardenctl at a kubeconfig whose underlying RBAC is read-only.
-- **Non-managed seeds** - credentials come from a static `<name>.login` Secret in the garden cluster, which only contains admin credentials. Requesting `viewer` or `auto` for a non-managed seed (via flag or the `managedSeeds` default) returns an error.
-
-> [!NOTE]
-> `auto` returns admin whenever your RBAC allows it. If you want guaranteed read-only access, configure `viewer` explicitly.
-
-#### Verifying which access level is in use
-
-When `gardenctl` explicitly chose an access level (via flag or per-garden config), it surfaces it inline after `target` and on stderr after `kubeconfig`:
-
-```console
-$ gardenctl target shoot prod-cluster --access-level=viewer
-Successfully targeted shoot "prod-cluster" (access level: viewer)
-```
-
-When neither a flag nor a per-garden config is set, `gardenctl` stays silent and lets `gardenlogin`'s own default apply (currently `auto`).
-
-For an explicit check, the access level is also embedded as a `--access-level=…` argument in the produced kubeconfig's exec plugin section (omitted when `gardenctl` deferred to `gardenlogin`'s default):
-
-```bash
-gardenctl kubeconfig | grep -- '--access-level='
-```
+`gardenctl` can request admin/viewer/auto kubeconfigs from `gardenlogin` per target scope (shoots, seeds), with per-garden defaults and per-invocation overrides via `--access-level` / `--admin` / `--viewer`. See [docs/config/access-level.md](docs/config/access-level.md) for the full reference.
 
 ### Config Path Overwrite
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,4 +12,5 @@
 
 ### Configuration
 * [Configure Access Restrictions](config/access-restrictions.md)
+* [Kubeconfig Access Level](config/access-level.md)
 

--- a/docs/config/access-level.md
+++ b/docs/config/access-level.md
@@ -1,0 +1,83 @@
+# Kubeconfig Access Level
+
+For shoots and seeds, `gardenctl` requests a kubeconfig from [`gardenlogin`](https://github.com/gardener/gardenlogin) with a configurable access level:
+
+- `admin` - full cluster-admin credentials.
+- `viewer` - read-only credentials with no access to encrypted resources (e.g. Secrets).
+- `auto` - try admin first; fall back to viewer if admin is denied. Convenient when you don't know your RBAC up front; for users who *do* have admin, this is effectively the same as `admin`.
+
+> [!NOTE]
+> `auto` returns admin whenever your RBAC allows it. If you want guaranteed read-only access, configure `viewer` explicitly.
+
+## Per-garden defaults
+
+Set per-scope defaults per garden under `kubeconfigAccessLevelDefaults`. The `shoots` and `seeds` fields are independent - for example, an admin who wants least-privilege access to customer shoots while still keeping admin access for seed-level debugging would set:
+
+```yaml
+gardens:
+  - identity: prd-garden
+    kubeconfig: /path/to/kubeconfig.yaml
+    kubeconfigAccessLevelDefaults:
+      shoots: viewer
+      seeds: admin
+```
+
+The same defaults can be set via the CLI rather than hand-editing the YAML:
+
+```bash
+gardenctl config set-garden prd-garden \
+  --default-shoot-access-level viewer \
+  --default-seed-access-level admin
+```
+
+When neither a flag nor a per-garden config is set, `gardenctl` omits `--access-level` and lets `gardenlogin`'s own default apply (currently `auto`).
+
+## One-off overrides
+
+Override per invocation with `--access-level` (or the `--admin` / `--viewer` shorthands), available on commands that produce a kubeconfig (`target`, `kubeconfig`, `kubectl-env`):
+
+```bash
+gardenctl kubeconfig --admin                       # one-off escalation
+gardenctl target --shoot my-shoot --viewer         # one-off de-escalation
+gardenctl kubeconfig --access-level=auto           # explicit auto (no shorthand)
+```
+
+The shorthands and the full form are mutually exclusive - pass at most one.
+
+> [!NOTE]
+> Flag overrides apply only to the invocation they're passed to. They are not persisted on disk, so a subsequent `gardenctl kubeconfig` (without a flag) re-resolves from the per-garden config defaults, not from the flag you passed to an earlier `gardenctl target`. For persistent changes set them via `gardenctl config set-garden`. You may also repeat the flags on `gardenctl kubeconfig`.
+
+## Scope resolution
+
+| You target... | Scope applied |
+|---|---|
+| `target shoot foo` (regular shoot) | `shoots` |
+| `target seed bar` (managed seed) | `seeds` |
+| `target shoot foo` where `foo` also backs a managed seed | `seeds` |
+| `--control-plane` of a shoot | `seeds` (the underlying cluster *is* the seed) |
+
+The "shoot that backs a managed seed" case is the non-obvious one: such a shoot **is** the seed cluster physically, so `target shoot foo` and `target seed foo` resolve to the same scope. Without this, setting `shoots: viewer` would silently leave managed-seed-backing shoots at whatever the `seeds:` policy is, which would be surprising.
+
+## What the access level does *not* apply to
+
+- The **garden cluster itself** - gardenctl uses your own kubeconfig as configured. There is no API to "downgrade" those credentials; if you want viewer-only access to the garden, point gardenctl at a kubeconfig whose underlying RBAC is read-only.
+- **Non-managed seeds** - credentials come from a static `<name>.login` Secret in the garden cluster, of unknown privilege from gardenctl's perspective. Requesting `viewer` for a non-managed seed (via flag or the `seeds` default) returns an error rather than silently producing a kubeconfig that might not actually be read-only. `admin` and `auto` fall through to the static kubeconfig as-is.
+
+## Verifying which access level is in use
+
+When `gardenctl` explicitly chose an access level (via flag or per-garden config), it surfaces it inline after `target` and on stderr after `kubeconfig`:
+
+```console
+$ gardenctl target shoot prod-cluster --access-level=viewer
+Successfully targeted shoot "prod-cluster" (access level: viewer)
+```
+
+For an explicit check, the access level is also embedded as a `--access-level=…` argument in the produced kubeconfig's exec plugin section (omitted when `gardenctl` deferred to `gardenlogin`'s default):
+
+```bash
+gardenctl kubeconfig | grep -- '--access-level='
+```
+
+## `kubectl-env` and symlink mode
+
+`kubectl-env` honors `--access-level` only when `linkKubeconfig: false` is configured. In symlink mode (the default), `kubectl-env` just points `KUBECONFIG` at the existing session kubeconfig - re-run `gardenctl target ... --access-level=…` to change the level instead.

--- a/docs/help/gardenctl_config_set-garden.md
+++ b/docs/help/gardenctl_config_set-garden.md
@@ -24,21 +24,26 @@ CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonp
 gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
 
 # configure my-garden with a context and patterns
-gardenctl config set-garden my-garden --context garden-context --pattern "^(?:landscape-dev/)?shoot--(?P<project>.+)--(?P<shoot>.+)$" --pattern "https://dashboard\.gardener\.cloud/namespace/(?P<namespace>[^/]+)/shoots/(?P<shoot>[^/]+)
+gardenctl config set-garden my-garden --context garden-context --pattern "^(?:landscape-dev/)?shoot--(?P<project>.+)--(?P<shoot>.+)$" --pattern "https://dashboard\.gardener\.cloud/namespace/(?P<namespace>[^/]+)/shoots/(?P<shoot>[^/]+)"
+
+# configure prd-garden so shoot kubeconfigs default to read-only viewer access (managed seed access stays at admin)
+gardenctl config set-garden prd-garden --default-shoot-access-level viewer
 ```
 
 ### Options
 
 ```
-      --alias string          unique alias of this Garden that can be used instead of the name to target this Garden
-      --context string        override the current-context of the garden cluster kubeconfig
-  -h, --help                  help for set-garden
-      --kubeconfig string     path to kubeconfig file for this Garden cluster
-      --pattern stringArray   define regex match patterns for this garden for custom input formats for targeting.
-                              Use named capturing groups to match target values.
-                              Supported capturing groups: project, namespace, shoot.
-                              Note that if you set this flag it will overwrite the pattern list in the config file.
-                              You may specify any number of extra patterns.
+      --alias string                               unique alias of this Garden that can be used instead of the name to target this Garden
+      --context string                             override the current-context of the garden cluster kubeconfig
+      --default-managed-seed-access-level string   default kubeconfig access level when targeting managed seeds in this garden. One of "admin", "viewer", "auto". Pass an empty value to reset to the built-in default ("admin").
+      --default-shoot-access-level string          default kubeconfig access level when targeting shoots in this garden. One of "admin", "viewer", "auto". Pass an empty value to reset to the built-in default ("admin").
+  -h, --help                                       help for set-garden
+      --kubeconfig string                          path to kubeconfig file for this Garden cluster
+      --pattern stringArray                        define regex match patterns for this garden for custom input formats for targeting.
+                                                   Use named capturing groups to match target values.
+                                                   Supported capturing groups: project, namespace, shoot.
+                                                   Note that if you set this flag it will overwrite the pattern list in the config file.
+                                                   You may specify any number of extra patterns.
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_config_set-garden.md
+++ b/docs/help/gardenctl_config_set-garden.md
@@ -26,24 +26,24 @@ gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
 # configure my-garden with a context and patterns
 gardenctl config set-garden my-garden --context garden-context --pattern "^(?:landscape-dev/)?shoot--(?P<project>.+)--(?P<shoot>.+)$" --pattern "https://dashboard\.gardener\.cloud/namespace/(?P<namespace>[^/]+)/shoots/(?P<shoot>[^/]+)"
 
-# configure prd-garden so shoot kubeconfigs default to read-only viewer access (managed seed access stays at admin)
+# configure prd-garden so shoot kubeconfigs default to read-only viewer access (seed access stays at admin)
 gardenctl config set-garden prd-garden --default-shoot-access-level viewer
 ```
 
 ### Options
 
 ```
-      --alias string                               unique alias of this Garden that can be used instead of the name to target this Garden
-      --context string                             override the current-context of the garden cluster kubeconfig
-      --default-managed-seed-access-level string   default kubeconfig access level when targeting managed seeds in this garden. One of "admin", "viewer", "auto". Pass an empty value to reset to the built-in default ("admin").
-      --default-shoot-access-level string          default kubeconfig access level when targeting shoots in this garden. One of "admin", "viewer", "auto". Pass an empty value to reset to the built-in default ("admin").
-  -h, --help                                       help for set-garden
-      --kubeconfig string                          path to kubeconfig file for this Garden cluster
-      --pattern stringArray                        define regex match patterns for this garden for custom input formats for targeting.
-                                                   Use named capturing groups to match target values.
-                                                   Supported capturing groups: project, namespace, shoot.
-                                                   Note that if you set this flag it will overwrite the pattern list in the config file.
-                                                   You may specify any number of extra patterns.
+      --alias string                        unique alias of this Garden that can be used instead of the name to target this Garden
+      --context string                      override the current-context of the garden cluster kubeconfig
+      --default-seed-access-level string    default kubeconfig access level when targeting seeds in this garden (and shoots that back a managed seed, since they physically are the seed cluster). One of "admin", "viewer", "auto". Pass an empty value to reset to the built-in default ("admin").
+      --default-shoot-access-level string   default kubeconfig access level when targeting shoots in this garden. One of "admin", "viewer", "auto". Pass an empty value to reset to the built-in default ("admin").
+  -h, --help                                help for set-garden
+      --kubeconfig string                   path to kubeconfig file for this Garden cluster
+      --pattern stringArray                 define regex match patterns for this garden for custom input formats for targeting.
+                                            Use named capturing groups to match target values.
+                                            Supported capturing groups: project, namespace, shoot.
+                                            Note that if you set this flag it will overwrite the pattern list in the config file.
+                                            You may specify any number of extra patterns.
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_config_set-garden.md
+++ b/docs/help/gardenctl_config_set-garden.md
@@ -35,8 +35,8 @@ gardenctl config set-garden prd-garden --default-shoot-access-level viewer
 ```
       --alias string                        unique alias of this Garden that can be used instead of the name to target this Garden
       --context string                      override the current-context of the garden cluster kubeconfig
-      --default-seed-access-level string    default kubeconfig access level when targeting seeds in this garden (and shoots that back a managed seed, since they physically are the seed cluster). One of "admin", "viewer", "auto". Pass an empty value to reset to the built-in default ("admin").
-      --default-shoot-access-level string   default kubeconfig access level when targeting shoots in this garden. One of "admin", "viewer", "auto". Pass an empty value to reset to the built-in default ("admin").
+      --default-seed-access-level string    default kubeconfig access level when targeting seeds in this garden (and shoots that back a managed seed, since they physically are the seed cluster). One of "admin", "viewer", "auto". Pass an empty value to unset and delegate to gardenlogin's default.
+      --default-shoot-access-level string   default kubeconfig access level when targeting shoots in this garden. One of "admin", "viewer", "auto". Pass an empty value to unset and delegate to gardenlogin's default.
   -h, --help                                help for set-garden
       --kubeconfig string                   path to kubeconfig file for this Garden cluster
       --pattern stringArray                 define regex match patterns for this garden for custom input formats for targeting.

--- a/docs/help/gardenctl_kubeconfig.md
+++ b/docs/help/gardenctl_kubeconfig.md
@@ -25,20 +25,21 @@ gardenctl kubeconfig --garden my-garden --project my-project
 ### Options
 
 ```
-      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
-      --context string                The name of the kubeconfig context to use
-      --control-plane                 target control plane of shoot, use together with shoot argument
-      --flatten                       Flatten the resulting kubeconfig file into self-contained output (useful for creating portable kubeconfig files)
-      --garden string                 target the given garden cluster
-  -h, --help                          help for kubeconfig
-      --minify                        Remove all information not used by current-context from the output
-  -o, --output string                 Output format. One of: (json, yaml, kyaml, name, go-template, go-template-file, template, templatefile, jsonpath, jsonpath-as-json, jsonpath-file). (default "yaml")
-      --project string                target the given project
-      --raw                           Display raw byte data
-      --seed string                   target the given seed cluster
-      --shoot string                  target the given shoot cluster
-      --show-managed-fields           If true, keep the managedFields when printing objects in JSON or YAML format.
-      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+      --allow-missing-template-keys      If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+      --context string                   The name of the kubeconfig context to use
+      --control-plane                    target control plane of shoot, use together with shoot argument
+      --flatten                          Flatten the resulting kubeconfig file into self-contained output (useful for creating portable kubeconfig files)
+      --garden string                    target the given garden cluster
+  -h, --help                             help for kubeconfig
+      --kubeconfig-access-level string   Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --minify                           Remove all information not used by current-context from the output
+  -o, --output string                    Output format. One of: (json, yaml, kyaml, name, go-template, go-template-file, template, templatefile, jsonpath, jsonpath-as-json, jsonpath-file). (default "yaml")
+      --project string                   target the given project
+      --raw                              Display raw byte data
+      --seed string                      target the given seed cluster
+      --shoot string                     target the given shoot cluster
+      --show-managed-fields              If true, keep the managedFields when printing objects in JSON or YAML format.
+      --template string                  Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_kubeconfig.md
+++ b/docs/help/gardenctl_kubeconfig.md
@@ -25,6 +25,7 @@ gardenctl kubeconfig --garden my-garden --project my-project
 ### Options
 
 ```
+      --admin                            shorthand for --kubeconfig-access-level=admin
       --allow-missing-template-keys      If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
       --context string                   The name of the kubeconfig context to use
       --control-plane                    target control plane of shoot, use together with shoot argument
@@ -40,6 +41,7 @@ gardenctl kubeconfig --garden my-garden --project my-project
       --shoot string                     target the given shoot cluster
       --show-managed-fields              If true, keep the managedFields when printing objects in JSON or YAML format.
       --template string                  Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+      --viewer                           shorthand for --kubeconfig-access-level=viewer
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_kubeconfig.md
+++ b/docs/help/gardenctl_kubeconfig.md
@@ -25,23 +25,23 @@ gardenctl kubeconfig --garden my-garden --project my-project
 ### Options
 
 ```
-      --admin                            shorthand for --kubeconfig-access-level=admin
-      --allow-missing-template-keys      If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
-      --context string                   The name of the kubeconfig context to use
-      --control-plane                    target control plane of shoot, use together with shoot argument
-      --flatten                          Flatten the resulting kubeconfig file into self-contained output (useful for creating portable kubeconfig files)
-      --garden string                    target the given garden cluster
-  -h, --help                             help for kubeconfig
-      --kubeconfig-access-level string   Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
-      --minify                           Remove all information not used by current-context from the output
-  -o, --output string                    Output format. One of: (json, yaml, kyaml, name, go-template, go-template-file, template, templatefile, jsonpath, jsonpath-as-json, jsonpath-file). (default "yaml")
-      --project string                   target the given project
-      --raw                              Display raw byte data
-      --seed string                      target the given seed cluster
-      --shoot string                     target the given shoot cluster
-      --show-managed-fields              If true, keep the managedFields when printing objects in JSON or YAML format.
-      --template string                  Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
-      --viewer                           shorthand for --kubeconfig-access-level=viewer
+      --access-level string           Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --admin                         shorthand for --access-level=admin
+      --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
+      --context string                The name of the kubeconfig context to use
+      --control-plane                 target control plane of shoot, use together with shoot argument
+      --flatten                       Flatten the resulting kubeconfig file into self-contained output (useful for creating portable kubeconfig files)
+      --garden string                 target the given garden cluster
+  -h, --help                          help for kubeconfig
+      --minify                        Remove all information not used by current-context from the output
+  -o, --output string                 Output format. One of: (json, yaml, kyaml, name, go-template, go-template-file, template, templatefile, jsonpath, jsonpath-as-json, jsonpath-file). (default "yaml")
+      --project string                target the given project
+      --raw                           Display raw byte data
+      --seed string                   target the given seed cluster
+      --shoot string                  target the given shoot cluster
+      --show-managed-fields           If true, keep the managedFields when printing objects in JSON or YAML format.
+      --template string               Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
+      --viewer                        shorthand for --access-level=viewer
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_kubeconfig.md
+++ b/docs/help/gardenctl_kubeconfig.md
@@ -25,7 +25,7 @@ gardenctl kubeconfig --garden my-garden --project my-project
 ### Options
 
 ```
-      --access-level string           Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --access-level string           Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --admin                         shorthand for --access-level=admin
       --allow-missing-template-keys   If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats. (default true)
       --context string                The name of the kubeconfig context to use

--- a/docs/help/gardenctl_kubectl-env.md
+++ b/docs/help/gardenctl_kubectl-env.md
@@ -13,9 +13,8 @@ For details on how to use the printed shell script, such as applying it temporar
 ### Options
 
 ```
-  -h, --help                             help for kubectl-env
-      --kubeconfig-access-level string   Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
-  -u, --unset                            Generate the script to unset the KUBECONFIG environment variable for 
+  -h, --help    help for kubectl-env
+  -u, --unset   Generate the script to unset the KUBECONFIG environment variable for 
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_kubectl-env.md
+++ b/docs/help/gardenctl_kubectl-env.md
@@ -13,8 +13,9 @@ For details on how to use the printed shell script, such as applying it temporar
 ### Options
 
 ```
-  -h, --help    help for kubectl-env
-  -u, --unset   Generate the script to unset the KUBECONFIG environment variable for 
+  -h, --help                             help for kubectl-env
+      --kubeconfig-access-level string   Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+  -u, --unset                            Generate the script to unset the KUBECONFIG environment variable for 
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_kubectl-env.md
+++ b/docs/help/gardenctl_kubectl-env.md
@@ -9,12 +9,17 @@ Generate a script that points KUBECONFIG to the currently targeted shoot, seed, 
 Each sub-command produces a shell-specific script.
 For details on how to use the printed shell script, such as applying it temporarily to your current session or permanently through your shell's startup file, refer to the corresponding sub-command's help.
 
+Note: --access-level only has an effect when linkKubeconfig is false. In symlink mode (the default) this command just points KUBECONFIG at the existing session kubeconfig, so the access level is whatever the most recent `gardenctl target` chose.
+
 
 ### Options
 
 ```
-  -h, --help    help for kubectl-env
-  -u, --unset   Generate the script to unset the KUBECONFIG environment variable for 
+      --access-level string   Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
+      --admin                 shorthand for --access-level=admin
+  -h, --help                  help for kubectl-env
+  -u, --unset                 Generate the script to unset the KUBECONFIG environment variable for 
+      --viewer                shorthand for --access-level=viewer
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_kubectl-env_bash.md
+++ b/docs/help/gardenctl_kubectl-env_bash.md
@@ -29,7 +29,6 @@ gardenctl kubectl-env bash [flags]
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
-      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_kubectl-env_bash.md
+++ b/docs/help/gardenctl_kubectl-env_bash.md
@@ -29,6 +29,7 @@ gardenctl kubectl-env bash [flags]
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
+      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_kubectl-env_bash.md
+++ b/docs/help/gardenctl_kubectl-env_bash.md
@@ -25,7 +25,9 @@ gardenctl kubectl-env bash [flags]
 ### Options inherited from parent commands
 
 ```
+      --access-level string                 Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
+      --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
@@ -41,6 +43,7 @@ gardenctl kubectl-env bash [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -u, --unset                               Generate the script to unset the KUBECONFIG environment variable for 
   -v, --v Level                             number for the log level verbosity
+      --viewer                              shorthand for --access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_kubectl-env_fish.md
+++ b/docs/help/gardenctl_kubectl-env_fish.md
@@ -29,7 +29,6 @@ gardenctl kubectl-env fish [flags]
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
-      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_kubectl-env_fish.md
+++ b/docs/help/gardenctl_kubectl-env_fish.md
@@ -29,6 +29,7 @@ gardenctl kubectl-env fish [flags]
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
+      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_kubectl-env_fish.md
+++ b/docs/help/gardenctl_kubectl-env_fish.md
@@ -25,7 +25,9 @@ gardenctl kubectl-env fish [flags]
 ### Options inherited from parent commands
 
 ```
+      --access-level string                 Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
+      --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
@@ -41,6 +43,7 @@ gardenctl kubectl-env fish [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -u, --unset                               Generate the script to unset the KUBECONFIG environment variable for 
   -v, --v Level                             number for the log level verbosity
+      --viewer                              shorthand for --access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_kubectl-env_powershell.md
+++ b/docs/help/gardenctl_kubectl-env_powershell.md
@@ -29,6 +29,7 @@ gardenctl kubectl-env powershell [flags]
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
+      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_kubectl-env_powershell.md
+++ b/docs/help/gardenctl_kubectl-env_powershell.md
@@ -29,7 +29,6 @@ gardenctl kubectl-env powershell [flags]
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
-      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_kubectl-env_powershell.md
+++ b/docs/help/gardenctl_kubectl-env_powershell.md
@@ -25,7 +25,9 @@ gardenctl kubectl-env powershell [flags]
 ### Options inherited from parent commands
 
 ```
+      --access-level string                 Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
+      --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
@@ -41,6 +43,7 @@ gardenctl kubectl-env powershell [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -u, --unset                               Generate the script to unset the KUBECONFIG environment variable for 
   -v, --v Level                             number for the log level verbosity
+      --viewer                              shorthand for --access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_kubectl-env_zsh.md
+++ b/docs/help/gardenctl_kubectl-env_zsh.md
@@ -29,6 +29,7 @@ gardenctl kubectl-env zsh [flags]
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
+      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_kubectl-env_zsh.md
+++ b/docs/help/gardenctl_kubectl-env_zsh.md
@@ -29,7 +29,6 @@ gardenctl kubectl-env zsh [flags]
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
-      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_kubectl-env_zsh.md
+++ b/docs/help/gardenctl_kubectl-env_zsh.md
@@ -25,7 +25,9 @@ gardenctl kubectl-env zsh [flags]
 ### Options inherited from parent commands
 
 ```
+      --access-level string                 Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
+      --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
@@ -41,6 +43,7 @@ gardenctl kubectl-env zsh [flags]
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -u, --unset                               Generate the script to unset the KUBECONFIG environment variable for 
   -v, --v Level                             number for the log level verbosity
+      --viewer                              shorthand for --access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_ssh-patch.md
+++ b/docs/help/gardenctl_ssh-patch.md
@@ -19,13 +19,14 @@ gardenctl ssh-patch cli-xxxxxxxx
 ### Options
 
 ```
-      --cidr stringArray   CIDRs to allow access to the bastion host; if not given, your system's public IPs (v4 and v6) are auto-detected.
-      --control-plane      target control plane of shoot, use together with shoot argument
-      --garden string      target the given garden cluster
-  -h, --help               help for ssh-patch
-      --project string     target the given project
-      --seed string        target the given seed cluster
-      --shoot string       target the given shoot cluster
+      --cidr stringArray                 CIDRs to allow access to the bastion host; if not given, your system's public IPs (v4 and v6) are auto-detected.
+      --control-plane                    target control plane of shoot, use together with shoot argument
+      --garden string                    target the given garden cluster
+  -h, --help                             help for ssh-patch
+      --kubeconfig-access-level string   Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --project string                   target the given project
+      --seed string                      target the given seed cluster
+      --shoot string                     target the given shoot cluster
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_ssh-patch.md
+++ b/docs/help/gardenctl_ssh-patch.md
@@ -19,14 +19,13 @@ gardenctl ssh-patch cli-xxxxxxxx
 ### Options
 
 ```
-      --cidr stringArray                 CIDRs to allow access to the bastion host; if not given, your system's public IPs (v4 and v6) are auto-detected.
-      --control-plane                    target control plane of shoot, use together with shoot argument
-      --garden string                    target the given garden cluster
-  -h, --help                             help for ssh-patch
-      --kubeconfig-access-level string   Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
-      --project string                   target the given project
-      --seed string                      target the given seed cluster
-      --shoot string                     target the given shoot cluster
+      --cidr stringArray   CIDRs to allow access to the bastion host; if not given, your system's public IPs (v4 and v6) are auto-detected.
+      --control-plane      target control plane of shoot, use together with shoot argument
+      --garden string      target the given garden cluster
+  -h, --help               help for ssh-patch
+      --project string     target the given project
+      --seed string        target the given seed cluster
+      --shoot string       target the given shoot cluster
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_ssh.md
+++ b/docs/help/gardenctl_ssh.md
@@ -51,7 +51,6 @@ gardenctl ssh --keep-bastion --bastion-name cli-xxxxxxxx --public-key-file /path
   -h, --help                                      help for ssh
       --interactive                               Open an SSH connection instead of just providing the bastion host (only if NODE_NAME is provided). (default true)
       --keep-bastion                              Do not delete immediately when gardenctl exits (Bastions will be garbage-collected after some time)
-      --kubeconfig-access-level string            Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --no-keepalive                              Exit after the bastion host became available without keeping the bastion alive or establishing an SSH connection. Note that this flag requires the flags --interactive=false and --keep-bastion to be set
       --node-strict-host-key-checking string      Specifies how the SSH client performs host key checking for the shoot node. Valid options are 'yes', 'no', or 'ask'. (default "ask")
       --node-user-known-hosts-file strings        Path to a custom known hosts file for verifying remote hosts' public keys during SSH connection to the shoot node. If not provided, defaults to <garden_home_dir>/cache/<shoot_uid>/.ssh/known_hosts.

--- a/docs/help/gardenctl_ssh.md
+++ b/docs/help/gardenctl_ssh.md
@@ -51,6 +51,7 @@ gardenctl ssh --keep-bastion --bastion-name cli-xxxxxxxx --public-key-file /path
   -h, --help                                      help for ssh
       --interactive                               Open an SSH connection instead of just providing the bastion host (only if NODE_NAME is provided). (default true)
       --keep-bastion                              Do not delete immediately when gardenctl exits (Bastions will be garbage-collected after some time)
+      --kubeconfig-access-level string            Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --no-keepalive                              Exit after the bastion host became available without keeping the bastion alive or establishing an SSH connection. Note that this flag requires the flags --interactive=false and --keep-bastion to be set
       --node-strict-host-key-checking string      Specifies how the SSH client performs host key checking for the shoot node. Valid options are 'yes', 'no', or 'ask'. (default "ask")
       --node-user-known-hosts-file strings        Path to a custom known hosts file for verifying remote hosts' public keys during SSH connection to the shoot node. If not provided, defaults to <garden_home_dir>/cache/<shoot_uid>/.ssh/known_hosts.

--- a/docs/help/gardenctl_target.md
+++ b/docs/help/gardenctl_target.md
@@ -22,15 +22,15 @@ gardenctl target value/that/matches/pattern --control-plane
 ### Options
 
 ```
-      --admin                            shorthand for --kubeconfig-access-level=admin
-      --control-plane                    target control plane of shoot, use together with shoot argument
-      --garden string                    target the given garden cluster
-  -h, --help                             help for target
-      --kubeconfig-access-level string   Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
-      --project string                   target the given project
-      --seed string                      target the given seed cluster
-      --shoot string                     target the given shoot cluster
-      --viewer                           shorthand for --kubeconfig-access-level=viewer
+      --access-level string   Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --admin                 shorthand for --access-level=admin
+      --control-plane         target control plane of shoot, use together with shoot argument
+      --garden string         target the given garden cluster
+  -h, --help                  help for target
+      --project string        target the given project
+      --seed string           target the given seed cluster
+      --shoot string          target the given shoot cluster
+      --viewer                shorthand for --access-level=viewer
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_target.md
+++ b/docs/help/gardenctl_target.md
@@ -22,12 +22,13 @@ gardenctl target value/that/matches/pattern --control-plane
 ### Options
 
 ```
-      --control-plane    target control plane of shoot, use together with shoot argument
-      --garden string    target the given garden cluster
-  -h, --help             help for target
-      --project string   target the given project
-      --seed string      target the given seed cluster
-      --shoot string     target the given shoot cluster
+      --control-plane                    target control plane of shoot, use together with shoot argument
+      --garden string                    target the given garden cluster
+  -h, --help                             help for target
+      --kubeconfig-access-level string   Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --project string                   target the given project
+      --seed string                      target the given seed cluster
+      --shoot string                     target the given shoot cluster
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_target.md
+++ b/docs/help/gardenctl_target.md
@@ -22,6 +22,7 @@ gardenctl target value/that/matches/pattern --control-plane
 ### Options
 
 ```
+      --admin                            shorthand for --kubeconfig-access-level=admin
       --control-plane                    target control plane of shoot, use together with shoot argument
       --garden string                    target the given garden cluster
   -h, --help                             help for target
@@ -29,6 +30,7 @@ gardenctl target value/that/matches/pattern --control-plane
       --project string                   target the given project
       --seed string                      target the given seed cluster
       --shoot string                     target the given shoot cluster
+      --viewer                           shorthand for --kubeconfig-access-level=viewer
 ```
 
 ### Options inherited from parent commands

--- a/docs/help/gardenctl_target.md
+++ b/docs/help/gardenctl_target.md
@@ -22,7 +22,7 @@ gardenctl target value/that/matches/pattern --control-plane
 ### Options
 
 ```
-      --access-level string   Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --access-level string   Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --admin                 shorthand for --access-level=admin
       --control-plane         target control plane of shoot, use together with shoot argument
       --garden string         target the given garden cluster

--- a/docs/help/gardenctl_target_control-plane.md
+++ b/docs/help/gardenctl_target_control-plane.md
@@ -34,6 +34,7 @@ gardenctl target control-plane --garden my-garden --project my-project --shoot m
 
 ```
       --add-dir-header                      If true, adds the file directory to the header of the log messages
+      --admin                               shorthand for --kubeconfig-access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
@@ -49,6 +50,7 @@ gardenctl target control-plane --garden my-garden --project my-project --shoot m
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
+      --viewer                              shorthand for --kubeconfig-access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_control-plane.md
+++ b/docs/help/gardenctl_target_control-plane.md
@@ -37,6 +37,7 @@ gardenctl target control-plane --garden my-garden --project my-project --shoot m
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
+      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_control-plane.md
+++ b/docs/help/gardenctl_target_control-plane.md
@@ -33,12 +33,12 @@ gardenctl target control-plane --garden my-garden --project my-project --shoot m
 ### Options inherited from parent commands
 
 ```
+      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
-      --admin                               shorthand for --kubeconfig-access-level=admin
+      --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
-      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)
@@ -50,7 +50,7 @@ gardenctl target control-plane --garden my-garden --project my-project --shoot m
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
-      --viewer                              shorthand for --kubeconfig-access-level=viewer
+      --viewer                              shorthand for --access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_control-plane.md
+++ b/docs/help/gardenctl_target_control-plane.md
@@ -33,7 +33,7 @@ gardenctl target control-plane --garden my-garden --project my-project --shoot m
 ### Options inherited from parent commands
 
 ```
-      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --access-level string                 Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
       --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_garden.md
+++ b/docs/help/gardenctl_target_garden.md
@@ -26,12 +26,12 @@ gardenctl target garden my-garden
 ### Options inherited from parent commands
 
 ```
+      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
-      --admin                               shorthand for --kubeconfig-access-level=admin
+      --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
-      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)
@@ -43,7 +43,7 @@ gardenctl target garden my-garden
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
-      --viewer                              shorthand for --kubeconfig-access-level=viewer
+      --viewer                              shorthand for --access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_garden.md
+++ b/docs/help/gardenctl_target_garden.md
@@ -30,6 +30,7 @@ gardenctl target garden my-garden
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
+      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_garden.md
+++ b/docs/help/gardenctl_target_garden.md
@@ -27,6 +27,7 @@ gardenctl target garden my-garden
 
 ```
       --add-dir-header                      If true, adds the file directory to the header of the log messages
+      --admin                               shorthand for --kubeconfig-access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
@@ -42,6 +43,7 @@ gardenctl target garden my-garden
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
+      --viewer                              shorthand for --kubeconfig-access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_garden.md
+++ b/docs/help/gardenctl_target_garden.md
@@ -26,7 +26,7 @@ gardenctl target garden my-garden
 ### Options inherited from parent commands
 
 ```
-      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --access-level string                 Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
       --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_project.md
+++ b/docs/help/gardenctl_target_project.md
@@ -30,12 +30,12 @@ gardenctl target project my-project --garden my-garden
 ### Options inherited from parent commands
 
 ```
+      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
-      --admin                               shorthand for --kubeconfig-access-level=admin
+      --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
-      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)
@@ -47,7 +47,7 @@ gardenctl target project my-project --garden my-garden
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
-      --viewer                              shorthand for --kubeconfig-access-level=viewer
+      --viewer                              shorthand for --access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_project.md
+++ b/docs/help/gardenctl_target_project.md
@@ -31,6 +31,7 @@ gardenctl target project my-project --garden my-garden
 
 ```
       --add-dir-header                      If true, adds the file directory to the header of the log messages
+      --admin                               shorthand for --kubeconfig-access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
@@ -46,6 +47,7 @@ gardenctl target project my-project --garden my-garden
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
+      --viewer                              shorthand for --kubeconfig-access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_project.md
+++ b/docs/help/gardenctl_target_project.md
@@ -34,6 +34,7 @@ gardenctl target project my-project --garden my-garden
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
+      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_project.md
+++ b/docs/help/gardenctl_target_project.md
@@ -30,7 +30,7 @@ gardenctl target project my-project --garden my-garden
 ### Options inherited from parent commands
 
 ```
-      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --access-level string                 Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
       --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_seed.md
+++ b/docs/help/gardenctl_target_seed.md
@@ -30,12 +30,12 @@ gardenctl target seed my-seed --garden my-garden
 ### Options inherited from parent commands
 
 ```
+      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
-      --admin                               shorthand for --kubeconfig-access-level=admin
+      --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
-      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)
@@ -47,7 +47,7 @@ gardenctl target seed my-seed --garden my-garden
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
-      --viewer                              shorthand for --kubeconfig-access-level=viewer
+      --viewer                              shorthand for --access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_seed.md
+++ b/docs/help/gardenctl_target_seed.md
@@ -31,6 +31,7 @@ gardenctl target seed my-seed --garden my-garden
 
 ```
       --add-dir-header                      If true, adds the file directory to the header of the log messages
+      --admin                               shorthand for --kubeconfig-access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
@@ -46,6 +47,7 @@ gardenctl target seed my-seed --garden my-garden
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
+      --viewer                              shorthand for --kubeconfig-access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_seed.md
+++ b/docs/help/gardenctl_target_seed.md
@@ -34,6 +34,7 @@ gardenctl target seed my-seed --garden my-garden
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
+      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_seed.md
+++ b/docs/help/gardenctl_target_seed.md
@@ -30,7 +30,7 @@ gardenctl target seed my-seed --garden my-garden
 ### Options inherited from parent commands
 
 ```
-      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --access-level string                 Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
       --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_shoot.md
+++ b/docs/help/gardenctl_target_shoot.md
@@ -32,12 +32,12 @@ gardenctl target shoot my-shoot --garden my-garden --project my-project
 ### Options inherited from parent commands
 
 ```
+      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
-      --admin                               shorthand for --kubeconfig-access-level=admin
+      --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
-      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)
@@ -49,7 +49,7 @@ gardenctl target shoot my-shoot --garden my-garden --project my-project
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
-      --viewer                              shorthand for --kubeconfig-access-level=viewer
+      --viewer                              shorthand for --access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_shoot.md
+++ b/docs/help/gardenctl_target_shoot.md
@@ -33,6 +33,7 @@ gardenctl target shoot my-shoot --garden my-garden --project my-project
 
 ```
       --add-dir-header                      If true, adds the file directory to the header of the log messages
+      --admin                               shorthand for --kubeconfig-access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
@@ -48,6 +49,7 @@ gardenctl target shoot my-shoot --garden my-garden --project my-project
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
+      --viewer                              shorthand for --kubeconfig-access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_shoot.md
+++ b/docs/help/gardenctl_target_shoot.md
@@ -36,6 +36,7 @@ gardenctl target shoot my-shoot --garden my-garden --project my-project
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
+      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_shoot.md
+++ b/docs/help/gardenctl_target_shoot.md
@@ -32,7 +32,7 @@ gardenctl target shoot my-shoot --garden my-garden --project my-project
 ### Options inherited from parent commands
 
 ```
-      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --access-level string                 Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
       --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_unset.md
+++ b/docs/help/gardenctl_target_unset.md
@@ -26,6 +26,7 @@ gardenctl target unset garden
 
 ```
       --add-dir-header                      If true, adds the file directory to the header of the log messages
+      --admin                               shorthand for --kubeconfig-access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
@@ -41,6 +42,7 @@ gardenctl target unset garden
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
+      --viewer                              shorthand for --kubeconfig-access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_unset.md
+++ b/docs/help/gardenctl_target_unset.md
@@ -29,6 +29,7 @@ gardenctl target unset garden
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
+      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_unset.md
+++ b/docs/help/gardenctl_target_unset.md
@@ -25,12 +25,12 @@ gardenctl target unset garden
 ### Options inherited from parent commands
 
 ```
+      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
-      --admin                               shorthand for --kubeconfig-access-level=admin
+      --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
-      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)
@@ -42,7 +42,7 @@ gardenctl target unset garden
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
-      --viewer                              shorthand for --kubeconfig-access-level=viewer
+      --viewer                              shorthand for --access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_unset.md
+++ b/docs/help/gardenctl_target_unset.md
@@ -25,7 +25,7 @@ gardenctl target unset garden
 ### Options inherited from parent commands
 
 ```
-      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --access-level string                 Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
       --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_view.md
+++ b/docs/help/gardenctl_target_view.md
@@ -22,6 +22,7 @@ gardenctl target view [flags]
 
 ```
       --add-dir-header                      If true, adds the file directory to the header of the log messages
+      --admin                               shorthand for --kubeconfig-access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
@@ -37,6 +38,7 @@ gardenctl target view [flags]
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
+      --viewer                              shorthand for --kubeconfig-access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_view.md
+++ b/docs/help/gardenctl_target_view.md
@@ -21,12 +21,12 @@ gardenctl target view [flags]
 ### Options inherited from parent commands
 
 ```
+      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
-      --admin                               shorthand for --kubeconfig-access-level=admin
+      --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
-      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)
@@ -38,7 +38,7 @@ gardenctl target view [flags]
       --skip-log-headers                    If true, avoid headers when opening log files (no effect when -logtostderr=true)
       --stderrthreshold severity            logs at or above this threshold go to stderr when writing to files and stderr (no effect when -logtostderr=true or -alsologtostderr=true unless -legacy_stderr_threshold_behavior=false) (default 2)
   -v, --v Level                             number for the log level verbosity
-      --viewer                              shorthand for --kubeconfig-access-level=viewer
+      --viewer                              shorthand for --access-level=viewer
       --vmodule moduleSpec                  comma-separated list of pattern=N settings for file-filtered logging
 ```
 

--- a/docs/help/gardenctl_target_view.md
+++ b/docs/help/gardenctl_target_view.md
@@ -25,6 +25,7 @@ gardenctl target view [flags]
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)
       --alsologtostderrthreshold severity   logs at or above this threshold go to stderr when -alsologtostderr=true (no effect when -logtostderr=true)
       --config string                       config file (default is ~/.garden/gardenctl-v2.yaml)
+      --kubeconfig-access-level string      Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
       --legacy-stderr-threshold-behavior    If true, stderrthreshold is ignored when logtostderr=true (legacy behavior). If false, stderrthreshold is honored even when logtostderr=true (default true)
       --log-backtrace-at traceLocation      when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                      If non-empty, write log files in this directory (no effect when -logtostderr=true)

--- a/docs/help/gardenctl_target_view.md
+++ b/docs/help/gardenctl_target_view.md
@@ -21,7 +21,7 @@ gardenctl target view [flags]
 ### Options inherited from parent commands
 
 ```
-      --access-level string                 Override default kubeconfig access level for shoots/managed-seeds. One of "admin", "viewer", "auto".
+      --access-level string                 Override the default kubeconfig access level when targeting shoots or seeds. One of "admin", "viewer", "auto".
       --add-dir-header                      If true, adds the file directory to the header of the log messages
       --admin                               shorthand for --access-level=admin
       --alsologtostderr                     log to standard error as well as files (no effect when -logtostderr=true)

--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -618,7 +618,7 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string, acces
 	// the static kubeconfig grants - they depend on the cluster's RBAC.
 	if accessLevel == config.KubeconfigAccessLevelViewer {
 		return nil, fmt.Errorf("seed %q is not a managed seed; gardenlogin's access-level mechanism is unavailable for static seed-login kubeconfigs. "+
-			"Re-run without %q (or with --kubeconfig-access-level=%s) to use the static kubeconfig as-is",
+			"Re-run without %q (or with --access-level=%s) to use the static kubeconfig as-is",
 			name, accessLevel, config.KubeconfigAccessLevelAdmin)
 	}
 

--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -21,6 +21,7 @@ import (
 	corev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	gardensecurityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	gardensecurityclientset "github.com/gardener/gardener/pkg/client/security/clientset/versioned"
 	"github.com/go-jose/go-jose/v4"
@@ -109,6 +110,11 @@ type Client interface {
 	GetConfigMap(ctx context.Context, namespace, name string) (*corev1.ConfigMap, error)
 	// GetShootOfManagedSeed returns shoot of seed using ManagedSeed resource. An error is returned if it is not a managed seed or the referenced shoot is nil
 	GetShootOfManagedSeed(ctx context.Context, name string) (*seedmanagementv1alpha1.Shoot, error)
+	// IsManagedSeed reports whether the shoot identified by (shootNamespace, shootName)
+	// is referenced by a ManagedSeed resource. Uses the spec.shoot.name field
+	// selector rather than relying on the (conventional but not guaranteed)
+	// equality of ManagedSeed and shoot names.
+	IsManagedSeed(ctx context.Context, shootNamespace, shootName string) (bool, error)
 
 	// GetBastion returns a Gardener bastion resource by namespace and name
 	GetBastion(ctx context.Context, namespace, name string) (*operationsv1alpha1.Bastion, error)
@@ -388,6 +394,19 @@ func (g *clientImpl) GetConfigMap(ctx context.Context, namespace, name string) (
 	}
 
 	return cm, nil
+}
+
+func (g *clientImpl) IsManagedSeed(ctx context.Context, shootNamespace, shootName string) (bool, error) {
+	list := &seedmanagementv1alpha1.ManagedSeedList{}
+
+	if err := g.c.List(ctx, list,
+		client.InNamespace(shootNamespace),
+		client.MatchingFields{seedmanagement.ManagedSeedShootName: shootName},
+	); err != nil {
+		return false, err
+	}
+
+	return len(list.Items) > 0, nil
 }
 
 func (g *clientImpl) GetShootOfManagedSeed(ctx context.Context, name string) (*seedmanagementv1alpha1.Shoot, error) {

--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -41,6 +41,8 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
 var decoder runtime.Decoder
@@ -68,8 +70,13 @@ type Client interface {
 	GetSeed(ctx context.Context, name string) (*gardencorev1beta1.Seed, error)
 	// ListSeeds returns all Gardener seed resources
 	ListSeeds(ctx context.Context, opts ...client.ListOption) (*gardencorev1beta1.SeedList, error)
-	// GetSeedClientConfig returns the client config for a seed
-	GetSeedClientConfig(ctx context.Context, name string) (clientcmd.ClientConfig, error)
+	// GetSeedClientConfig returns the client config for a seed.
+	// For managed seeds, accessLevel is honored (the call is delegated to
+	// GetShootClientConfig). For non-managed seeds the kubeconfig comes from a
+	// static <name>.login Secret which only supports admin access - a non-admin
+	// accessLevel returns an error rather than silently producing an admin
+	// kubeconfig. Pass an empty value or "admin" for non-managed seeds.
+	GetSeedClientConfig(ctx context.Context, name string, accessLevel config.KubeconfigAccessLevel) (clientcmd.ClientConfig, error)
 
 	// GetShoot returns a Gardener shoot resource in a namespace by name
 	GetShoot(ctx context.Context, namespace, name string) (*gardencorev1beta1.Shoot, error)
@@ -78,8 +85,10 @@ type Client interface {
 	FindShoot(ctx context.Context, opts ...client.ListOption) (*gardencorev1beta1.Shoot, error)
 	// ListShoots returns all Gardener shoot resources, filtered by a list option
 	ListShoots(ctx context.Context, opts ...client.ListOption) (*gardencorev1beta1.ShootList, error)
-	// GetShootClientConfig returns the client config for a shoot
-	GetShootClientConfig(ctx context.Context, namespace, name string) (clientcmd.ClientConfig, error)
+	// GetShootClientConfig returns the client config for a shoot.
+	// accessLevel selects the gardenlogin --access-level (admin, viewer, auto). An empty
+	// value omits the flag, falling back to gardenlogin's own default.
+	GetShootClientConfig(ctx context.Context, namespace, name string, accessLevel config.KubeconfigAccessLevel) (clientcmd.ClientConfig, error)
 
 	// GetSecretBinding returns a Gardener secretbinding resource
 	GetSecretBinding(ctx context.Context, namespace, name string) (*gardencorev1beta1.SecretBinding, error)
@@ -561,7 +570,7 @@ func (g *clientImpl) CurrentUser(ctx context.Context) (string, error) {
 	return "", fmt.Errorf("could not detect current user")
 }
 
-func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string) (clientcmd.ClientConfig, error) {
+func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string, accessLevel config.KubeconfigAccessLevel) (clientcmd.ClientConfig, error) {
 	logger := klog.FromContext(ctx)
 
 	shoot, err := g.GetShootOfManagedSeed(ctx, name)
@@ -577,7 +586,17 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string) (clie
 			},
 			"seed", name)
 
-		return g.GetShootClientConfig(ctx, "garden", shoot.Name)
+		return g.GetShootClientConfig(ctx, "garden", shoot.Name, accessLevel)
+	}
+
+	// Non-managed seed: kubeconfig comes from a static <name>.login Secret rather
+	// than gardenlogin, so the admin/viewer/auto distinction does not apply.
+	// Reject any explicit non-admin choice rather than silently returning admin -
+	// a silent escalation would defeat the point of asking for viewer.
+	if accessLevel != "" && accessLevel != config.KubeconfigAccessLevelAdmin {
+		return nil, fmt.Errorf("seed %q is not a managed seed; %q kubeconfig access is unavailable (only %q is supported). "+
+			"Re-run with --kubeconfig-access-level=%s to override",
+			name, accessLevel, config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelAdmin)
 	}
 
 	key := types.NamespacedName{Name: name}

--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -608,14 +608,18 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string, acces
 		return g.GetShootClientConfig(ctx, "garden", shoot.Name, accessLevel)
 	}
 
-	// Non-managed seed: kubeconfig comes from a static <name>.login Secret rather
-	// than gardenlogin, so the admin/viewer/auto distinction does not apply.
-	// Reject any explicit non-admin choice rather than silently returning admin -
-	// a silent escalation would defeat the point of asking for viewer.
-	if accessLevel != "" && accessLevel != config.KubeconfigAccessLevelAdmin {
-		return nil, fmt.Errorf("seed %q is not a managed seed; %q kubeconfig access is unavailable (only %q is supported). "+
-			"Re-run with --kubeconfig-access-level=%s to override",
-			name, accessLevel, config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelAdmin)
+	// Non-managed seed: kubeconfig comes from a static <name>.login Secret, so
+	// gardenlogin's access-level mechanism is not available on this path. We
+	// reject only an explicit "viewer" request - the user asked for read-only
+	// and we cannot deliver it, so silently returning the static kubeconfig
+	// would be a privilege surprise. "auto" semantically means "try admin,
+	// fall back to viewer", so falling through here matches its documented
+	// behavior. Note that gardenctl cannot determine the actual privileges
+	// the static kubeconfig grants - they depend on the cluster's RBAC.
+	if accessLevel == config.KubeconfigAccessLevelViewer {
+		return nil, fmt.Errorf("seed %q is not a managed seed; gardenlogin's access-level mechanism is unavailable for static seed-login kubeconfigs. "+
+			"Re-run without %q (or with --kubeconfig-access-level=%s) to use the static kubeconfig as-is",
+			name, accessLevel, config.KubeconfigAccessLevelAdmin)
 	}
 
 	key := types.NamespacedName{Name: name}

--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -111,15 +111,17 @@ type Client interface {
 	// GetShootOfManagedSeed returns shoot of seed using ManagedSeed resource. An error is returned if it is not a managed seed or the referenced shoot is nil
 	GetShootOfManagedSeed(ctx context.Context, name string) (*seedmanagementv1alpha1.Shoot, error)
 	// IsManagedSeed reports whether the shoot identified by (shootNamespace, shootName)
-	// is referenced by a ManagedSeed resource. Uses the spec.shoot.name field
-	// selector rather than relying on the (conventional but not guaranteed)
-	// equality of ManagedSeed and shoot names.
+	// is referenced by a ManagedSeed resource. Returns false without an API call
+	// when shootNamespace is not the garden namespace, since the Gardener API
+	// server enforces that ManagedSeeds and their referenced shoots both live in
+	// the garden namespace. This also avoids a forbidden List for regular users,
+	// who typically lack ManagedSeed List permission in their project namespaces.
 	IsManagedSeed(ctx context.Context, shootNamespace, shootName string) (bool, error)
 	// IsManagedSeedByName reports whether a seed of the given name is a managed
-	// seed (i.e. produced by a ManagedSeed resource). Lists cluster-wide so it
-	// works regardless of which namespace the ManagedSeed lives in.
+	// seed. ManagedSeed.metadata.name equals the resulting Seed.metadata.name,
+	// so this is a direct Get in the garden namespace (see Gardener's
+	// utils/kubernetes.GetManagedSeedByName for the same pattern).
 	IsManagedSeedByName(ctx context.Context, seedName string) (bool, error)
-
 	// GetBastion returns a Gardener bastion resource by namespace and name
 	GetBastion(ctx context.Context, namespace, name string) (*operationsv1alpha1.Bastion, error)
 	// ListBastions returns all Gardener bastion resources, filtered by a list option
@@ -401,6 +403,10 @@ func (g *clientImpl) GetConfigMap(ctx context.Context, namespace, name string) (
 }
 
 func (g *clientImpl) IsManagedSeed(ctx context.Context, shootNamespace, shootName string) (bool, error) {
+	if shootNamespace != corev1beta1constants.GardenNamespace {
+		return false, nil
+	}
+
 	list := &seedmanagementv1alpha1.ManagedSeedList{}
 
 	if err := g.c.List(ctx, list,
@@ -414,25 +420,23 @@ func (g *clientImpl) IsManagedSeed(ctx context.Context, shootNamespace, shootNam
 }
 
 func (g *clientImpl) IsManagedSeedByName(ctx context.Context, seedName string) (bool, error) {
-	// A ManagedSeed produces a Seed of the same metadata.name, but its
-	// spec.shoot.name may differ - so the lookup is by name, not field selector.
-	list := &seedmanagementv1alpha1.ManagedSeedList{}
-	if err := g.c.List(ctx, list); err != nil {
+	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
+	key := types.NamespacedName{Namespace: corev1beta1constants.GardenNamespace, Name: seedName}
+
+	if err := g.c.Get(ctx, key, managedSeed); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+
 		return false, err
 	}
 
-	for i := range list.Items {
-		if list.Items[i].Name == seedName {
-			return true, nil
-		}
-	}
-
-	return false, nil
+	return true, nil
 }
 
 func (g *clientImpl) GetShootOfManagedSeed(ctx context.Context, name string) (*seedmanagementv1alpha1.Shoot, error) {
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-	key := types.NamespacedName{Namespace: "garden", Name: name} // Currently, managed seeds are restricted to the garden namespace
+	key := types.NamespacedName{Namespace: corev1beta1constants.GardenNamespace, Name: name} // Currently, managed seeds are restricted to the garden namespace
 
 	if err := g.c.Get(ctx, key, managedSeed); err != nil {
 		return nil, err
@@ -621,12 +625,12 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string, acces
 	if !apierrors.IsNotFound(err) {
 		logger.V(1).Info("using referred shoot of managed seed",
 			"shoot", klog.ObjectRef{
-				Namespace: "garden",
+				Namespace: corev1beta1constants.GardenNamespace,
 				Name:      shoot.Name,
 			},
 			"seed", name)
 
-		return g.GetShootClientConfig(ctx, "garden", shoot.Name, accessLevel)
+		return g.GetShootClientConfig(ctx, corev1beta1constants.GardenNamespace, shoot.Name, accessLevel)
 	}
 
 	// Non-managed seed: kubeconfig comes from a static <name>.login Secret, so
@@ -645,7 +649,7 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string, acces
 
 	key := types.NamespacedName{Name: name}
 
-	secret, err := g.GetSecret(ctx, "garden", name+".login")
+	secret, err := g.GetSecret(ctx, corev1beta1constants.GardenNamespace, name+".login")
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			return nil, err
@@ -654,12 +658,12 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string, acces
 		// fallback to deprecated .oidc secret
 		var oidcErr error
 
-		secret, oidcErr = g.GetSecret(ctx, "garden", name+".oidc")
+		secret, oidcErr = g.GetSecret(ctx, corev1beta1constants.GardenNamespace, name+".oidc")
 		if oidcErr != nil {
 			return nil, fmt.Errorf("failed to get kubeconfig for seed %v: %w", key, err) // use original not-found error as cause and ignore error of fallback
 		}
 
-		klog.FromContext(ctx).Info("Using deprecated secret to obtain seed kubeconfig", "secret", klog.KRef("garden", name+".oidc"))
+		klog.FromContext(ctx).Info("Using deprecated secret to obtain seed kubeconfig", "secret", klog.KRef(corev1beta1constants.GardenNamespace, name+".oidc"))
 	}
 
 	value, ok := secret.Data["kubeconfig"]

--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -414,15 +414,20 @@ func (g *clientImpl) IsManagedSeed(ctx context.Context, shootNamespace, shootNam
 }
 
 func (g *clientImpl) IsManagedSeedByName(ctx context.Context, seedName string) (bool, error) {
+	// A ManagedSeed produces a Seed of the same metadata.name, but its
+	// spec.shoot.name may differ - so the lookup is by name, not field selector.
 	list := &seedmanagementv1alpha1.ManagedSeedList{}
-
-	if err := g.c.List(ctx, list,
-		client.MatchingFields{seedmanagement.ManagedSeedShootName: seedName},
-	); err != nil {
+	if err := g.c.List(ctx, list); err != nil {
 		return false, err
 	}
 
-	return len(list.Items) > 0, nil
+	for i := range list.Items {
+		if list.Items[i].Name == seedName {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (g *clientImpl) GetShootOfManagedSeed(ctx context.Context, name string) (*seedmanagementv1alpha1.Shoot, error) {

--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -115,6 +115,10 @@ type Client interface {
 	// selector rather than relying on the (conventional but not guaranteed)
 	// equality of ManagedSeed and shoot names.
 	IsManagedSeed(ctx context.Context, shootNamespace, shootName string) (bool, error)
+	// IsManagedSeedByName reports whether a seed of the given name is a managed
+	// seed (i.e. produced by a ManagedSeed resource). Lists cluster-wide so it
+	// works regardless of which namespace the ManagedSeed lives in.
+	IsManagedSeedByName(ctx context.Context, seedName string) (bool, error)
 
 	// GetBastion returns a Gardener bastion resource by namespace and name
 	GetBastion(ctx context.Context, namespace, name string) (*operationsv1alpha1.Bastion, error)
@@ -402,6 +406,18 @@ func (g *clientImpl) IsManagedSeed(ctx context.Context, shootNamespace, shootNam
 	if err := g.c.List(ctx, list,
 		client.InNamespace(shootNamespace),
 		client.MatchingFields{seedmanagement.ManagedSeedShootName: shootName},
+	); err != nil {
+		return false, err
+	}
+
+	return len(list.Items) > 0, nil
+}
+
+func (g *clientImpl) IsManagedSeedByName(ctx context.Context, seedName string) (bool, error) {
+	list := &seedmanagementv1alpha1.ManagedSeedList{}
+
+	if err := g.c.List(ctx, list,
+		client.MatchingFields{seedmanagement.ManagedSeedShootName: seedName},
 	); err != nil {
 		return false, err
 	}

--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -72,11 +72,14 @@ type Client interface {
 	// ListSeeds returns all Gardener seed resources
 	ListSeeds(ctx context.Context, opts ...client.ListOption) (*gardencorev1beta1.SeedList, error)
 	// GetSeedClientConfig returns the client config for a seed.
+	//
 	// For managed seeds, accessLevel is honored (the call is delegated to
-	// GetShootClientConfig). For non-managed seeds the kubeconfig comes from a
-	// static <name>.login Secret which only supports admin access - a non-admin
-	// accessLevel returns an error rather than silently producing an admin
-	// kubeconfig. Pass an empty value or "admin" for non-managed seeds.
+	// GetShootClientConfig).
+	//
+	// For non-managed seeds the kubeconfig comes from a static <name>.login
+	// Secret; an explicit "viewer" accessLevel returns an error since gardenctl
+	// cannot guarantee the privileges of a static kubeconfig. Any other value
+	// (empty, "admin", "auto") returns the static kubeconfig as-is.
 	GetSeedClientConfig(ctx context.Context, name string, accessLevel config.KubeconfigAccessLevel) (clientcmd.ClientConfig, error)
 
 	// GetShoot returns a Gardener shoot resource in a namespace by name
@@ -644,7 +647,7 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string, acces
 	if accessLevel == config.KubeconfigAccessLevelViewer {
 		return nil, fmt.Errorf("seed %q is not a managed seed; gardenlogin's access-level mechanism is unavailable for static seed-login kubeconfigs. "+
 			"Re-run without %q (or with --access-level=%s) to use the static kubeconfig as-is",
-			name, accessLevel, config.KubeconfigAccessLevelAdmin)
+			name, accessLevel, config.KubeconfigAccessLevelAuto)
 	}
 
 	key := types.NamespacedName{Name: name}

--- a/internal/client/garden/client_test.go
+++ b/internal/client/garden/client_test.go
@@ -221,22 +221,22 @@ var _ = Describe("Client", func() {
 			})
 		})
 
-		DescribeTable("rejects non-admin access level for non-managed seeds",
+		DescribeTable("rejects only viewer for non-managed seeds (the user asked for read-only and we cannot deliver it)",
 			func(level config.KubeconfigAccessLevel) {
 				_, err := gardenClient.GetSeedClientConfig(ctx, "seed-1", level)
 				Expect(err).To(MatchError(ContainSubstring("not a managed seed")))
 			},
 			Entry("viewer", config.KubeconfigAccessLevelViewer),
-			Entry("auto", config.KubeconfigAccessLevelAuto),
 		)
 
-		DescribeTable("permits admin or empty access level for non-managed seeds",
+		DescribeTable("permits admin, auto, or empty access level for non-managed seeds (auto falls back to admin per its documented semantics)",
 			func(level config.KubeconfigAccessLevel) {
 				_, err := gardenClient.GetSeedClientConfig(ctx, "seed-1", level)
 				Expect(err).NotTo(HaveOccurred())
 			},
 			Entry("empty (built-in default)", config.KubeconfigAccessLevel("")),
 			Entry("admin", config.KubeconfigAccessLevelAdmin),
+			Entry("auto", config.KubeconfigAccessLevelAuto),
 		)
 	})
 

--- a/internal/client/garden/client_test.go
+++ b/internal/client/garden/client_test.go
@@ -36,6 +36,7 @@ import (
 
 	clientgarden "github.com/gardener/gardenctl-v2/internal/client/garden"
 	"github.com/gardener/gardenctl-v2/internal/fake"
+	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
 type createInterceptingClient struct {
@@ -201,7 +202,7 @@ var _ = Describe("Client", func() {
 		})
 
 		DescribeTable("when the secret exists", func(seedName string) {
-			clientConfig, err := gardenClient.GetSeedClientConfig(ctx, seedName)
+			clientConfig, err := gardenClient.GetSeedClientConfig(ctx, seedName, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			rawConfig, err := clientConfig.RawConfig()
@@ -214,11 +215,29 @@ var _ = Describe("Client", func() {
 
 		Context("when the secret does not exist", func() {
 			It("it should fail with not found error", func() {
-				_, err := gardenClient.GetSeedClientConfig(ctx, "seed-3")
+				_, err := gardenClient.GetSeedClientConfig(ctx, "seed-3", "")
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 			})
 		})
+
+		DescribeTable("rejects non-admin access level for non-managed seeds",
+			func(level config.KubeconfigAccessLevel) {
+				_, err := gardenClient.GetSeedClientConfig(ctx, "seed-1", level)
+				Expect(err).To(MatchError(ContainSubstring("not a managed seed")))
+			},
+			Entry("viewer", config.KubeconfigAccessLevelViewer),
+			Entry("auto", config.KubeconfigAccessLevelAuto),
+		)
+
+		DescribeTable("permits admin or empty access level for non-managed seeds",
+			func(level config.KubeconfigAccessLevel) {
+				_, err := gardenClient.GetSeedClientConfig(ctx, "seed-1", level)
+				Expect(err).NotTo(HaveOccurred())
+			},
+			Entry("empty (built-in default)", config.KubeconfigAccessLevel("")),
+			Entry("admin", config.KubeconfigAccessLevelAdmin),
+		)
 	})
 
 	Describe("GetShootOfManagedSeed", func() {
@@ -329,7 +348,7 @@ var _ = Describe("Client", func() {
 						gardenName,
 					)
 
-					clientConfig, err := gardenClient.GetShootClientConfig(ctx, namespace, shootName)
+					clientConfig, err := gardenClient.GetShootClientConfig(ctx, namespace, shootName, "")
 					Expect(err).NotTo(HaveOccurred())
 
 					rawConfig, err := clientConfig.RawConfig()
@@ -358,6 +377,32 @@ var _ = Describe("Client", func() {
 					}))
 					Expect(authInfo.Exec.InstallHint).ToNot(BeEmpty())
 				})
+
+				DescribeTable("appends --access-level when set",
+					func(level config.KubeconfigAccessLevel) {
+						gardenClient = clientgarden.NewClient(
+							nil,
+							fake.NewClientWithObjects(testShoot1, caConfigMap),
+							gardenName,
+						)
+
+						clientConfig, err := gardenClient.GetShootClientConfig(ctx, namespace, shootName, level)
+						Expect(err).NotTo(HaveOccurred())
+
+						rawConfig, err := clientConfig.RawConfig()
+						Expect(err).NotTo(HaveOccurred())
+
+						context := rawConfig.Contexts[rawConfig.CurrentContext]
+						authInfo := rawConfig.AuthInfos[context.AuthInfo]
+						Expect(authInfo.Exec.Args).To(Equal([]string{
+							"get-client-certificate",
+							fmt.Sprintf("--access-level=%s", level),
+						}))
+					},
+					Entry("admin", config.KubeconfigAccessLevelAdmin),
+					Entry("viewer", config.KubeconfigAccessLevelViewer),
+					Entry("auto", config.KubeconfigAccessLevelAuto),
+				)
 			})
 
 			Context("legacy kubeconfig", func() {
@@ -374,7 +419,7 @@ var _ = Describe("Client", func() {
 						gardenName,
 					)
 
-					clientConfig, err := gardenClient.GetShootClientConfig(ctx, namespace, shootName)
+					clientConfig, err := gardenClient.GetShootClientConfig(ctx, namespace, shootName, "")
 					Expect(err).NotTo(HaveOccurred())
 
 					rawConfig, err := clientConfig.RawConfig()
@@ -400,6 +445,30 @@ var _ = Describe("Client", func() {
 						fmt.Sprintf("--garden-cluster-identity=%s", gardenName),
 					}))
 				})
+
+				It("should append --access-level when set in legacy mode", func() {
+					gardenClient = clientgarden.NewClient(
+						nil,
+						fake.NewClientWithObjects(testShoot1, caConfigMap),
+						gardenName,
+					)
+
+					clientConfig, err := gardenClient.GetShootClientConfig(ctx, namespace, shootName, config.KubeconfigAccessLevelViewer)
+					Expect(err).NotTo(HaveOccurred())
+
+					rawConfig, err := clientConfig.RawConfig()
+					Expect(err).NotTo(HaveOccurred())
+
+					context := rawConfig.Contexts[rawConfig.CurrentContext]
+					authInfo := rawConfig.AuthInfos[context.AuthInfo]
+					Expect(authInfo.Exec.Args).To(Equal([]string{
+						"get-client-certificate",
+						fmt.Sprintf("--name=%s", shootName),
+						fmt.Sprintf("--namespace=%s", namespace),
+						fmt.Sprintf("--garden-cluster-identity=%s", gardenName),
+						fmt.Sprintf("--access-level=%s", config.KubeconfigAccessLevelViewer),
+					}))
+				})
 			})
 		})
 
@@ -413,7 +482,7 @@ var _ = Describe("Client", func() {
 			})
 
 			It("it should fail with not found error", func() {
-				_, err := gardenClient.GetShootClientConfig(ctx, namespace, shootName)
+				_, err := gardenClient.GetShootClientConfig(ctx, namespace, shootName, "")
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 				Expect(err.Error()).To(ContainSubstring(shootName + ".ca-cluster"))

--- a/internal/client/garden/client_test.go
+++ b/internal/client/garden/client_test.go
@@ -55,6 +55,16 @@ func (cic createInterceptingClient) Create(ctx context.Context, obj client.Objec
 	return cic.Client.Create(ctx, obj, opts...)
 }
 
+// listFailingClient errors on any List call. Used to prove a code path does
+// not call List - if List were called, the wrapped error would propagate.
+type listFailingClient struct {
+	client.Client
+}
+
+func (listFailingClient) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return fmt.Errorf("List should not have been called")
+}
+
 var _ = Describe("Client", func() {
 	const (
 		gardenName = "my-garden"
@@ -266,6 +276,72 @@ var _ = Describe("Client", func() {
 			shoot, err := gardenClient.GetShootOfManagedSeed(ctx, "managedSeed")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(shoot.Name).To(Equal("shootOfManagedSeed"))
+		})
+	})
+
+	Describe("IsManagedSeed", func() {
+		var managedSeed *seedmanagementv1alpha1.ManagedSeed
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			managedSeed = &seedmanagementv1alpha1.ManagedSeed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ms",
+					Namespace: "garden",
+					UID:       "00000000-0000-0000-0000-000000000001",
+				},
+				Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+					Shoot: &seedmanagementv1alpha1.Shoot{Name: "shoot-foo"},
+				},
+			}
+		})
+
+		It("returns true when a matching ManagedSeed exists in the garden namespace", func() {
+			gardenClient = clientgarden.NewClient(nil, fake.NewClientWithObjects(managedSeed), gardenName)
+			ok, err := gardenClient.IsManagedSeed(ctx, "garden", "shoot-foo")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("returns false when no ManagedSeed exists in the garden namespace", func() {
+			gardenClient = clientgarden.NewClient(nil, fake.NewClientWithObjects(), gardenName)
+			ok, err := gardenClient.IsManagedSeed(ctx, "garden", "any-shoot")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("returns false without an API call when shootNamespace is not the garden namespace (RBAC safety)", func() {
+			// listFailingClient errors on any List call. If IsManagedSeed's
+			// short-circuit works, no List is performed and this test passes.
+			gardenClient = clientgarden.NewClient(nil, listFailingClient{Client: fake.NewClientWithObjects(managedSeed)}, gardenName)
+			ok, err := gardenClient.IsManagedSeed(ctx, "garden-myproject", "shoot-foo")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("IsManagedSeedByName", func() {
+		BeforeEach(func() { ctx = context.Background() })
+
+		It("returns true when a ManagedSeed of that name exists in the garden namespace", func() {
+			managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-seed",
+					Namespace: "garden",
+					UID:       "00000000-0000-0000-0000-000000000002",
+				},
+			}
+			gardenClient = clientgarden.NewClient(nil, fake.NewClientWithObjects(managedSeed), gardenName)
+			ok, err := gardenClient.IsManagedSeedByName(ctx, "my-seed")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+		})
+
+		It("returns false when no ManagedSeed of that name exists (NotFound)", func() {
+			gardenClient = clientgarden.NewClient(nil, fake.NewClientWithObjects(), gardenName)
+			ok, err := gardenClient.IsManagedSeedByName(ctx, "absent-seed")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeFalse())
 		})
 	})
 

--- a/internal/client/garden/client_test.go
+++ b/internal/client/garden/client_test.go
@@ -244,7 +244,7 @@ var _ = Describe("Client", func() {
 				_, err := gardenClient.GetSeedClientConfig(ctx, "seed-1", level)
 				Expect(err).NotTo(HaveOccurred())
 			},
-			Entry("empty (built-in default)", config.KubeconfigAccessLevel("")),
+			Entry("empty (delegate to gardenlogin's default)", config.KubeconfigAccessLevel("")),
 			Entry("admin", config.KubeconfigAccessLevelAdmin),
 			Entry("auto", config.KubeconfigAccessLevelAuto),
 		)

--- a/internal/client/garden/mocks/mock_client.go
+++ b/internal/client/garden/mocks/mock_client.go
@@ -319,6 +319,21 @@ func (mr *MockClientMockRecorder) GetWorkloadIdentity(arg0, arg1, arg2 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkloadIdentity", reflect.TypeOf((*MockClient)(nil).GetWorkloadIdentity), arg0, arg1, arg2)
 }
 
+// IsManagedSeed mocks base method.
+func (m *MockClient) IsManagedSeed(arg0 context.Context, arg1, arg2 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsManagedSeed", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsManagedSeed indicates an expected call of IsManagedSeed.
+func (mr *MockClientMockRecorder) IsManagedSeed(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsManagedSeed", reflect.TypeOf((*MockClient)(nil).IsManagedSeed), arg0, arg1, arg2)
+}
+
 // ListBastions mocks base method.
 func (m *MockClient) ListBastions(arg0 context.Context, arg1 ...client.ListOption) (*v1alpha1.BastionList, error) {
 	m.ctrl.T.Helper()

--- a/internal/client/garden/mocks/mock_client.go
+++ b/internal/client/garden/mocks/mock_client.go
@@ -10,6 +10,7 @@ import (
 	time "time"
 
 	garden "github.com/gardener/gardenctl-v2/internal/client/garden"
+	config "github.com/gardener/gardenctl-v2/pkg/config"
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	v1alpha10 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
@@ -244,18 +245,18 @@ func (mr *MockClientMockRecorder) GetSeed(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // GetSeedClientConfig mocks base method.
-func (m *MockClient) GetSeedClientConfig(arg0 context.Context, arg1 string) (clientcmd.ClientConfig, error) {
+func (m *MockClient) GetSeedClientConfig(arg0 context.Context, arg1 string, arg2 config.KubeconfigAccessLevel) (clientcmd.ClientConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSeedClientConfig", arg0, arg1)
+	ret := m.ctrl.Call(m, "GetSeedClientConfig", arg0, arg1, arg2)
 	ret0, _ := ret[0].(clientcmd.ClientConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSeedClientConfig indicates an expected call of GetSeedClientConfig.
-func (mr *MockClientMockRecorder) GetSeedClientConfig(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetSeedClientConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeedClientConfig", reflect.TypeOf((*MockClient)(nil).GetSeedClientConfig), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSeedClientConfig", reflect.TypeOf((*MockClient)(nil).GetSeedClientConfig), arg0, arg1, arg2)
 }
 
 // GetShoot mocks base method.
@@ -274,18 +275,18 @@ func (mr *MockClientMockRecorder) GetShoot(arg0, arg1, arg2 interface{}) *gomock
 }
 
 // GetShootClientConfig mocks base method.
-func (m *MockClient) GetShootClientConfig(arg0 context.Context, arg1, arg2 string) (clientcmd.ClientConfig, error) {
+func (m *MockClient) GetShootClientConfig(arg0 context.Context, arg1, arg2 string, arg3 config.KubeconfigAccessLevel) (clientcmd.ClientConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetShootClientConfig", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetShootClientConfig", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(clientcmd.ClientConfig)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetShootClientConfig indicates an expected call of GetShootClientConfig.
-func (mr *MockClientMockRecorder) GetShootClientConfig(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) GetShootClientConfig(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShootClientConfig", reflect.TypeOf((*MockClient)(nil).GetShootClientConfig), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShootClientConfig", reflect.TypeOf((*MockClient)(nil).GetShootClientConfig), arg0, arg1, arg2, arg3)
 }
 
 // GetShootOfManagedSeed mocks base method.

--- a/internal/client/garden/mocks/mock_client.go
+++ b/internal/client/garden/mocks/mock_client.go
@@ -334,6 +334,21 @@ func (mr *MockClientMockRecorder) IsManagedSeed(arg0, arg1, arg2 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsManagedSeed", reflect.TypeOf((*MockClient)(nil).IsManagedSeed), arg0, arg1, arg2)
 }
 
+// IsManagedSeedByName mocks base method.
+func (m *MockClient) IsManagedSeedByName(arg0 context.Context, arg1 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsManagedSeedByName", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsManagedSeedByName indicates an expected call of IsManagedSeedByName.
+func (mr *MockClientMockRecorder) IsManagedSeedByName(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsManagedSeedByName", reflect.TypeOf((*MockClient)(nil).IsManagedSeedByName), arg0, arg1)
+}
+
 // ListBastions mocks base method.
 func (m *MockClient) ListBastions(arg0 context.Context, arg1 ...client.ListOption) (*v1alpha1.BastionList, error) {
 	m.ctrl.T.Helper()

--- a/internal/client/garden/shoot_client.go
+++ b/internal/client/garden/shoot_client.go
@@ -25,6 +25,8 @@ import (
 	clientauthenticationv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
 func init() {
@@ -140,7 +142,7 @@ func (k *shootKubeconfigRequest) validate() error {
 // If legacy is false, the shoot reference and garden cluster identity is passed via the cluster extensions,
 // which is supported starting with kubectl version v1.20.0.
 // If legacy is true, the shoot reference and garden cluster identity are passed as command line flags to the plugin.
-func (k *shootKubeconfigRequest) generate(legacy bool) (*clientcmdapi.Config, error) {
+func (k *shootKubeconfigRequest) generate(legacy bool, accessLevel config.KubeconfigAccessLevel) (*clientcmdapi.Config, error) {
 	var extension *execPluginConfig
 
 	args := []string{
@@ -165,6 +167,10 @@ func (k *shootKubeconfigRequest) generate(legacy bool) (*clientcmdapi.Config, er
 			},
 			GardenClusterIdentity: k.gardenClusterIdentity,
 		}
+	}
+
+	if accessLevel != "" {
+		args = append(args, fmt.Sprintf("--access-level=%s", accessLevel))
 	}
 
 	config := clientcmdapi.NewConfig()
@@ -212,7 +218,7 @@ func (k *shootKubeconfigRequest) generate(legacy bool) (*clientcmdapi.Config, er
 	return config, nil
 }
 
-func (g *clientImpl) GetShootClientConfig(ctx context.Context, namespace, name string) (clientcmd.ClientConfig, error) {
+func (g *clientImpl) GetShootClientConfig(ctx context.Context, namespace, name string, accessLevel config.KubeconfigAccessLevel) (clientcmd.ClientConfig, error) {
 	if len(g.name) == 0 {
 		return nil, errors.New("garden name must not be empty")
 	}
@@ -285,7 +291,7 @@ func (g *clientImpl) GetShootClientConfig(ctx context.Context, namespace, name s
 
 	legacy := constraint.Check(version)
 
-	config, err := kubeconfigRequest.generate(legacy)
+	config, err := kubeconfigRequest.generate(legacy, accessLevel)
 	if err != nil {
 		return nil, fmt.Errorf("generation failed for kubeconfig request: %w", err)
 	}

--- a/internal/fake/factory.go
+++ b/internal/fake/factory.go
@@ -89,7 +89,7 @@ func (f *Factory) Manager() (target.Manager, error) {
 
 	sessionDir := os.TempDir()
 
-	return target.NewManager(f.Config, f.TargetProviderImpl, f.ClientProviderImpl, sessionDir)
+	return target.NewManager(f.Config, f.TargetProviderImpl, f.ClientProviderImpl, sessionDir, "")
 }
 
 func (f *Factory) Context() context.Context {

--- a/internal/fake/factory.go
+++ b/internal/fake/factory.go
@@ -48,6 +48,9 @@ type Factory struct {
 
 	// SessionID is the session identifier for this factory instance.
 	SessionID string
+
+	// KubeconfigAccessLevel mirrors FactoryImpl.KubeconfigAccessLevel.
+	KubeconfigAccessLevel config.KubeconfigAccessLevel
 }
 
 var _ util.Factory = &Factory{}
@@ -89,7 +92,7 @@ func (f *Factory) Manager() (target.Manager, error) {
 
 	sessionDir := os.TempDir()
 
-	return target.NewManager(f.Config, f.TargetProviderImpl, f.ClientProviderImpl, sessionDir, "")
+	return target.NewManager(f.Config, f.TargetProviderImpl, f.ClientProviderImpl, sessionDir, f.KubeconfigAccessLevel)
 }
 
 func (f *Factory) Context() context.Context {

--- a/internal/util/factory.go
+++ b/internal/util/factory.go
@@ -76,6 +76,8 @@ type FactoryImpl struct {
 	// if empty.
 	ConfigFile string
 
+	KubeconfigAccessLevel config.KubeconfigAccessLevel
+
 	// targetFlags can be used to completely override the target configuration
 	// stored on the filesystem via a CLI flags.
 	targetFlags target.TargetFlags
@@ -133,7 +135,7 @@ func (f *FactoryImpl) Manager() (target.Manager, error) {
 	targetProvider := target.NewTargetProvider(filepath.Join(sessionDirectory, "target.yaml"), f.targetFlags)
 	clientProvider := internalclient.NewProvider()
 
-	return target.NewManager(cfg, targetProvider, clientProvider, sessionDirectory)
+	return target.NewManager(cfg, targetProvider, clientProvider, sessionDirectory, f.KubeconfigAccessLevel)
 }
 
 func (f *FactoryImpl) GardenHomeDir() string {

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -128,12 +128,10 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 	kubeconfigCmd := kubeconfig.NewCmdKubeconfig(f, ioStreams)
 
 	// The --kubeconfig-access-level flag is only meaningful for commands that
-	// produce a gardenlogin-driven kubeconfig.
+	// produce a user-facing gardenlogin-driven kubeconfig.
 	flagsutil.AddKubeconfigAccessLevelFlag(targetCmd, &f.KubeconfigAccessLevel)
 	flagsutil.AddKubeconfigAccessLevelFlag(kubeconfigCmd, &f.KubeconfigAccessLevel)
 	flagsutil.AddKubeconfigAccessLevelFlag(kubectlEnvCmd, &f.KubeconfigAccessLevel)
-	flagsutil.AddKubeconfigAccessLevelFlag(sshCmd, &f.KubeconfigAccessLevel)
-	flagsutil.AddKubeconfigAccessLevelFlag(sshpatchCmd, &f.KubeconfigAccessLevel)
 
 	cmd.AddCommand(sshCmd)
 	cmd.AddCommand(sshpatchCmd)

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -32,7 +32,6 @@ import (
 	cmdsshpatch "github.com/gardener/gardenctl-v2/pkg/cmd/sshpatch"
 	cmdtarget "github.com/gardener/gardenctl-v2/pkg/cmd/target"
 	cmdversion "github.com/gardener/gardenctl-v2/pkg/cmd/version"
-	flagsutil "github.com/gardener/gardenctl-v2/pkg/flags"
 )
 
 const (
@@ -123,18 +122,9 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 	// add subcommands
 	sshCmd := cmdssh.NewCmdSSH(f, cmdssh.NewSSHOptions(ioStreams))
 	sshpatchCmd := cmdsshpatch.NewCmdSSHPatch(f, ioStreams)
-	targetCmd := cmdtarget.NewCmdTarget(f, ioStreams)
+	targetCmd := cmdtarget.NewCmdTarget(f, ioStreams, &f.KubeconfigAccessLevel)
 	kubectlEnvCmd := cmdkubectl.NewCmdKubectlEnv(f, ioStreams)
-	kubeconfigCmd := kubeconfig.NewCmdKubeconfig(f, ioStreams)
-
-	// The --kubeconfig-access-level flag is only meaningful for commands that
-	// produce a user-facing gardenlogin-driven kubeconfig. kubectl-env's symlink
-	// mode (the configured default) makes the flag a no-op there, and its
-	// non-symlink path still respects per-garden config defaults; users wanting
-	// a one-shot override should `gardenctl target --kubeconfig-access-level=...`
-	// before running kubectl-env.
-	flagsutil.AddKubeconfigAccessLevelFlag(targetCmd, &f.KubeconfigAccessLevel)
-	flagsutil.AddKubeconfigAccessLevelFlag(kubeconfigCmd, &f.KubeconfigAccessLevel)
+	kubeconfigCmd := kubeconfig.NewCmdKubeconfig(f, ioStreams, &f.KubeconfigAccessLevel)
 
 	cmd.AddCommand(sshCmd)
 	cmd.AddCommand(sshpatchCmd)

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -128,10 +128,13 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 	kubeconfigCmd := kubeconfig.NewCmdKubeconfig(f, ioStreams)
 
 	// The --kubeconfig-access-level flag is only meaningful for commands that
-	// produce a user-facing gardenlogin-driven kubeconfig.
+	// produce a user-facing gardenlogin-driven kubeconfig. kubectl-env's symlink
+	// mode (the configured default) makes the flag a no-op there, and its
+	// non-symlink path still respects per-garden config defaults; users wanting
+	// a one-shot override should `gardenctl target --kubeconfig-access-level=...`
+	// before running kubectl-env.
 	flagsutil.AddKubeconfigAccessLevelFlag(targetCmd, &f.KubeconfigAccessLevel)
 	flagsutil.AddKubeconfigAccessLevelFlag(kubeconfigCmd, &f.KubeconfigAccessLevel)
-	flagsutil.AddKubeconfigAccessLevelFlag(kubectlEnvCmd, &f.KubeconfigAccessLevel)
 
 	cmd.AddCommand(sshCmd)
 	cmd.AddCommand(sshpatchCmd)

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -32,6 +32,7 @@ import (
 	cmdsshpatch "github.com/gardener/gardenctl-v2/pkg/cmd/sshpatch"
 	cmdtarget "github.com/gardener/gardenctl-v2/pkg/cmd/target"
 	cmdversion "github.com/gardener/gardenctl-v2/pkg/cmd/version"
+	flagsutil "github.com/gardener/gardenctl-v2/pkg/flags"
 )
 
 const (
@@ -120,15 +121,29 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 	flags.StringVar(&f.ConfigFile, "config", "", fmt.Sprintf("config file (default is %s)", filepath.Join("~", gardenHomeFolder, configName+"."+configExtension)))
 
 	// add subcommands
-	cmd.AddCommand(cmdssh.NewCmdSSH(f, cmdssh.NewSSHOptions(ioStreams)))
-	cmd.AddCommand(cmdsshpatch.NewCmdSSHPatch(f, ioStreams))
-	cmd.AddCommand(cmdtarget.NewCmdTarget(f, ioStreams))
+	sshCmd := cmdssh.NewCmdSSH(f, cmdssh.NewSSHOptions(ioStreams))
+	sshpatchCmd := cmdsshpatch.NewCmdSSHPatch(f, ioStreams)
+	targetCmd := cmdtarget.NewCmdTarget(f, ioStreams)
+	kubectlEnvCmd := cmdkubectl.NewCmdKubectlEnv(f, ioStreams)
+	kubeconfigCmd := kubeconfig.NewCmdKubeconfig(f, ioStreams)
+
+	// The --kubeconfig-access-level flag is only meaningful for commands that
+	// produce a gardenlogin-driven kubeconfig.
+	flagsutil.AddKubeconfigAccessLevelFlag(targetCmd, &f.KubeconfigAccessLevel)
+	flagsutil.AddKubeconfigAccessLevelFlag(kubeconfigCmd, &f.KubeconfigAccessLevel)
+	flagsutil.AddKubeconfigAccessLevelFlag(kubectlEnvCmd, &f.KubeconfigAccessLevel)
+	flagsutil.AddKubeconfigAccessLevelFlag(sshCmd, &f.KubeconfigAccessLevel)
+	flagsutil.AddKubeconfigAccessLevelFlag(sshpatchCmd, &f.KubeconfigAccessLevel)
+
+	cmd.AddCommand(sshCmd)
+	cmd.AddCommand(sshpatchCmd)
+	cmd.AddCommand(targetCmd)
 	cmd.AddCommand(cmdversion.NewCmdVersion(f, cmdversion.NewVersionOptions(ioStreams)))
 	cmd.AddCommand(cmdconfig.NewCmdConfig(f, ioStreams))
 	cmd.AddCommand(cmdprovider.NewCmdProviderEnv(f, ioStreams))
-	cmd.AddCommand(cmdkubectl.NewCmdKubectlEnv(f, ioStreams))
+	cmd.AddCommand(kubectlEnvCmd)
 	cmd.AddCommand(cmdrc.NewCmdRC(f, ioStreams))
-	cmd.AddCommand(kubeconfig.NewCmdKubeconfig(f, ioStreams))
+	cmd.AddCommand(kubeconfigCmd)
 	cmd.AddCommand(resolve.NewCmdResolve(f, ioStreams))
 
 	return cmd

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -123,7 +123,7 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 	sshCmd := cmdssh.NewCmdSSH(f, cmdssh.NewSSHOptions(ioStreams))
 	sshpatchCmd := cmdsshpatch.NewCmdSSHPatch(f, ioStreams)
 	targetCmd := cmdtarget.NewCmdTarget(f, ioStreams, &f.KubeconfigAccessLevel)
-	kubectlEnvCmd := cmdkubectl.NewCmdKubectlEnv(f, ioStreams)
+	kubectlEnvCmd := cmdkubectl.NewCmdKubectlEnv(f, ioStreams, &f.KubeconfigAccessLevel)
 	kubeconfigCmd := kubeconfig.NewCmdKubeconfig(f, ioStreams, &f.KubeconfigAccessLevel)
 
 	cmd.AddCommand(sshCmd)

--- a/pkg/cmd/config/config_test.go
+++ b/pkg/cmd/config/config_test.go
@@ -16,7 +16,6 @@ import (
 
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
 	"github.com/gardener/gardenctl-v2/pkg/config"
-	"github.com/gardener/gardenctl-v2/pkg/target"
 )
 
 var _ = Describe("Config Command", func() {
@@ -56,10 +55,6 @@ var _ = Describe("Config Command", func() {
 			})
 
 			It("should successfully run subcommand set-garden", func() {
-				// gardenIdentity3 isn't the current target -> no kubeconfig refresh.
-				factory.EXPECT().Context().Return(nil).AnyTimes()
-				manager.EXPECT().CurrentTarget().Return(target.NewTarget("", "", "", ""), nil)
-
 				garden := &config.Garden{
 					Name:       gardenIdentity3,
 					Kubeconfig: "/path/to/kubeconfig",

--- a/pkg/cmd/config/config_test.go
+++ b/pkg/cmd/config/config_test.go
@@ -16,6 +16,7 @@ import (
 
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
 	"github.com/gardener/gardenctl-v2/pkg/config"
+	"github.com/gardener/gardenctl-v2/pkg/target"
 )
 
 var _ = Describe("Config Command", func() {
@@ -55,6 +56,10 @@ var _ = Describe("Config Command", func() {
 			})
 
 			It("should successfully run subcommand set-garden", func() {
+				// gardenIdentity3 isn't the current target -> no kubeconfig refresh.
+				factory.EXPECT().Context().Return(nil).AnyTimes()
+				manager.EXPECT().CurrentTarget().Return(target.NewTarget("", "", "", ""), nil)
+
 				garden := &config.Garden{
 					Name:       gardenIdentity3,
 					Kubeconfig: "/path/to/kubeconfig",

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 	"github.com/gardener/gardenctl-v2/pkg/config"
 	flagsutil "github.com/gardener/gardenctl-v2/pkg/flags"
-	"github.com/gardener/gardenctl-v2/pkg/target"
 )
 
 const (
@@ -68,9 +67,6 @@ gardenctl config set-garden prd-garden --default-shoot-access-level viewer`,
 
 type setGardenOptions struct {
 	base.Options
-	// Manager is the target manager. Held so Run can refresh the active session
-	// kubeconfig when the modified garden is the currently-targeted one.
-	Manager target.Manager
 	// Configuration is the gardenctl configuration
 	Configuration *config.Config
 	// Name is a unique name of this Garden that can be used to target this Garden
@@ -138,7 +134,6 @@ func (o *setGardenOptions) Complete(f util.Factory, _ *cobra.Command, args []str
 		return errors.New("failed to get configuration")
 	}
 
-	o.Manager = manager
 	o.Configuration = cfg
 
 	if len(args) > 0 {
@@ -186,7 +181,7 @@ You may specify any number of extra patterns.`)
 }
 
 // Run executes the command.
-func (o *setGardenOptions) Run(f util.Factory) error {
+func (o *setGardenOptions) Run(_ util.Factory) error {
 	garden, err := o.Configuration.Garden(o.Name)
 	if err == nil {
 		if o.KubeconfigFlag.Provided() {
@@ -232,30 +227,12 @@ func (o *setGardenOptions) Run(f util.Factory) error {
 
 	fmt.Fprintf(o.IOStreams.Out, "Successfully configured garden %q\n", o.Name)
 
-	o.refreshKubeconfigIfTargeted(f)
+	if o.DefaultShootAccessLevelFlag.Provided() || o.DefaultManagedSeedAccessLevelFlag.Provided() {
+		fmt.Fprintf(o.IOStreams.ErrOut,
+			"Note: existing session kubeconfigs are not regenerated. Run `gardenctl target` again for the new access level to take effect.\n")
+	}
 
 	return nil
-}
-
-// refreshKubeconfigIfTargeted regenerates the active session kubeconfig when
-// the modified garden is the currently-targeted one, so config changes (e.g. a
-// new defaultKubeconfigAccessLevel) take effect for in-flight kubectl calls
-// without the user having to re-target. Soft-fails: the config save already
-// succeeded, so we surface refresh errors as a warning rather than failing the
-// command.
-func (o *setGardenOptions) refreshKubeconfigIfTargeted(f util.Factory) {
-	if o.Manager == nil {
-		return
-	}
-
-	currentTarget, err := o.Manager.CurrentTarget()
-	if err != nil || currentTarget.GardenName() != o.Name {
-		return
-	}
-
-	if err := o.Manager.RefreshKubeconfig(f.Context()); err != nil {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Warning: failed to refresh kubeconfig for current target: %v\n", err)
-	}
 }
 
 // applyAccessLevelFlags writes the per-scope access level flags into the Garden's

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -19,6 +19,13 @@ import (
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
 	"github.com/gardener/gardenctl-v2/pkg/config"
+	flagsutil "github.com/gardener/gardenctl-v2/pkg/flags"
+	"github.com/gardener/gardenctl-v2/pkg/target"
+)
+
+const (
+	FlagDefaultShootAccessLevel       = "default-shoot-access-level"
+	FlagDefaultManagedSeedAccessLevel = "default-managed-seed-access-level"
 )
 
 // NewCmdConfigSetGarden returns a new (config) set-garden command.
@@ -43,18 +50,27 @@ CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonp
 gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
 
 # configure my-garden with a context and patterns
-gardenctl config set-garden my-garden --context garden-context --pattern "^(?:landscape-dev/)?shoot--(?P<project>.+)--(?P<shoot>.+)$" --pattern "https://dashboard\.gardener\.cloud/namespace/(?P<namespace>[^/]+)/shoots/(?P<shoot>[^/]+)`,
+gardenctl config set-garden my-garden --context garden-context --pattern "^(?:landscape-dev/)?shoot--(?P<project>.+)--(?P<shoot>.+)$" --pattern "https://dashboard\.gardener\.cloud/namespace/(?P<namespace>[^/]+)/shoots/(?P<shoot>[^/]+)"
+
+# configure prd-garden so shoot kubeconfigs default to read-only viewer access (managed seed access stays at admin)
+gardenctl config set-garden prd-garden --default-shoot-access-level viewer`,
 		ValidArgsFunction: validGardenArgsFunctionWrapper(f, ioStreams),
 		RunE:              base.WrapRunE(o, f),
 	}
 
 	o.AddFlags(cmd.Flags())
 
+	flagsutil.RegisterKubeconfigAccessLevelCompletion(cmd, FlagDefaultShootAccessLevel)
+	flagsutil.RegisterKubeconfigAccessLevelCompletion(cmd, FlagDefaultManagedSeedAccessLevel)
+
 	return cmd
 }
 
 type setGardenOptions struct {
 	base.Options
+	// Manager is the target manager. Held so Run can refresh the active session
+	// kubeconfig when the modified garden is the currently-targeted one.
+	Manager target.Manager
 	// Configuration is the gardenctl configuration
 	Configuration *config.Config
 	// Name is a unique name of this Garden that can be used to target this Garden
@@ -72,16 +88,58 @@ type setGardenOptions struct {
 	// Supported capturing groups: project, namespace, shoot
 	// +optional
 	Patterns []string
+	// DefaultShootAccessLevelFlag sets defaultKubeconfigAccessLevel.shoots in the
+	// stored Garden config (admin | viewer | auto).
+	// +optional
+	DefaultShootAccessLevelFlag accessLevelFlag
+	// DefaultManagedSeedAccessLevelFlag sets defaultKubeconfigAccessLevel.managedSeeds
+	// in the stored Garden config (admin | viewer | auto).
+	// +optional
+	DefaultManagedSeedAccessLevelFlag accessLevelFlag
 }
 
-// Complete adapts from the command line args to the data required.
-func (o *setGardenOptions) Complete(f util.Factory, _ *cobra.Command, args []string) error {
-	config, err := getConfiguration(f)
-	if err != nil {
+// accessLevelFlag is a pflag.Value for config.KubeconfigAccessLevel that also
+// tracks whether the flag was explicitly provided on the command line. This
+// lets set-garden distinguish "user wants to set to X" from "user did not
+// touch this field" - important when updating an existing Garden entry.
+type accessLevelFlag struct {
+	provided bool
+	value    config.KubeconfigAccessLevel
+}
+
+var _ pflag.Value = (*accessLevelFlag)(nil)
+
+func (f *accessLevelFlag) Set(value string) error {
+	candidate := config.KubeconfigAccessLevel(value)
+	if err := candidate.Validate(); err != nil {
 		return err
 	}
 
-	o.Configuration = config
+	f.value = candidate
+	f.provided = true
+
+	return nil
+}
+
+func (f *accessLevelFlag) Type() string                        { return "string" }
+func (f *accessLevelFlag) String() string                      { return string(f.value) }
+func (f *accessLevelFlag) Provided() bool                      { return f.provided }
+func (f *accessLevelFlag) Value() config.KubeconfigAccessLevel { return f.value }
+
+// Complete adapts from the command line args to the data required.
+func (o *setGardenOptions) Complete(f util.Factory, _ *cobra.Command, args []string) error {
+	manager, err := f.Manager()
+	if err != nil {
+		return fmt.Errorf("failed to get target manager: %w", err)
+	}
+
+	cfg := manager.Configuration()
+	if cfg == nil {
+		return errors.New("failed to get configuration")
+	}
+
+	o.Manager = manager
+	o.Configuration = cfg
 
 	if len(args) > 0 {
 		o.Name = strings.TrimSpace(args[0])
@@ -119,10 +177,16 @@ Use named capturing groups to match target values.
 Supported capturing groups: project, namespace, shoot.
 Note that if you set this flag it will overwrite the pattern list in the config file.
 You may specify any number of extra patterns.`)
+	flags.Var(&o.DefaultShootAccessLevelFlag, FlagDefaultShootAccessLevel,
+		fmt.Sprintf(`default kubeconfig access level when targeting shoots in this garden. One of %q, %q, %q. Pass an empty value to reset to the built-in default (%q).`,
+			config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelViewer, config.KubeconfigAccessLevelAuto, config.KubeconfigAccessLevelAdmin))
+	flags.Var(&o.DefaultManagedSeedAccessLevelFlag, FlagDefaultManagedSeedAccessLevel,
+		fmt.Sprintf(`default kubeconfig access level when targeting managed seeds in this garden. One of %q, %q, %q. Pass an empty value to reset to the built-in default (%q).`,
+			config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelViewer, config.KubeconfigAccessLevelAuto, config.KubeconfigAccessLevelAdmin))
 }
 
 // Run executes the command.
-func (o *setGardenOptions) Run(_ util.Factory) error {
+func (o *setGardenOptions) Run(f util.Factory) error {
 	garden, err := o.Configuration.Garden(o.Name)
 	if err == nil {
 		if o.KubeconfigFlag.Provided() {
@@ -145,14 +209,20 @@ func (o *setGardenOptions) Run(_ util.Factory) error {
 				garden.Patterns = nil
 			}
 		}
+
+		o.applyAccessLevelFlags(garden)
 	} else {
-		o.Configuration.Gardens = append(o.Configuration.Gardens, config.Garden{
+		newGarden := config.Garden{
 			Name:       o.Name,
 			Kubeconfig: o.KubeconfigFlag.Value(),
 			Context:    o.ContextFlag.Value(),
 			Alias:      o.Alias.Value(),
 			Patterns:   o.Patterns,
-		})
+		}
+
+		o.applyAccessLevelFlags(&newGarden)
+
+		o.Configuration.Gardens = append(o.Configuration.Gardens, newGarden)
 	}
 
 	err = o.Configuration.Save()
@@ -162,7 +232,55 @@ func (o *setGardenOptions) Run(_ util.Factory) error {
 
 	fmt.Fprintf(o.IOStreams.Out, "Successfully configured garden %q\n", o.Name)
 
+	o.refreshKubeconfigIfTargeted(f)
+
 	return nil
+}
+
+// refreshKubeconfigIfTargeted regenerates the active session kubeconfig when
+// the modified garden is the currently-targeted one, so config changes (e.g. a
+// new defaultKubeconfigAccessLevel) take effect for in-flight kubectl calls
+// without the user having to re-target. Soft-fails: the config save already
+// succeeded, so we surface refresh errors as a warning rather than failing the
+// command.
+func (o *setGardenOptions) refreshKubeconfigIfTargeted(f util.Factory) {
+	if o.Manager == nil {
+		return
+	}
+
+	currentTarget, err := o.Manager.CurrentTarget()
+	if err != nil || currentTarget.GardenName() != o.Name {
+		return
+	}
+
+	if err := o.Manager.RefreshKubeconfig(f.Context()); err != nil {
+		fmt.Fprintf(o.IOStreams.ErrOut, "Warning: failed to refresh kubeconfig for current target: %v\n", err)
+	}
+}
+
+// applyAccessLevelFlags writes the per-scope access level flags into the Garden's
+// DefaultKubeconfigAccessLevel, allocating the struct lazily and clearing it when
+// both fields end up empty so we don't litter the config file with empty objects.
+func (o *setGardenOptions) applyAccessLevelFlags(garden *config.Garden) {
+	if !o.DefaultShootAccessLevelFlag.Provided() && !o.DefaultManagedSeedAccessLevelFlag.Provided() {
+		return
+	}
+
+	if garden.DefaultKubeconfigAccessLevel == nil {
+		garden.DefaultKubeconfigAccessLevel = &config.KubeconfigAccessLevels{}
+	}
+
+	if o.DefaultShootAccessLevelFlag.Provided() {
+		garden.DefaultKubeconfigAccessLevel.Shoots = o.DefaultShootAccessLevelFlag.Value()
+	}
+
+	if o.DefaultManagedSeedAccessLevelFlag.Provided() {
+		garden.DefaultKubeconfigAccessLevel.ManagedSeeds = o.DefaultManagedSeedAccessLevelFlag.Value()
+	}
+
+	if garden.DefaultKubeconfigAccessLevel.Shoots == "" && garden.DefaultKubeconfigAccessLevel.ManagedSeeds == "" {
+		garden.DefaultKubeconfigAccessLevel = nil
+	}
 }
 
 func validatePatterns(patterns []string) error {

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -84,11 +84,11 @@ type setGardenOptions struct {
 	// Supported capturing groups: project, namespace, shoot
 	// +optional
 	Patterns []string
-	// DefaultShootAccessLevelFlag sets defaultKubeconfigAccessLevel.shoots in the
+	// DefaultShootAccessLevelFlag sets kubeconfigAccessLevelDefaults.shoots in the
 	// stored Garden config (admin | viewer | auto).
 	// +optional
 	DefaultShootAccessLevelFlag accessLevelFlag
-	// DefaultManagedSeedAccessLevelFlag sets defaultKubeconfigAccessLevel.managedSeeds
+	// DefaultManagedSeedAccessLevelFlag sets kubeconfigAccessLevelDefaults.managedSeeds
 	// in the stored Garden config (admin | viewer | auto).
 	// +optional
 	DefaultManagedSeedAccessLevelFlag accessLevelFlag
@@ -236,27 +236,27 @@ func (o *setGardenOptions) Run(_ util.Factory) error {
 }
 
 // applyAccessLevelFlags writes the per-scope access level flags into the Garden's
-// DefaultKubeconfigAccessLevel, allocating the struct lazily and clearing it when
+// KubeconfigAccessLevelDefaults, allocating the struct lazily and clearing it when
 // both fields end up empty so we don't litter the config file with empty objects.
 func (o *setGardenOptions) applyAccessLevelFlags(garden *config.Garden) {
 	if !o.DefaultShootAccessLevelFlag.Provided() && !o.DefaultManagedSeedAccessLevelFlag.Provided() {
 		return
 	}
 
-	if garden.DefaultKubeconfigAccessLevel == nil {
-		garden.DefaultKubeconfigAccessLevel = &config.KubeconfigAccessLevels{}
+	if garden.KubeconfigAccessLevelDefaults == nil {
+		garden.KubeconfigAccessLevelDefaults = &config.KubeconfigAccessLevels{}
 	}
 
 	if o.DefaultShootAccessLevelFlag.Provided() {
-		garden.DefaultKubeconfigAccessLevel.Shoots = o.DefaultShootAccessLevelFlag.Value()
+		garden.KubeconfigAccessLevelDefaults.Shoots = o.DefaultShootAccessLevelFlag.Value()
 	}
 
 	if o.DefaultManagedSeedAccessLevelFlag.Provided() {
-		garden.DefaultKubeconfigAccessLevel.ManagedSeeds = o.DefaultManagedSeedAccessLevelFlag.Value()
+		garden.KubeconfigAccessLevelDefaults.ManagedSeeds = o.DefaultManagedSeedAccessLevelFlag.Value()
 	}
 
-	if garden.DefaultKubeconfigAccessLevel.Shoots == "" && garden.DefaultKubeconfigAccessLevel.ManagedSeeds == "" {
-		garden.DefaultKubeconfigAccessLevel = nil
+	if garden.KubeconfigAccessLevelDefaults.Shoots == "" && garden.KubeconfigAccessLevelDefaults.ManagedSeeds == "" {
+		garden.KubeconfigAccessLevelDefaults = nil
 	}
 }
 

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	FlagDefaultShootAccessLevel       = "default-shoot-access-level"
-	FlagDefaultSeedAccessLevel        = "default-seed-access-level"
+	FlagDefaultShootAccessLevel = "default-shoot-access-level"
+	FlagDefaultSeedAccessLevel  = "default-seed-access-level"
 )
 
 // NewCmdConfigSetGarden returns a new (config) set-garden command.

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -85,11 +85,11 @@ type setGardenOptions struct {
 	// +optional
 	Patterns []string
 	// DefaultShootAccessLevelFlag sets kubeconfigAccessLevelDefaults.shoots in the
-	// stored Garden config (admin | viewer | auto).
+	// stored Garden config (admin | viewer | auto | "" to delegate to gardenlogin's default).
 	// +optional
 	DefaultShootAccessLevelFlag accessLevelFlag
 	// DefaultSeedAccessLevelFlag sets kubeconfigAccessLevelDefaults.seeds in the
-	// stored Garden config (admin | viewer | auto).
+	// stored Garden config (admin | viewer | auto | "" to delegate to gardenlogin's default).
 	// +optional
 	DefaultSeedAccessLevelFlag accessLevelFlag
 }
@@ -173,11 +173,11 @@ Supported capturing groups: project, namespace, shoot.
 Note that if you set this flag it will overwrite the pattern list in the config file.
 You may specify any number of extra patterns.`)
 	flags.Var(&o.DefaultShootAccessLevelFlag, FlagDefaultShootAccessLevel,
-		fmt.Sprintf(`default kubeconfig access level when targeting shoots in this garden. One of %q, %q, %q. Pass an empty value to reset to the built-in default (%q).`,
-			config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelViewer, config.KubeconfigAccessLevelAuto, config.KubeconfigAccessLevelAdmin))
+		fmt.Sprintf(`default kubeconfig access level when targeting shoots in this garden. One of %q, %q, %q. Pass an empty value to unset and delegate to gardenlogin's default.`,
+			config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelViewer, config.KubeconfigAccessLevelAuto))
 	flags.Var(&o.DefaultSeedAccessLevelFlag, FlagDefaultSeedAccessLevel,
-		fmt.Sprintf(`default kubeconfig access level when targeting seeds in this garden (and shoots that back a managed seed, since they physically are the seed cluster). One of %q, %q, %q. Pass an empty value to reset to the built-in default (%q).`,
-			config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelViewer, config.KubeconfigAccessLevelAuto, config.KubeconfigAccessLevelAdmin))
+		fmt.Sprintf(`default kubeconfig access level when targeting seeds in this garden (and shoots that back a managed seed, since they physically are the seed cluster). One of %q, %q, %q. Pass an empty value to unset and delegate to gardenlogin's default.`,
+			config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelViewer, config.KubeconfigAccessLevelAuto))
 }
 
 // Run executes the command.
@@ -229,7 +229,7 @@ func (o *setGardenOptions) Run(_ util.Factory) error {
 
 	if o.DefaultShootAccessLevelFlag.Provided() || o.DefaultSeedAccessLevelFlag.Provided() {
 		fmt.Fprintf(o.IOStreams.ErrOut,
-			"Note: existing session kubeconfigs are not regenerated. Run `gardenctl target` again for the new access level to take effect.\n")
+			"\nNote: existing session kubeconfigs are not regenerated. Run `gardenctl target` again for the new access level to take effect.\n")
 	}
 
 	return nil

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	FlagDefaultShootAccessLevel       = "default-shoot-access-level"
-	FlagDefaultManagedSeedAccessLevel = "default-managed-seed-access-level"
+	FlagDefaultSeedAccessLevel        = "default-seed-access-level"
 )
 
 // NewCmdConfigSetGarden returns a new (config) set-garden command.
@@ -51,7 +51,7 @@ gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
 # configure my-garden with a context and patterns
 gardenctl config set-garden my-garden --context garden-context --pattern "^(?:landscape-dev/)?shoot--(?P<project>.+)--(?P<shoot>.+)$" --pattern "https://dashboard\.gardener\.cloud/namespace/(?P<namespace>[^/]+)/shoots/(?P<shoot>[^/]+)"
 
-# configure prd-garden so shoot kubeconfigs default to read-only viewer access (managed seed access stays at admin)
+# configure prd-garden so shoot kubeconfigs default to read-only viewer access (seed access stays at admin)
 gardenctl config set-garden prd-garden --default-shoot-access-level viewer`,
 		ValidArgsFunction: validGardenArgsFunctionWrapper(f, ioStreams),
 		RunE:              base.WrapRunE(o, f),
@@ -60,7 +60,7 @@ gardenctl config set-garden prd-garden --default-shoot-access-level viewer`,
 	o.AddFlags(cmd.Flags())
 
 	flagsutil.RegisterKubeconfigAccessLevelCompletion(cmd, FlagDefaultShootAccessLevel)
-	flagsutil.RegisterKubeconfigAccessLevelCompletion(cmd, FlagDefaultManagedSeedAccessLevel)
+	flagsutil.RegisterKubeconfigAccessLevelCompletion(cmd, FlagDefaultSeedAccessLevel)
 
 	return cmd
 }
@@ -88,10 +88,10 @@ type setGardenOptions struct {
 	// stored Garden config (admin | viewer | auto).
 	// +optional
 	DefaultShootAccessLevelFlag accessLevelFlag
-	// DefaultManagedSeedAccessLevelFlag sets kubeconfigAccessLevelDefaults.managedSeeds
-	// in the stored Garden config (admin | viewer | auto).
+	// DefaultSeedAccessLevelFlag sets kubeconfigAccessLevelDefaults.seeds in the
+	// stored Garden config (admin | viewer | auto).
 	// +optional
-	DefaultManagedSeedAccessLevelFlag accessLevelFlag
+	DefaultSeedAccessLevelFlag accessLevelFlag
 }
 
 // accessLevelFlag is a pflag.Value for config.KubeconfigAccessLevel that also
@@ -175,8 +175,8 @@ You may specify any number of extra patterns.`)
 	flags.Var(&o.DefaultShootAccessLevelFlag, FlagDefaultShootAccessLevel,
 		fmt.Sprintf(`default kubeconfig access level when targeting shoots in this garden. One of %q, %q, %q. Pass an empty value to reset to the built-in default (%q).`,
 			config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelViewer, config.KubeconfigAccessLevelAuto, config.KubeconfigAccessLevelAdmin))
-	flags.Var(&o.DefaultManagedSeedAccessLevelFlag, FlagDefaultManagedSeedAccessLevel,
-		fmt.Sprintf(`default kubeconfig access level when targeting managed seeds in this garden. One of %q, %q, %q. Pass an empty value to reset to the built-in default (%q).`,
+	flags.Var(&o.DefaultSeedAccessLevelFlag, FlagDefaultSeedAccessLevel,
+		fmt.Sprintf(`default kubeconfig access level when targeting seeds in this garden (and shoots that back a managed seed, since they physically are the seed cluster). One of %q, %q, %q. Pass an empty value to reset to the built-in default (%q).`,
 			config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelViewer, config.KubeconfigAccessLevelAuto, config.KubeconfigAccessLevelAdmin))
 }
 
@@ -227,7 +227,7 @@ func (o *setGardenOptions) Run(_ util.Factory) error {
 
 	fmt.Fprintf(o.IOStreams.Out, "Successfully configured garden %q\n", o.Name)
 
-	if o.DefaultShootAccessLevelFlag.Provided() || o.DefaultManagedSeedAccessLevelFlag.Provided() {
+	if o.DefaultShootAccessLevelFlag.Provided() || o.DefaultSeedAccessLevelFlag.Provided() {
 		fmt.Fprintf(o.IOStreams.ErrOut,
 			"Note: existing session kubeconfigs are not regenerated. Run `gardenctl target` again for the new access level to take effect.\n")
 	}
@@ -239,7 +239,7 @@ func (o *setGardenOptions) Run(_ util.Factory) error {
 // KubeconfigAccessLevelDefaults, allocating the struct lazily and clearing it when
 // both fields end up empty so we don't litter the config file with empty objects.
 func (o *setGardenOptions) applyAccessLevelFlags(garden *config.Garden) {
-	if !o.DefaultShootAccessLevelFlag.Provided() && !o.DefaultManagedSeedAccessLevelFlag.Provided() {
+	if !o.DefaultShootAccessLevelFlag.Provided() && !o.DefaultSeedAccessLevelFlag.Provided() {
 		return
 	}
 
@@ -251,11 +251,11 @@ func (o *setGardenOptions) applyAccessLevelFlags(garden *config.Garden) {
 		garden.KubeconfigAccessLevelDefaults.Shoots = o.DefaultShootAccessLevelFlag.Value()
 	}
 
-	if o.DefaultManagedSeedAccessLevelFlag.Provided() {
-		garden.KubeconfigAccessLevelDefaults.ManagedSeeds = o.DefaultManagedSeedAccessLevelFlag.Value()
+	if o.DefaultSeedAccessLevelFlag.Provided() {
+		garden.KubeconfigAccessLevelDefaults.Seeds = o.DefaultSeedAccessLevelFlag.Value()
 	}
 
-	if garden.KubeconfigAccessLevelDefaults.Shoots == "" && garden.KubeconfigAccessLevelDefaults.ManagedSeeds == "" {
+	if garden.KubeconfigAccessLevelDefaults.Shoots == "" && garden.KubeconfigAccessLevelDefaults.Seeds == "" {
 		garden.KubeconfigAccessLevelDefaults = nil
 	}
 }

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -94,33 +94,26 @@ type setGardenOptions struct {
 	DefaultSeedAccessLevelFlag accessLevelFlag
 }
 
-// accessLevelFlag is a pflag.Value for config.KubeconfigAccessLevel that also
-// tracks whether the flag was explicitly provided on the command line. This
-// lets set-garden distinguish "user wants to set to X" from "user did not
-// touch this field" - important when updating an existing Garden entry.
+// accessLevelFlag wraps flag.StringFlag to validate config.KubeconfigAccessLevel
+// values at parse time while inheriting the standard provided-tracking semantics
+// used by the other flags in this command.
 type accessLevelFlag struct {
-	provided bool
-	value    config.KubeconfigAccessLevel
+	flag.StringFlag
 }
 
 var _ pflag.Value = (*accessLevelFlag)(nil)
 
 func (f *accessLevelFlag) Set(value string) error {
-	candidate := config.KubeconfigAccessLevel(value)
-	if err := candidate.Validate(); err != nil {
+	if err := config.KubeconfigAccessLevel(value).Validate(); err != nil {
 		return err
 	}
 
-	f.value = candidate
-	f.provided = true
-
-	return nil
+	return f.StringFlag.Set(value)
 }
 
-func (f *accessLevelFlag) Type() string                        { return "string" }
-func (f *accessLevelFlag) String() string                      { return string(f.value) }
-func (f *accessLevelFlag) Provided() bool                      { return f.provided }
-func (f *accessLevelFlag) Value() config.KubeconfigAccessLevel { return f.value }
+func (f *accessLevelFlag) AccessLevel() config.KubeconfigAccessLevel {
+	return config.KubeconfigAccessLevel(f.Value())
+}
 
 // Complete adapts from the command line args to the data required.
 func (o *setGardenOptions) Complete(f util.Factory, _ *cobra.Command, args []string) error {
@@ -248,11 +241,11 @@ func (o *setGardenOptions) applyAccessLevelFlags(garden *config.Garden) {
 	}
 
 	if o.DefaultShootAccessLevelFlag.Provided() {
-		garden.KubeconfigAccessLevelDefaults.Shoots = o.DefaultShootAccessLevelFlag.Value()
+		garden.KubeconfigAccessLevelDefaults.Shoots = o.DefaultShootAccessLevelFlag.AccessLevel()
 	}
 
 	if o.DefaultSeedAccessLevelFlag.Provided() {
-		garden.KubeconfigAccessLevelDefaults.Seeds = o.DefaultSeedAccessLevelFlag.Value()
+		garden.KubeconfigAccessLevelDefaults.Seeds = o.DefaultSeedAccessLevelFlag.AccessLevel()
 	}
 
 	if garden.KubeconfigAccessLevelDefaults.Shoots == "" && garden.KubeconfigAccessLevelDefaults.Seeds == "" {

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -7,6 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package config_test
 
 import (
+	"errors"
+
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -14,6 +17,7 @@ import (
 
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
 	"github.com/gardener/gardenctl-v2/pkg/config"
+	"github.com/gardener/gardenctl-v2/pkg/target"
 )
 
 var _ = Describe("Config Subcommand SetGarden", func() {
@@ -28,7 +32,7 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 			Expect(cmd.Use).To(Equal("set-garden"))
 			Expect(cmd.ValidArgsFunction).NotTo(BeNil())
 			Expect(cmd.ValidArgs).To(BeNil())
-			assertAllFlagNames(cmd.Flags(), "alias", "context", "kubeconfig", "pattern")
+			assertAllFlagNames(cmd.Flags(), "alias", "context", "default-managed-seed-access-level", "default-shoot-access-level", "kubeconfig", "pattern")
 		})
 	})
 
@@ -55,7 +59,15 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 					manager.EXPECT().Configuration().Return(cfg)
 					Expect(options.Complete(factory, nil, []string{" garden "})).To(Succeed())
 					Expect(options.Configuration).To(BeIdenticalTo(cfg))
+					Expect(options.Manager).To(BeIdenticalTo(manager))
 					Expect(options.Name).To(Equal("garden"))
+				})
+			})
+
+			Context("when getting the manager fails", func() {
+				It("should propagate the error", func() {
+					factory.EXPECT().Manager().Return(nil, errors.New("boom"))
+					Expect(options.Complete(factory, nil, nil)).To(MatchError(MatchRegexp("^failed to get target manager")))
 				})
 			})
 		})
@@ -167,6 +179,142 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 			It("should fail when the filename is invalid", func() {
 				options.Configuration.Filename = string([]byte{0})
 				Expect(options.Run(nil)).To(MatchError(MatchRegexp("^failed to configure garden")))
+			})
+
+			Describe("default kubeconfig access level flags", func() {
+				It("sets shoots and managedSeeds on a new garden", func() {
+					options.Name = gardenIdentity3
+					Expect(options.KubeconfigFlag.Set(pathToKubeconfig)).To(Succeed())
+					Expect(options.DefaultShootAccessLevelFlag.Set(string(config.KubeconfigAccessLevelViewer))).To(Succeed())
+					Expect(options.DefaultManagedSeedAccessLevelFlag.Set(string(config.KubeconfigAccessLevelAdmin))).To(Succeed())
+					Expect(options.Run(nil)).To(Succeed())
+
+					assertGarden(cfg, &config.Garden{
+						Name:       gardenIdentity3,
+						Kubeconfig: pathToKubeconfig,
+						DefaultKubeconfigAccessLevel: &config.KubeconfigAccessLevels{
+							Shoots:       config.KubeconfigAccessLevelViewer,
+							ManagedSeeds: config.KubeconfigAccessLevelAdmin,
+						},
+					})
+				})
+
+				It("sets only the provided sub-field on an existing garden, leaving the other untouched", func() {
+					options.Name = gardenIdentity1
+					Expect(options.DefaultShootAccessLevelFlag.Set(string(config.KubeconfigAccessLevelViewer))).To(Succeed())
+					Expect(options.Run(nil)).To(Succeed())
+
+					garden, err := cfg.Garden(gardenIdentity1)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(garden.DefaultKubeconfigAccessLevel).NotTo(BeNil())
+					Expect(garden.DefaultKubeconfigAccessLevel.Shoots).To(Equal(config.KubeconfigAccessLevelViewer))
+					Expect(garden.DefaultKubeconfigAccessLevel.ManagedSeeds).To(BeEmpty())
+				})
+
+				It("clears the struct when both fields end up empty", func() {
+					options.Name = gardenIdentity1
+					// Pre-seed the garden with a non-nil struct so we can prove it gets cleared.
+					garden, err := cfg.Garden(gardenIdentity1)
+					Expect(err).NotTo(HaveOccurred())
+
+					garden.DefaultKubeconfigAccessLevel = &config.KubeconfigAccessLevels{
+						Shoots: config.KubeconfigAccessLevelViewer,
+					}
+
+					Expect(options.DefaultShootAccessLevelFlag.Set("")).To(Succeed())
+					Expect(options.Run(nil)).To(Succeed())
+
+					garden, err = cfg.Garden(gardenIdentity1)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(garden.DefaultKubeconfigAccessLevel).To(BeNil())
+				})
+
+				It("rejects an invalid value at flag-parse time", func() {
+					Expect(options.DefaultShootAccessLevelFlag.Set("guest")).
+						To(MatchError(ContainSubstring(`invalid kubeconfig access level "guest"`)))
+				})
+			})
+
+			Describe("--default-*-access-level flags via real cobra flag parsing", func() {
+				It("clears the per-scope field when an empty value is parsed", func() {
+					// Pre-seed the existing garden with a non-nil struct.
+					existing, err := cfg.Garden(gardenIdentity1)
+
+					Expect(err).NotTo(HaveOccurred())
+
+					existing.DefaultKubeconfigAccessLevel = &config.KubeconfigAccessLevels{
+						Shoots: config.KubeconfigAccessLevelViewer,
+					}
+
+					factory.EXPECT().Manager().Return(manager, nil)
+					manager.EXPECT().Configuration().Return(cfg)
+					// Modified garden is not the current target -> refresh path is skipped.
+					manager.EXPECT().CurrentTarget().Return(target.NewTarget("", "", "", ""), nil)
+					factory.EXPECT().Context().Return(nil).AnyTimes()
+
+					cmd := cmdconfig.NewCmdConfigSetGarden(factory, streams)
+					cmd.SetArgs([]string{
+						gardenIdentity1,
+						"--default-shoot-access-level=",
+					})
+					Expect(cmd.Execute()).To(Succeed())
+
+					updated, err := cfg.Garden(gardenIdentity1)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(updated.DefaultKubeconfigAccessLevel).To(BeNil())
+				})
+
+				It("rejects an invalid value during cobra parse, never reaching Run", func() {
+					// No factory/manager EXPECTs: cobra rejects the flag value before
+					// PreRun/Run fires, so none of our code is invoked.
+					cmd := cmdconfig.NewCmdConfigSetGarden(factory, streams)
+					cmd.SetArgs([]string{
+						gardenIdentity1,
+						"--default-shoot-access-level=guest",
+					})
+					Expect(cmd.Execute()).To(MatchError(ContainSubstring(`invalid kubeconfig access level "guest"`)))
+				})
+			})
+
+			Describe("automatic kubeconfig refresh after a config change", func() {
+				BeforeEach(func() {
+					// The Run path needs a Factory only for f.Context() in the refresh
+					// soft-fail branch, so a mock that returns a real ctx is enough.
+					factory.EXPECT().Context().Return(nil).AnyTimes()
+
+					options.Manager = manager
+				})
+
+				It("refreshes the kubeconfig when the modified garden is the current target", func() {
+					options.Name = gardenIdentity1
+					Expect(options.DefaultShootAccessLevelFlag.Set(string(config.KubeconfigAccessLevelViewer))).To(Succeed())
+
+					manager.EXPECT().CurrentTarget().Return(target.NewTarget(gardenIdentity1, "", "", ""), nil)
+					manager.EXPECT().RefreshKubeconfig(gomock.Any()).Return(nil)
+
+					Expect(options.Run(factory)).To(Succeed())
+				})
+
+				It("does not refresh when the modified garden is not the current target", func() {
+					options.Name = gardenIdentity1
+					Expect(options.DefaultShootAccessLevelFlag.Set(string(config.KubeconfigAccessLevelViewer))).To(Succeed())
+
+					manager.EXPECT().CurrentTarget().Return(target.NewTarget(gardenIdentity2, "", "", ""), nil)
+					// No RefreshKubeconfig expectation - Mock would FAIL on an unexpected call.
+
+					Expect(options.Run(factory)).To(Succeed())
+				})
+
+				It("soft-fails (warns, does not error) when refresh fails", func() {
+					options.Name = gardenIdentity1
+					Expect(options.DefaultShootAccessLevelFlag.Set(string(config.KubeconfigAccessLevelViewer))).To(Succeed())
+
+					manager.EXPECT().CurrentTarget().Return(target.NewTarget(gardenIdentity1, "", "", ""), nil)
+					manager.EXPECT().RefreshKubeconfig(gomock.Any()).Return(errors.New("refresh boom"))
+
+					Expect(options.Run(factory)).To(Succeed())
+					Expect(errOut.String()).To(ContainSubstring("Warning: failed to refresh kubeconfig"))
+				})
 			})
 		})
 	})

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 					assertGarden(cfg, &config.Garden{
 						Name:       gardenIdentity3,
 						Kubeconfig: pathToKubeconfig,
-						DefaultKubeconfigAccessLevel: &config.KubeconfigAccessLevels{
+						KubeconfigAccessLevelDefaults: &config.KubeconfigAccessLevels{
 							Shoots:       config.KubeconfigAccessLevelViewer,
 							ManagedSeeds: config.KubeconfigAccessLevelAdmin,
 						},
@@ -203,9 +203,9 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 
 					garden, err := cfg.Garden(gardenIdentity1)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(garden.DefaultKubeconfigAccessLevel).NotTo(BeNil())
-					Expect(garden.DefaultKubeconfigAccessLevel.Shoots).To(Equal(config.KubeconfigAccessLevelViewer))
-					Expect(garden.DefaultKubeconfigAccessLevel.ManagedSeeds).To(BeEmpty())
+					Expect(garden.KubeconfigAccessLevelDefaults).NotTo(BeNil())
+					Expect(garden.KubeconfigAccessLevelDefaults.Shoots).To(Equal(config.KubeconfigAccessLevelViewer))
+					Expect(garden.KubeconfigAccessLevelDefaults.ManagedSeeds).To(BeEmpty())
 				})
 
 				It("clears the struct when both fields end up empty", func() {
@@ -214,7 +214,7 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 					garden, err := cfg.Garden(gardenIdentity1)
 					Expect(err).NotTo(HaveOccurred())
 
-					garden.DefaultKubeconfigAccessLevel = &config.KubeconfigAccessLevels{
+					garden.KubeconfigAccessLevelDefaults = &config.KubeconfigAccessLevels{
 						Shoots: config.KubeconfigAccessLevelViewer,
 					}
 
@@ -223,7 +223,7 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 
 					garden, err = cfg.Garden(gardenIdentity1)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(garden.DefaultKubeconfigAccessLevel).To(BeNil())
+					Expect(garden.KubeconfigAccessLevelDefaults).To(BeNil())
 				})
 
 				It("rejects an invalid value at flag-parse time", func() {
@@ -239,7 +239,7 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 
 					Expect(err).NotTo(HaveOccurred())
 
-					existing.DefaultKubeconfigAccessLevel = &config.KubeconfigAccessLevels{
+					existing.KubeconfigAccessLevelDefaults = &config.KubeconfigAccessLevels{
 						Shoots: config.KubeconfigAccessLevelViewer,
 					}
 
@@ -255,7 +255,7 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 
 					updated, err := cfg.Garden(gardenIdentity1)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(updated.DefaultKubeconfigAccessLevel).To(BeNil())
+					Expect(updated.KubeconfigAccessLevelDefaults).To(BeNil())
 				})
 
 				It("rejects an invalid value during cobra parse, never reaching Run", func() {

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -208,28 +208,6 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 					Expect(garden.KubeconfigAccessLevelDefaults.ManagedSeeds).To(BeEmpty())
 				})
 
-				It("clears the struct when both fields end up empty", func() {
-					options.Name = gardenIdentity1
-					// Pre-seed the garden with a non-nil struct so we can prove it gets cleared.
-					garden, err := cfg.Garden(gardenIdentity1)
-					Expect(err).NotTo(HaveOccurred())
-
-					garden.KubeconfigAccessLevelDefaults = &config.KubeconfigAccessLevels{
-						Shoots: config.KubeconfigAccessLevelViewer,
-					}
-
-					Expect(options.DefaultShootAccessLevelFlag.Set("")).To(Succeed())
-					Expect(options.Run(nil)).To(Succeed())
-
-					garden, err = cfg.Garden(gardenIdentity1)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(garden.KubeconfigAccessLevelDefaults).To(BeNil())
-				})
-
-				It("rejects an invalid value at flag-parse time", func() {
-					Expect(options.DefaultShootAccessLevelFlag.Set("guest")).
-						To(MatchError(ContainSubstring(`invalid kubeconfig access level "guest"`)))
-				})
 			})
 
 			Describe("--default-*-access-level flags via real cobra flag parsing", func() {

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -9,7 +9,6 @@ package config_test
 import (
 	"errors"
 
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
@@ -17,7 +16,6 @@ import (
 
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
 	"github.com/gardener/gardenctl-v2/pkg/config"
-	"github.com/gardener/gardenctl-v2/pkg/target"
 )
 
 var _ = Describe("Config Subcommand SetGarden", func() {
@@ -59,7 +57,6 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 					manager.EXPECT().Configuration().Return(cfg)
 					Expect(options.Complete(factory, nil, []string{" garden "})).To(Succeed())
 					Expect(options.Configuration).To(BeIdenticalTo(cfg))
-					Expect(options.Manager).To(BeIdenticalTo(manager))
 					Expect(options.Name).To(Equal("garden"))
 				})
 			})
@@ -248,9 +245,6 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 
 					factory.EXPECT().Manager().Return(manager, nil)
 					manager.EXPECT().Configuration().Return(cfg)
-					// Modified garden is not the current target -> refresh path is skipped.
-					manager.EXPECT().CurrentTarget().Return(target.NewTarget("", "", "", ""), nil)
-					factory.EXPECT().Context().Return(nil).AnyTimes()
 
 					cmd := cmdconfig.NewCmdConfigSetGarden(factory, streams)
 					cmd.SetArgs([]string{
@@ -274,46 +268,20 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 					})
 					Expect(cmd.Execute()).To(MatchError(ContainSubstring(`invalid kubeconfig access level "guest"`)))
 				})
-			})
 
-			Describe("automatic kubeconfig refresh after a config change", func() {
-				BeforeEach(func() {
-					// The Run path needs a Factory only for f.Context() in the refresh
-					// soft-fail branch, so a mock that returns a real ctx is enough.
-					factory.EXPECT().Context().Return(nil).AnyTimes()
-
-					options.Manager = manager
-				})
-
-				It("refreshes the kubeconfig when the modified garden is the current target", func() {
+				It("prints a re-target hint when an access-level flag was changed", func() {
 					options.Name = gardenIdentity1
 					Expect(options.DefaultShootAccessLevelFlag.Set(string(config.KubeconfigAccessLevelViewer))).To(Succeed())
 
-					manager.EXPECT().CurrentTarget().Return(target.NewTarget(gardenIdentity1, "", "", ""), nil)
-					manager.EXPECT().RefreshKubeconfig(gomock.Any()).Return(nil)
-
-					Expect(options.Run(factory)).To(Succeed())
+					Expect(options.Run(nil)).To(Succeed())
+					Expect(errOut.String()).To(ContainSubstring("Run `gardenctl target` again"))
 				})
 
-				It("does not refresh when the modified garden is not the current target", func() {
+				It("prints no hint when no access-level flag was provided", func() {
 					options.Name = gardenIdentity1
-					Expect(options.DefaultShootAccessLevelFlag.Set(string(config.KubeconfigAccessLevelViewer))).To(Succeed())
 
-					manager.EXPECT().CurrentTarget().Return(target.NewTarget(gardenIdentity2, "", "", ""), nil)
-					// No RefreshKubeconfig expectation - Mock would FAIL on an unexpected call.
-
-					Expect(options.Run(factory)).To(Succeed())
-				})
-
-				It("soft-fails (warns, does not error) when refresh fails", func() {
-					options.Name = gardenIdentity1
-					Expect(options.DefaultShootAccessLevelFlag.Set(string(config.KubeconfigAccessLevelViewer))).To(Succeed())
-
-					manager.EXPECT().CurrentTarget().Return(target.NewTarget(gardenIdentity1, "", "", ""), nil)
-					manager.EXPECT().RefreshKubeconfig(gomock.Any()).Return(errors.New("refresh boom"))
-
-					Expect(options.Run(factory)).To(Succeed())
-					Expect(errOut.String()).To(ContainSubstring("Warning: failed to refresh kubeconfig"))
+					Expect(options.Run(nil)).To(Succeed())
+					Expect(errOut.String()).To(BeEmpty())
 				})
 			})
 		})

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -70,7 +70,8 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 		})
 
 		Describe("Validate", func() {
-			DescribeTable("Validating Name Argument",
+			DescribeTable(
+				"Validating Name Argument",
 				func(name string, matcher types.GomegaMatcher) {
 					o := cmdconfig.NewSetGardenOptions()
 					o.Name = name
@@ -82,7 +83,8 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 				Entry("when garden starts with hyphen", "-garden", MatchError("invalid garden name \"-garden\": garden name must start and end with an alphanumeric character")),
 			)
 
-			DescribeTable("Validating Pattern Flag",
+			DescribeTable(
+				"Validating Pattern Flag",
 				func(patterns []string, matcher types.GomegaMatcher) {
 					o := cmdconfig.NewSetGardenOptions()
 					o.Name = "foo"
@@ -97,7 +99,8 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 				Entry("when a pattern has an invalid subexpression name", []string{"^shoot--(?P<cluster>.+)$`"}, MatchError("pattern[0] contains an invalid subexpression \"cluster\"")),
 			)
 
-			DescribeTable("Validating Alias Flag",
+			DescribeTable(
+				"Validating Alias Flag",
 				func(alias string, shouldSetAlias bool, matcher types.GomegaMatcher) {
 					o := cmdconfig.NewSetGardenOptions()
 
@@ -207,7 +210,6 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 					Expect(garden.KubeconfigAccessLevelDefaults.Shoots).To(Equal(config.KubeconfigAccessLevelViewer))
 					Expect(garden.KubeconfigAccessLevelDefaults.Seeds).To(BeEmpty())
 				})
-
 			})
 
 			Describe("--default-*-access-level flags via real cobra flag parsing", func() {

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 			Expect(cmd.Use).To(Equal("set-garden"))
 			Expect(cmd.ValidArgsFunction).NotTo(BeNil())
 			Expect(cmd.ValidArgs).To(BeNil())
-			assertAllFlagNames(cmd.Flags(), "alias", "context", "default-managed-seed-access-level", "default-shoot-access-level", "kubeconfig", "pattern")
+			assertAllFlagNames(cmd.Flags(), "alias", "context", "default-seed-access-level", "default-shoot-access-level", "kubeconfig", "pattern")
 		})
 	})
 
@@ -179,19 +179,19 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 			})
 
 			Describe("default kubeconfig access level flags", func() {
-				It("sets shoots and managedSeeds on a new garden", func() {
+				It("sets shoots and seeds on a new garden", func() {
 					options.Name = gardenIdentity3
 					Expect(options.KubeconfigFlag.Set(pathToKubeconfig)).To(Succeed())
 					Expect(options.DefaultShootAccessLevelFlag.Set(string(config.KubeconfigAccessLevelViewer))).To(Succeed())
-					Expect(options.DefaultManagedSeedAccessLevelFlag.Set(string(config.KubeconfigAccessLevelAdmin))).To(Succeed())
+					Expect(options.DefaultSeedAccessLevelFlag.Set(string(config.KubeconfigAccessLevelAdmin))).To(Succeed())
 					Expect(options.Run(nil)).To(Succeed())
 
 					assertGarden(cfg, &config.Garden{
 						Name:       gardenIdentity3,
 						Kubeconfig: pathToKubeconfig,
 						KubeconfigAccessLevelDefaults: &config.KubeconfigAccessLevels{
-							Shoots:       config.KubeconfigAccessLevelViewer,
-							ManagedSeeds: config.KubeconfigAccessLevelAdmin,
+							Shoots: config.KubeconfigAccessLevelViewer,
+							Seeds:  config.KubeconfigAccessLevelAdmin,
 						},
 					})
 				})
@@ -205,7 +205,7 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(garden.KubeconfigAccessLevelDefaults).NotTo(BeNil())
 					Expect(garden.KubeconfigAccessLevelDefaults.Shoots).To(Equal(config.KubeconfigAccessLevelViewer))
-					Expect(garden.KubeconfigAccessLevelDefaults.ManagedSeeds).To(BeEmpty())
+					Expect(garden.KubeconfigAccessLevelDefaults.Seeds).To(BeEmpty())
 				})
 
 			})

--- a/pkg/cmd/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kubeconfig/kubeconfig.go
@@ -7,6 +7,7 @@ package kubeconfig
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -124,17 +125,26 @@ func (o *options) Complete(f util.Factory, _ *cobra.Command, _ []string) error {
 
 	ctx := f.Context()
 
-	config, err := manager.ClientConfig(ctx, currentTarget)
+	clientConfig, err := manager.ClientConfig(ctx, currentTarget)
 	if err != nil {
 		return err
 	}
 
-	rawConfig, err := config.RawConfig()
+	rawConfig, err := clientConfig.RawConfig()
 	if err != nil {
 		return err
 	}
 
 	o.RawConfig = &rawConfig
+
+	// Always surface the kubeconfig access level so the user can be confident
+	// which credentials they got. Goes to stderr so it doesn't pollute the
+	// kubeconfig YAML on stdout (which users typically pipe to a file or kubectl).
+	// Skipped for targets that don't produce a gardenlogin kubeconfig (e.g.
+	// garden- or project-only targets) where the notion does not apply.
+	if level, ok := manager.EffectiveAccessLevel(currentTarget); ok && level != "" {
+		fmt.Fprintf(o.IOStreams.ErrOut, "Kubeconfig access level: %s\n", level)
+	}
 
 	return nil
 }

--- a/pkg/cmd/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kubeconfig/kubeconfig.go
@@ -20,12 +20,14 @@ import (
 
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/flags"
 	"github.com/gardener/gardenctl-v2/pkg/target"
 )
 
-// NewCmdKubeconfig returns a new kubeconfig command.
-func NewCmdKubeconfig(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+// NewCmdKubeconfig returns a new kubeconfig command. accessLevel is bound to
+// the --kubeconfig-access-level flag.
+func NewCmdKubeconfig(f util.Factory, ioStreams util.IOStreams, accessLevel *config.KubeconfigAccessLevel) *cobra.Command {
 	o := newOptions(ioStreams)
 
 	cmd := &cobra.Command{
@@ -51,6 +53,7 @@ gardenctl kubeconfig --garden my-garden --project my-project`,
 
 	f.TargetFlags().AddFlags(cmd.Flags())
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, cmd.Flags())
+	flags.AddKubeconfigAccessLevelFlag(cmd, accessLevel)
 
 	utilruntime.Must(cmd.RegisterFlagCompletionFunc("output", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return o.PrintFlags.AllowedFormats(), cobra.ShellCompDirectiveNoFileComp

--- a/pkg/cmd/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kubeconfig/kubeconfig.go
@@ -26,7 +26,7 @@ import (
 )
 
 // NewCmdKubeconfig returns a new kubeconfig command. accessLevel is bound to
-// the --kubeconfig-access-level flag.
+// the --access-level flag.
 func NewCmdKubeconfig(f util.Factory, ioStreams util.IOStreams, accessLevel *config.KubeconfigAccessLevel) *cobra.Command {
 	o := newOptions(ioStreams)
 

--- a/pkg/cmd/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kubeconfig/kubeconfig.go
@@ -142,8 +142,13 @@ func (o *options) Complete(f util.Factory, _ *cobra.Command, _ []string) error {
 
 	// Print the access level to stderr (stdout is the kubeconfig YAML) only when
 	// gardenctl explicitly chose one. When unset we let gardenlogin's own default
-	// apply and stay silent.
-	if level, ok := manager.EffectiveAccessLevel(currentTarget); ok {
+	// apply and stay silent. Display-path soft-warn: the kubeconfig YAML on
+	// stdout is already correct from ClientConfig above.
+	level, ok, lvlErr := manager.EffectiveAccessLevel(ctx, currentTarget)
+	switch {
+	case lvlErr != nil:
+		fmt.Fprintf(o.IOStreams.ErrOut, "Warning: could not determine effective access level: %v\n", lvlErr)
+	case ok:
 		fmt.Fprintf(o.IOStreams.ErrOut, "Access level: %s\n", level)
 	}
 

--- a/pkg/cmd/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kubeconfig/kubeconfig.go
@@ -137,13 +137,11 @@ func (o *options) Complete(f util.Factory, _ *cobra.Command, _ []string) error {
 
 	o.RawConfig = &rawConfig
 
-	// Always surface the kubeconfig access level so the user can be confident
-	// which credentials they got. Goes to stderr so it doesn't pollute the
-	// kubeconfig YAML on stdout (which users typically pipe to a file or kubectl).
-	// Skipped for targets that don't produce a gardenlogin kubeconfig (e.g.
-	// garden- or project-only targets) where the notion does not apply.
-	if level, ok := manager.EffectiveAccessLevel(currentTarget); ok && level != "" {
-		fmt.Fprintf(o.IOStreams.ErrOut, "Kubeconfig access level: %s\n", level)
+	// Print the access level to stderr (stdout is the kubeconfig YAML) only when
+	// gardenctl explicitly chose one. When unset we let gardenlogin's own default
+	// apply and stay silent.
+	if level, ok := manager.EffectiveAccessLevel(currentTarget); ok {
+		fmt.Fprintf(o.IOStreams.ErrOut, "Access level: %s\n", level)
 	}
 
 	return nil

--- a/pkg/cmd/kubeconfig/kubeconfig_test.go
+++ b/pkg/cmd/kubeconfig/kubeconfig_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Kubeconfig Command - Options", func() {
 			factory.EXPECT().TargetFlags().Return(targetFlags).AnyTimes()
 
 			streams, _, out, _ = util.NewTestIOStreams()
-			cmd = cmdkubeconfig.NewCmdKubeconfig(factory, streams)
+			cmd = cmdkubeconfig.NewCmdKubeconfig(factory, streams, new(gardenconfig.KubeconfigAccessLevel))
 		})
 
 		It("should execute the kubeconfig subcommand", func() {

--- a/pkg/cmd/kubeconfig/kubeconfig_test.go
+++ b/pkg/cmd/kubeconfig/kubeconfig_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Kubeconfig Command - Options", func() {
 
 			manager.EXPECT().CurrentTarget().Return(t, nil)
 			manager.EXPECT().ClientConfig(ctx, t).Return(config, nil)
-			manager.EXPECT().EffectiveAccessLevel(t).Return(gardenconfig.KubeconfigAccessLevel(""), false)
+			manager.EXPECT().EffectiveAccessLevel(ctx, t).Return(gardenconfig.KubeconfigAccessLevel(""), false, nil)
 
 			targetFlags := target.NewTargetFlags("", "", "", "", false)
 			factory.EXPECT().TargetFlags().Return(targetFlags).AnyTimes()
@@ -110,7 +110,7 @@ users: null
 				factory.EXPECT().Context().Return(ctx)
 				manager.EXPECT().CurrentTarget().Return(t, nil)
 				manager.EXPECT().ClientConfig(ctx, t).Return(config, nil)
-				manager.EXPECT().EffectiveAccessLevel(t).Return(gardenconfig.KubeconfigAccessLevel(""), false)
+				manager.EXPECT().EffectiveAccessLevel(ctx, t).Return(gardenconfig.KubeconfigAccessLevel(""), false, nil)
 
 				Expect(options.Complete(factory, nil, nil)).To(Succeed())
 				Expect(options.PrintObject).NotTo(BeNil())
@@ -126,7 +126,7 @@ users: null
 					factory.EXPECT().Context().Return(ctx)
 					manager.EXPECT().CurrentTarget().Return(t, nil)
 					manager.EXPECT().ClientConfig(ctx, t).Return(config, nil)
-					manager.EXPECT().EffectiveAccessLevel(t).Return(level, applies)
+					manager.EXPECT().EffectiveAccessLevel(ctx, t).Return(level, applies, nil)
 
 					Expect(options.Complete(factory, nil, nil)).To(Succeed())
 

--- a/pkg/cmd/kubeconfig/kubeconfig_test.go
+++ b/pkg/cmd/kubeconfig/kubeconfig_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/gardenctl-v2/internal/util"
 	utilmocks "github.com/gardener/gardenctl-v2/internal/util/mocks"
 	cmdkubeconfig "github.com/gardener/gardenctl-v2/pkg/cmd/kubeconfig"
+	gardenconfig "github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/target"
 	targetmocks "github.com/gardener/gardenctl-v2/pkg/target/mocks"
 )
@@ -66,6 +67,7 @@ var _ = Describe("Kubeconfig Command - Options", func() {
 
 			manager.EXPECT().CurrentTarget().Return(t, nil)
 			manager.EXPECT().ClientConfig(ctx, t).Return(config, nil)
+			manager.EXPECT().EffectiveAccessLevel(t).Return(gardenconfig.KubeconfigAccessLevel(""), false)
 
 			targetFlags := target.NewTargetFlags("", "", "", "", false)
 			factory.EXPECT().TargetFlags().Return(targetFlags).AnyTimes()
@@ -108,11 +110,38 @@ users: null
 				factory.EXPECT().Context().Return(ctx)
 				manager.EXPECT().CurrentTarget().Return(t, nil)
 				manager.EXPECT().ClientConfig(ctx, t).Return(config, nil)
+				manager.EXPECT().EffectiveAccessLevel(t).Return(gardenconfig.KubeconfigAccessLevel(""), false)
 
 				Expect(options.Complete(factory, nil, nil)).To(Succeed())
 				Expect(options.PrintObject).NotTo(BeNil())
 				Expect(options.RawConfig).To(Equal(&rawConfig))
 			})
+
+			DescribeTable("prints the access level on stderr when applicable to the target",
+				func(level gardenconfig.KubeconfigAccessLevel, applies bool, expectNotice bool) {
+					streams, _, _, errOut := util.NewTestIOStreams()
+					options.IOStreams = streams
+
+					factory.EXPECT().Manager().Return(manager, nil)
+					factory.EXPECT().Context().Return(ctx)
+					manager.EXPECT().CurrentTarget().Return(t, nil)
+					manager.EXPECT().ClientConfig(ctx, t).Return(config, nil)
+					manager.EXPECT().EffectiveAccessLevel(t).Return(level, applies)
+
+					Expect(options.Complete(factory, nil, nil)).To(Succeed())
+
+					if expectNotice {
+						Expect(errOut.String()).To(Equal("Kubeconfig access level: " + string(level) + "\n"))
+					} else {
+						Expect(errOut.String()).To(BeEmpty())
+					}
+				},
+				Entry("admin: shown", gardenconfig.KubeconfigAccessLevelAdmin, true, true),
+				Entry("viewer: shown", gardenconfig.KubeconfigAccessLevelViewer, true, true),
+				Entry("auto: shown", gardenconfig.KubeconfigAccessLevelAuto, true, true),
+				Entry("not applicable to target shape: silent", gardenconfig.KubeconfigAccessLevel(""), false, false),
+				Entry("empty level (defensive): silent", gardenconfig.KubeconfigAccessLevel(""), true, false),
+			)
 
 			It("should fail to complete options when the target is empty", func() {
 				currentTarget := target.NewTarget("", "", "", "")

--- a/pkg/cmd/kubeconfig/kubeconfig_test.go
+++ b/pkg/cmd/kubeconfig/kubeconfig_test.go
@@ -131,7 +131,7 @@ users: null
 					Expect(options.Complete(factory, nil, nil)).To(Succeed())
 
 					if expectNotice {
-						Expect(errOut.String()).To(Equal("Kubeconfig access level: " + string(level) + "\n"))
+						Expect(errOut.String()).To(Equal("Access level: " + string(level) + "\n"))
 					} else {
 						Expect(errOut.String()).To(BeEmpty())
 					}
@@ -139,8 +139,7 @@ users: null
 				Entry("admin: shown", gardenconfig.KubeconfigAccessLevelAdmin, true, true),
 				Entry("viewer: shown", gardenconfig.KubeconfigAccessLevelViewer, true, true),
 				Entry("auto: shown", gardenconfig.KubeconfigAccessLevelAuto, true, true),
-				Entry("not applicable to target shape: silent", gardenconfig.KubeconfigAccessLevel(""), false, false),
-				Entry("empty level (defensive): silent", gardenconfig.KubeconfigAccessLevel(""), true, false),
+				Entry("gardenctl did not decide a level: silent", gardenconfig.KubeconfigAccessLevel(""), false, false),
 			)
 
 			It("should fail to complete options when the target is empty", func() {

--- a/pkg/cmd/kubectlenv/kubectlenv.go
+++ b/pkg/cmd/kubectlenv/kubectlenv.go
@@ -14,15 +14,21 @@ import (
 
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/env"
+	"github.com/gardener/gardenctl-v2/pkg/flags"
 )
 
-// NewCmdKubectlEnv returns a new kubectl-env command.
-func NewCmdKubectlEnv(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+// NewCmdKubectlEnv returns a new kubectl-env command. accessLevel is bound to
+// the --access-level flag. It is only consulted when linkKubeconfig is false;
+// in symlink mode kubectl-env merely points KUBECONFIG at the existing session
+// kubeconfig and Run warns if the flag was set anyway.
+func NewCmdKubectlEnv(f util.Factory, ioStreams util.IOStreams, accessLevel *config.KubeconfigAccessLevel) *cobra.Command {
 	o := &options{
 		Options: base.Options{
 			IOStreams: ioStreams,
 		},
+		AccessLevel: accessLevel,
 	}
 	runE := base.WrapRunE(o, f)
 	cmd := &cobra.Command{
@@ -32,10 +38,13 @@ func NewCmdKubectlEnv(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
 
 Each sub-command produces a shell-specific script.
 For details on how to use the printed shell script, such as applying it temporarily to your current session or permanently through your shell's startup file, refer to the corresponding sub-command's help.
+
+Note: --access-level only has an effect when linkKubeconfig is false. In symlink mode (the default) this command just points KUBECONFIG at the existing session kubeconfig, so the access level is whatever the most recent ` + "`gardenctl target`" + ` chose.
 `,
 		Aliases: []string{"k-env", "cluster-env"},
 	}
 	o.AddFlags(cmd.PersistentFlags())
+	flags.AddKubeconfigAccessLevelFlag(cmd, accessLevel)
 
 	for _, s := range env.ValidShells() {
 		cmd.AddCommand(&cobra.Command{

--- a/pkg/cmd/kubectlenv/kubectlenv_test.go
+++ b/pkg/cmd/kubectlenv/kubectlenv_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gardener/gardenctl-v2/internal/util"
 	utilmocks "github.com/gardener/gardenctl-v2/internal/util/mocks"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/kubectlenv"
+	"github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/env"
 	"github.com/gardener/gardenctl-v2/pkg/target"
 	targetmocks "github.com/gardener/gardenctl-v2/pkg/target/mocks"
@@ -47,7 +48,7 @@ var _ = Describe("Env Commands", func() {
 
 	Describe("given a KubectlEnv instance", func() {
 		BeforeEach(func() {
-			cmd = kubectlenv.NewCmdKubectlEnv(factory, streams)
+			cmd = kubectlenv.NewCmdKubectlEnv(factory, streams, new(config.KubeconfigAccessLevel))
 		})
 
 		It("should have Use, Flags and SubCommands", func() {

--- a/pkg/cmd/kubectlenv/options.go
+++ b/pkg/cmd/kubectlenv/options.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/env"
 	"github.com/gardener/gardenctl-v2/pkg/target"
 )
@@ -40,6 +41,11 @@ type options struct {
 	Template env.Template
 	// Symlink indicates if KUBECONFIG environment variable should point to the session stable symlink
 	Symlink bool
+	// AccessLevel is the value bound to this command's --access-level flag
+	// (empty when unset). Only consulted in non-symlink mode; in symlink mode
+	// the existing session kubeconfig is reused as-is and Run warns if
+	// AccessLevel was set anyway.
+	AccessLevel *config.KubeconfigAccessLevel
 }
 
 // Complete adapts from the command line args to the data required.
@@ -103,6 +109,16 @@ func (o *options) Run(f util.Factory) error {
 
 	if !o.Symlink && o.Target.GardenName() == "" {
 		return target.ErrNoGardenTargeted
+	}
+
+	// In symlink mode kubectl-env just points KUBECONFIG at the existing session
+	// kubeconfig, so --access-level has no effect here - warn the user so they
+	// know to re-run `gardenctl target` with the flag instead.
+	if o.Symlink && o.AccessLevel != nil && *o.AccessLevel != "" {
+		fmt.Fprintf(o.IOStreams.ErrOut,
+			"Warning: --access-level has no effect with linkKubeconfig: true (the default). "+
+				"Re-run `gardenctl target ... --access-level=%s` to change the access level of the session kubeconfig.\n",
+			*o.AccessLevel)
 	}
 
 	data := map[string]interface{}{

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -228,7 +228,15 @@ func (o *TargetOptions) Run(f util.Factory) error {
 
 	if o.Output == "" {
 		var levelSuffix string
-		if level, ok := manager.EffectiveAccessLevel(currentTarget); ok {
+
+		level, ok, lvlErr := manager.EffectiveAccessLevel(ctx, currentTarget)
+		switch {
+		case lvlErr != nil:
+			// Display-path soft-warn: the kubeconfig itself is already correct
+			// (ClientConfig either succeeded with the right scope or the command
+			// has already errored out).
+			fmt.Fprintf(o.IOStreams.ErrOut, "Warning: could not determine effective access level: %v\n", lvlErr)
+		case ok:
 			levelSuffix = fmt.Sprintf(" (access level: %s)", level)
 		}
 

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -223,18 +223,15 @@ func (o *TargetOptions) Run(f util.Factory) error {
 	}
 
 	if o.Output == "" {
-		if o.Kind == TargetKindControlPlane {
-			fmt.Fprintf(o.IOStreams.Out, "Successfully targeted control plane of shoot %q\n", currentTarget.ShootName())
-		} else if o.Kind != "" {
-			fmt.Fprintf(o.IOStreams.Out, "Successfully targeted %s %q\n", o.Kind, o.TargetName)
+		var levelSuffix string
+		if level, ok := manager.EffectiveAccessLevel(currentTarget); ok {
+			levelSuffix = fmt.Sprintf(" (access level: %s)", level)
 		}
 
-		// Always surface the kubeconfig access level so the user can be confident
-		// which credentials they got. Skipped only for targets that don't produce
-		// a gardenlogin kubeconfig (garden- or project-only targets), where the
-		// notion does not apply.
-		if level, ok := manager.EffectiveAccessLevel(currentTarget); ok && level != "" {
-			fmt.Fprintf(o.IOStreams.Out, "Kubeconfig access level: %s\n", level)
+		if o.Kind == TargetKindControlPlane {
+			fmt.Fprintf(o.IOStreams.Out, "Successfully targeted control plane of shoot %q%s\n", currentTarget.ShootName(), levelSuffix)
+		} else if o.Kind != "" {
+			fmt.Fprintf(o.IOStreams.Out, "Successfully targeted %s %q%s\n", o.Kind, o.TargetName, levelSuffix)
 		}
 	}
 

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -25,7 +25,7 @@ import (
 )
 
 // NewCmdTarget returns a new target command. accessLevel is bound to the
-// --kubeconfig-access-level persistent flag so its value is available on this
+// --access-level persistent flag so its value is available on this
 // command and all of its subcommands.
 func NewCmdTarget(f util.Factory, ioStreams util.IOStreams, accessLevel *config.KubeconfigAccessLevel) *cobra.Command {
 	o := NewTargetOptions(ioStreams)

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -19,12 +19,15 @@ import (
 	"github.com/gardener/gardenctl-v2/internal/util"
 	"github.com/gardener/gardenctl-v2/pkg/ac"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/flags"
 	"github.com/gardener/gardenctl-v2/pkg/target"
 )
 
-// NewCmdTarget returns a new target command.
-func NewCmdTarget(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+// NewCmdTarget returns a new target command. accessLevel is bound to the
+// --kubeconfig-access-level persistent flag so its value is available on this
+// command and all of its subcommands.
+func NewCmdTarget(f util.Factory, ioStreams util.IOStreams, accessLevel *config.KubeconfigAccessLevel) *cobra.Command {
 	o := NewTargetOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:   "target",
@@ -51,6 +54,7 @@ gardenctl target value/that/matches/pattern --control-plane`,
 
 	f.TargetFlags().AddFlags(cmd.Flags())
 	flags.RegisterCompletionFuncsForTargetFlags(cmd, f, ioStreams, cmd.Flags())
+	flags.AddKubeconfigAccessLevelFlag(cmd, accessLevel)
 
 	return cmd
 }

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -228,6 +228,14 @@ func (o *TargetOptions) Run(f util.Factory) error {
 		} else if o.Kind != "" {
 			fmt.Fprintf(o.IOStreams.Out, "Successfully targeted %s %q\n", o.Kind, o.TargetName)
 		}
+
+		// Always surface the kubeconfig access level so the user can be confident
+		// which credentials they got. Skipped only for targets that don't produce
+		// a gardenlogin kubeconfig (garden- or project-only targets), where the
+		// notion does not apply.
+		if level, ok := manager.EffectiveAccessLevel(currentTarget); ok && level != "" {
+			fmt.Fprintf(o.IOStreams.Out, "Kubeconfig access level: %s\n", level)
+		}
 	}
 
 	if manager.Configuration().SymlinkTargetKubeconfig() {

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -227,9 +227,23 @@ func (o *TargetOptions) Run(f util.Factory) error {
 	}
 
 	if o.Output == "" {
+		// dynamicTargetProvider.merge() wipes deeper target levels whenever
+		// --garden is set on the CLI, even immediately after TargetXXX persisted
+		// a shoot/seed. Re-apply the just-targeted leaf so EffectiveAccessLevel
+		// sees it instead of falling through to "no scope".
+		levelTarget := currentTarget
+		switch o.Kind {
+		case TargetKindShoot:
+			levelTarget = levelTarget.WithShootName(o.TargetName)
+		case TargetKindSeed:
+			levelTarget = levelTarget.WithSeedName(o.TargetName)
+		case TargetKindControlPlane:
+			levelTarget = levelTarget.WithControlPlane(true)
+		}
+
 		var levelSuffix string
 
-		level, ok, lvlErr := manager.EffectiveAccessLevel(ctx, currentTarget)
+		level, ok, lvlErr := manager.EffectiveAccessLevel(ctx, levelTarget)
 		switch {
 		case lvlErr != nil:
 			// Display-path soft-warn: the kubeconfig itself is already correct

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -234,6 +234,7 @@ func (o *TargetOptions) Run(f util.Factory) error {
 		// falling through to "no scope". Drop this workaround once #744 fixes
 		// the root cause.
 		levelTarget := currentTarget
+
 		switch o.Kind {
 		case TargetKindShoot:
 			levelTarget = levelTarget.WithShootName(o.TargetName)

--- a/pkg/cmd/target/target.go
+++ b/pkg/cmd/target/target.go
@@ -227,10 +227,12 @@ func (o *TargetOptions) Run(f util.Factory) error {
 	}
 
 	if o.Output == "" {
-		// dynamicTargetProvider.merge() wipes deeper target levels whenever
-		// --garden is set on the CLI, even immediately after TargetXXX persisted
-		// a shoot/seed. Re-apply the just-targeted leaf so EffectiveAccessLevel
-		// sees it instead of falling through to "no scope".
+		// TODO(gardener/gardenctl-v2#744): dynamicTargetProvider.merge() wipes
+		// deeper target levels whenever --garden is set on the CLI, even
+		// immediately after TargetXXX persisted a shoot/seed. Re-apply the
+		// just-targeted leaf so EffectiveAccessLevel sees it instead of
+		// falling through to "no scope". Drop this workaround once #744 fixes
+		// the root cause.
 		levelTarget := currentTarget
 		switch o.Kind {
 		case TargetKindShoot:

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -176,8 +176,9 @@ var _ = Describe("Target Command", func() {
 			// run command
 			Expect(cmd.RunE(cmd, []string{shootName})).To(Succeed())
 			Expect(out.String()).To(ContainSubstring("Successfully targeted shoot %q\n", shootName))
-			// No per-garden default and no flag -> resolves to admin -> line shows admin.
-			Expect(out.String()).To(ContainSubstring("Kubeconfig access level: admin"))
+			// No per-garden default and no flag -> gardenctl did not decide a level ->
+			// no access-level line so gardenlogin's own default applies.
+			Expect(out.String()).NotTo(ContainSubstring("access level"))
 
 			currentTarget, err := targetProvider.Read()
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -176,8 +176,6 @@ var _ = Describe("Target Command", func() {
 			// run command
 			Expect(cmd.RunE(cmd, []string{shootName})).To(Succeed())
 			Expect(out.String()).To(ContainSubstring("Successfully targeted shoot %q\n", shootName))
-			// No per-garden default and no flag -> gardenctl did not decide a level ->
-			// no access-level line so gardenlogin's own default applies.
 			Expect(out.String()).NotTo(ContainSubstring("access level"))
 
 			currentTarget, err := targetProvider.Read()
@@ -196,8 +194,7 @@ var _ = Describe("Target Command", func() {
 			cmd := cmdtarget.NewCmdTargetShoot(factory, streams)
 
 			Expect(cmd.RunE(cmd, []string{shootName})).To(Succeed())
-			Expect(out.String()).To(ContainSubstring("Successfully targeted shoot %q\n", shootName))
-			Expect(out.String()).To(ContainSubstring("Kubeconfig access level: viewer"))
+			Expect(out.String()).To(ContainSubstring("Successfully targeted shoot %q (access level: viewer)\n", shootName))
 		})
 
 		It("should be able to target a control plane", func() {

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -122,7 +122,7 @@ var _ = Describe("Target Command", func() {
 		})
 
 		It("should reject bad options", func() {
-			cmd := cmdtarget.NewCmdTarget(factory, streams)
+			cmd := cmdtarget.NewCmdTarget(factory, streams, new(config.KubeconfigAccessLevel))
 
 			Expect(cmd.RunE(cmd, nil)).NotTo(Succeed())
 		})
@@ -216,7 +216,7 @@ var _ = Describe("Target Command", func() {
 		})
 
 		It("should be able to target via pattern matching", func() {
-			cmd := cmdtarget.NewCmdTarget(factory, streams)
+			cmd := cmdtarget.NewCmdTarget(factory, streams, new(config.KubeconfigAccessLevel))
 
 			// run command
 			Expect(cmd.RunE(cmd, []string{fmt.Sprintf("shoot--%s--%s", projectName, shootName)})).To(Succeed())

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -199,6 +199,7 @@ var _ = Describe("Target Command", func() {
 			Expect(out.String()).To(ContainSubstring("Successfully targeted shoot %q (access level: viewer)\n", shootName))
 		})
 
+
 		It("should be able to target a control plane", func() {
 			// user has already targeted a garden, project and shoot
 			targetProvider.Target = target.NewTarget(gardenName, projectName, "", shootName)
@@ -388,3 +389,4 @@ var _ = Describe("Target Options", func() {
 		Expect(o.Validate()).To(Succeed())
 	})
 })
+

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Target Command", func() {
 
 		It("uses the per-garden shoots access level when set", func() {
 			targetProvider.Target = target.NewTarget(gardenName, projectName, "", "")
-			cfg.Gardens[0].DefaultKubeconfigAccessLevel = &config.KubeconfigAccessLevels{
+			cfg.Gardens[0].KubeconfigAccessLevelDefaults = &config.KubeconfigAccessLevels{
 				Shoots: config.KubeconfigAccessLevelViewer,
 			}
 			cmd := cmdtarget.NewCmdTargetShoot(factory, streams)

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -176,6 +176,8 @@ var _ = Describe("Target Command", func() {
 			// run command
 			Expect(cmd.RunE(cmd, []string{shootName})).To(Succeed())
 			Expect(out.String()).To(ContainSubstring("Successfully targeted shoot %q\n", shootName))
+			// No per-garden default and no flag -> resolves to admin -> line shows admin.
+			Expect(out.String()).To(ContainSubstring("Kubeconfig access level: admin"))
 
 			currentTarget, err := targetProvider.Read()
 			Expect(err).NotTo(HaveOccurred())
@@ -183,6 +185,18 @@ var _ = Describe("Target Command", func() {
 			Expect(currentTarget.ProjectName()).To(Equal(projectName))
 			Expect(currentTarget.SeedName()).To(Equal(seedName))
 			Expect(currentTarget.ShootName()).To(Equal(shootName))
+		})
+
+		It("uses the per-garden shoots access level when set", func() {
+			targetProvider.Target = target.NewTarget(gardenName, projectName, "", "")
+			cfg.Gardens[0].DefaultKubeconfigAccessLevel = &config.KubeconfigAccessLevels{
+				Shoots: config.KubeconfigAccessLevelViewer,
+			}
+			cmd := cmdtarget.NewCmdTargetShoot(factory, streams)
+
+			Expect(cmd.RunE(cmd, []string{shootName})).To(Succeed())
+			Expect(out.String()).To(ContainSubstring("Successfully targeted shoot %q\n", shootName))
+			Expect(out.String()).To(ContainSubstring("Kubeconfig access level: viewer"))
 		})
 
 		It("should be able to target a control plane", func() {

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Target Command", func() {
 		streams        util.IOStreams
 		in             *util.SafeBytesBuffer
 		out            *util.SafeBytesBuffer
+		errOut         *util.SafeBytesBuffer
 		ctrl           *gomock.Controller
 		cfg            *config.Config
 		clientProvider *clientmocks.MockProvider
@@ -97,7 +98,7 @@ var _ = Describe("Target Command", func() {
 			},
 		}
 
-		streams, in, out, _ = util.NewTestIOStreams()
+		streams, in, out, errOut = util.NewTestIOStreams()
 
 		ctrl = gomock.NewController(GinkgoT())
 
@@ -194,6 +195,7 @@ var _ = Describe("Target Command", func() {
 			cmd := cmdtarget.NewCmdTargetShoot(factory, streams)
 
 			Expect(cmd.RunE(cmd, []string{shootName})).To(Succeed())
+			Expect(errOut.String()).To(BeEmpty())
 			Expect(out.String()).To(ContainSubstring("Successfully targeted shoot %q (access level: viewer)\n", shootName))
 		})
 

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -199,7 +199,6 @@ var _ = Describe("Target Command", func() {
 			Expect(out.String()).To(ContainSubstring("Successfully targeted shoot %q (access level: viewer)\n", shootName))
 		})
 
-
 		It("should be able to target a control plane", func() {
 			// user has already targeted a garden, project and shoot
 			targetProvider.Target = target.NewTarget(gardenName, projectName, "", shootName)
@@ -389,4 +388,3 @@ var _ = Describe("Target Options", func() {
 		Expect(o.Validate()).To(Succeed())
 	})
 })
-

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,9 +12,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 
 	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/pflag"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/klog/v2"
@@ -57,6 +59,107 @@ type Garden struct {
 	// AccessRestrictions is a list of access restriction definitions
 	// +optional
 	AccessRestrictions []ac.AccessRestriction `json:"accessRestrictions,omitempty"`
+	// DefaultKubeconfigAccessLevel sets the default access level requested per
+	// target scope when no --kubeconfig-access-level flag is provided. Each
+	// sub-field defaults to "admin" when empty.
+	// +optional
+	DefaultKubeconfigAccessLevel *KubeconfigAccessLevels `json:"defaultKubeconfigAccessLevel,omitempty"`
+}
+
+// KubeconfigAccessLevels defines per-scope default access levels for kubeconfig
+// requests in a garden. Non-managed seeds are not configurable here - they always use
+// the static seed-login secret, which only supports admin access.
+type KubeconfigAccessLevels struct {
+	// Shoots is the default access level used when targeting a shoot.
+	// +optional
+	Shoots KubeconfigAccessLevel `json:"shoots,omitempty"`
+	// ManagedSeeds is the default access level used when targeting a managed seed
+	// (or a shoot's control plane on a managed seed).
+	// +optional
+	ManagedSeeds KubeconfigAccessLevel `json:"managedSeeds,omitempty"`
+}
+
+// Validate returns an error if any of the per-scope levels has an invalid value.
+func (l *KubeconfigAccessLevels) Validate() error {
+	if l == nil {
+		return nil
+	}
+
+	if err := l.Shoots.Validate(); err != nil {
+		return fmt.Errorf("shoots: %w", err)
+	}
+
+	if err := l.ManagedSeeds.Validate(); err != nil {
+		return fmt.Errorf("managedSeeds: %w", err)
+	}
+
+	return nil
+}
+
+// KubeconfigAccessLevel selects which kubeconfig gardenlogin requests on behalf of the user.
+// The string values match gardenlogin's --access-level CLI flag values (a stable CLI
+// contract; gardenlogin does not export these constants as Go symbols).
+type KubeconfigAccessLevel string
+
+const (
+	// KubeconfigAccessLevelAdmin requests an admin (cluster-admin) kubeconfig.
+	KubeconfigAccessLevelAdmin KubeconfigAccessLevel = "admin"
+	// KubeconfigAccessLevelViewer requests a read-only viewer kubeconfig.
+	KubeconfigAccessLevelViewer KubeconfigAccessLevel = "viewer"
+	// KubeconfigAccessLevelAuto attempts admin and falls back to viewer on permission denial.
+	KubeconfigAccessLevelAuto KubeconfigAccessLevel = "auto"
+)
+
+var AllKubeconfigAccessLevels = []KubeconfigAccessLevel{
+	KubeconfigAccessLevelAdmin,
+	KubeconfigAccessLevelViewer,
+	KubeconfigAccessLevelAuto,
+}
+
+// AllKubeconfigAccessLevelStrings returns the AllKubeconfigAccessLevels values as
+// strings, suitable for cobra shell-completion functions which return []string.
+func AllKubeconfigAccessLevelStrings() []string {
+	values := make([]string, 0, len(AllKubeconfigAccessLevels))
+	for _, l := range AllKubeconfigAccessLevels {
+		values = append(values, string(l))
+	}
+
+	return values
+}
+
+// Validate returns an error if the access level is not one of the allowed values.
+// An empty value is treated as valid (= use the built-in default).
+func (l KubeconfigAccessLevel) Validate() error {
+	if l == "" || slices.Contains(AllKubeconfigAccessLevels, l) {
+		return nil
+	}
+
+	return fmt.Errorf("invalid kubeconfig access level %q: must be one of %q, %q, %q",
+		l, KubeconfigAccessLevelAdmin, KubeconfigAccessLevelViewer, KubeconfigAccessLevelAuto)
+}
+
+var _ pflag.Value = (*KubeconfigAccessLevel)(nil)
+
+// Set implements pflag.Value, validating the input against the allowed access levels.
+func (l *KubeconfigAccessLevel) Set(value string) error {
+	candidate := KubeconfigAccessLevel(value)
+	if err := candidate.Validate(); err != nil {
+		return err
+	}
+
+	*l = candidate
+
+	return nil
+}
+
+// Type implements pflag.Value.
+func (l *KubeconfigAccessLevel) Type() string {
+	return "string"
+}
+
+// String implements pflag.Value and fmt.Stringer.
+func (l *KubeconfigAccessLevel) String() string {
+	return string(*l)
 }
 
 // ProviderConfig represents provider-specific configuration options.
@@ -203,6 +306,10 @@ func (config *Config) validateGardens() error {
 			} else if !ok {
 				seen[garden.Alias] = false
 			}
+		}
+
+		if err := garden.DefaultKubeconfigAccessLevel.Validate(); err != nil {
+			return fmt.Errorf("garden %q: defaultKubeconfigAccessLevel: %w", garden.Name, err)
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,7 +60,7 @@ type Garden struct {
 	// +optional
 	AccessRestrictions []ac.AccessRestriction `json:"accessRestrictions,omitempty"`
 	// KubeconfigAccessLevelDefaults sets the default access level requested per
-	// target scope when no --kubeconfig-access-level flag is provided. Each
+	// target scope when no --access-level flag is provided. Each
 	// sub-field defaults to "admin" when empty.
 	// +optional
 	KubeconfigAccessLevelDefaults *KubeconfigAccessLevels `json:"kubeconfigAccessLevelDefaults,omitempty"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -59,11 +59,11 @@ type Garden struct {
 	// AccessRestrictions is a list of access restriction definitions
 	// +optional
 	AccessRestrictions []ac.AccessRestriction `json:"accessRestrictions,omitempty"`
-	// DefaultKubeconfigAccessLevel sets the default access level requested per
+	// KubeconfigAccessLevelDefaults sets the default access level requested per
 	// target scope when no --kubeconfig-access-level flag is provided. Each
 	// sub-field defaults to "admin" when empty.
 	// +optional
-	DefaultKubeconfigAccessLevel *KubeconfigAccessLevels `json:"defaultKubeconfigAccessLevel,omitempty"`
+	KubeconfigAccessLevelDefaults *KubeconfigAccessLevels `json:"kubeconfigAccessLevelDefaults,omitempty"`
 }
 
 // KubeconfigAccessLevels defines per-scope default access levels for kubeconfig
@@ -308,8 +308,8 @@ func (config *Config) validateGardens() error {
 			}
 		}
 
-		if err := garden.DefaultKubeconfigAccessLevel.Validate(); err != nil {
-			return fmt.Errorf("garden %q: defaultKubeconfigAccessLevel: %w", garden.Name, err)
+		if err := garden.KubeconfigAccessLevelDefaults.Validate(); err != nil {
+			return fmt.Errorf("garden %q: kubeconfigAccessLevelDefaults: %w", garden.Name, err)
 		}
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -131,14 +131,13 @@ func AllKubeconfigAccessLevelStrings() []string {
 }
 
 // Validate returns an error if the access level is not one of the allowed values.
-// An empty value is treated as valid (= use the built-in default).
+// An empty value is treated as valid (= delegate to gardenlogin's default).
 func (l KubeconfigAccessLevel) Validate() error {
 	if l == "" || slices.Contains(AllKubeconfigAccessLevels, l) {
 		return nil
 	}
 
-	return fmt.Errorf("invalid kubeconfig access level %q: must be one of %q, %q, %q",
-		l, KubeconfigAccessLevelAdmin, KubeconfigAccessLevelViewer, KubeconfigAccessLevelAuto)
+	return fmt.Errorf("invalid kubeconfig access level %q: must be one of %q", l, AllKubeconfigAccessLevels)
 }
 
 var _ pflag.Value = (*KubeconfigAccessLevel)(nil)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,16 +67,19 @@ type Garden struct {
 }
 
 // KubeconfigAccessLevels defines per-scope default access levels for kubeconfig
-// requests in a garden. Non-managed seeds are not configurable here - they always use
-// the static seed-login secret, which only supports admin access.
+// requests in a garden. The Seeds default applies to any seed kubeconfig
+// request (managed or not); for non-managed seeds the static seed-login secret
+// is returned and an explicit "viewer" level is rejected by GetSeedClientConfig.
 type KubeconfigAccessLevels struct {
 	// Shoots is the default access level used when targeting a shoot.
 	// +optional
 	Shoots KubeconfigAccessLevel `json:"shoots,omitempty"`
-	// ManagedSeeds is the default access level used when targeting a managed seed
-	// (or a shoot's control plane on a managed seed).
+	// Seeds is the default access level used when targeting a seed (managed or
+	// not), or a shoot's control plane (which runs on a seed). A shoot that
+	// backs a managed seed also uses this default, since it physically is the
+	// seed cluster.
 	// +optional
-	ManagedSeeds KubeconfigAccessLevel `json:"managedSeeds,omitempty"`
+	Seeds KubeconfigAccessLevel `json:"seeds,omitempty"`
 }
 
 // Validate returns an error if any of the per-scope levels has an invalid value.
@@ -89,8 +92,8 @@ func (l *KubeconfigAccessLevels) Validate() error {
 		return fmt.Errorf("shoots: %w", err)
 	}
 
-	if err := l.ManagedSeeds.Validate(); err != nil {
-		return fmt.Errorf("managedSeeds: %w", err)
+	if err := l.Seeds.Validate(); err != nil {
+		return fmt.Errorf("seeds: %w", err)
 	}
 
 	return nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -448,4 +448,94 @@ provider:
 			Expect(config.ValidateGardenName("_")).To(MatchError("garden name must start and end with an alphanumeric character"))
 		})
 	})
+
+	Describe("KubeconfigAccessLevel", func() {
+		Describe("Validate", func() {
+			DescribeTable("accepts valid values",
+				func(value config.KubeconfigAccessLevel) {
+					Expect(value.Validate()).To(Succeed())
+				},
+				Entry("empty (use built-in default)", config.KubeconfigAccessLevel("")),
+				Entry("admin", config.KubeconfigAccessLevelAdmin),
+				Entry("viewer", config.KubeconfigAccessLevelViewer),
+				Entry("auto", config.KubeconfigAccessLevelAuto),
+			)
+
+			It("rejects unknown values with a descriptive error", func() {
+				err := config.KubeconfigAccessLevel("guest").Validate()
+				Expect(err).To(MatchError(ContainSubstring(`invalid kubeconfig access level "guest"`)))
+				Expect(err).To(MatchError(ContainSubstring(`"admin"`)))
+				Expect(err).To(MatchError(ContainSubstring(`"viewer"`)))
+				Expect(err).To(MatchError(ContainSubstring(`"auto"`)))
+			})
+		})
+
+		Describe("Set (pflag.Value)", func() {
+			It("assigns valid values", func() {
+				var l config.KubeconfigAccessLevel
+				Expect(l.Set("viewer")).To(Succeed())
+				Expect(l).To(Equal(config.KubeconfigAccessLevelViewer))
+			})
+
+			It("returns an error and leaves the value unchanged on bad input", func() {
+				l := config.KubeconfigAccessLevelAdmin
+				Expect(l.Set("nope")).To(MatchError(ContainSubstring("invalid kubeconfig access level")))
+				Expect(l).To(Equal(config.KubeconfigAccessLevelAdmin))
+			})
+
+			It("reports a string type for help output", func() {
+				var l config.KubeconfigAccessLevel
+				Expect(l.Type()).To(Equal("string"))
+			})
+
+			It("stringifies to its raw value", func() {
+				l := config.KubeconfigAccessLevelViewer
+				Expect(l.String()).To(Equal("viewer"))
+			})
+		})
+	})
+
+	Describe("Garden.DefaultKubeconfigAccessLevel validation via Config.Validate", func() {
+		It("rejects an unknown shoots access level", func() {
+			cfg := &config.Config{
+				Gardens: []config.Garden{{
+					Name:       "g1",
+					Kubeconfig: "kubeconfig",
+					DefaultKubeconfigAccessLevel: &config.KubeconfigAccessLevels{
+						Shoots: config.KubeconfigAccessLevel("guest"),
+					},
+				}},
+			}
+			Expect(cfg.Validate()).To(MatchError(ContainSubstring(`shoots: invalid kubeconfig access level "guest"`)))
+		})
+
+		It("rejects an unknown managedSeeds access level", func() {
+			cfg := &config.Config{
+				Gardens: []config.Garden{{
+					Name:       "g1",
+					Kubeconfig: "kubeconfig",
+					DefaultKubeconfigAccessLevel: &config.KubeconfigAccessLevels{
+						ManagedSeeds: config.KubeconfigAccessLevel("guest"),
+					},
+				}},
+			}
+			Expect(cfg.Validate()).To(MatchError(ContainSubstring(`managedSeeds: invalid kubeconfig access level "guest"`)))
+		})
+
+		It("accepts a missing, partial, or valid access level config", func() {
+			cfg := &config.Config{
+				Gardens: []config.Garden{
+					{Name: "g1", Kubeconfig: "kubeconfig"},
+					{Name: "g2", Kubeconfig: "kubeconfig", DefaultKubeconfigAccessLevel: &config.KubeconfigAccessLevels{
+						Shoots: config.KubeconfigAccessLevelViewer,
+					}},
+					{Name: "g3", Kubeconfig: "kubeconfig", DefaultKubeconfigAccessLevel: &config.KubeconfigAccessLevels{
+						Shoots:       config.KubeconfigAccessLevelViewer,
+						ManagedSeeds: config.KubeconfigAccessLevelAdmin,
+					}},
+				},
+			}
+			Expect(cfg.Validate()).To(Succeed())
+		})
+	})
 })

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -495,13 +495,13 @@ provider:
 		})
 	})
 
-	Describe("Garden.DefaultKubeconfigAccessLevel validation via Config.Validate", func() {
+	Describe("Garden.KubeconfigAccessLevelDefaults validation via Config.Validate", func() {
 		It("rejects an unknown shoots access level", func() {
 			cfg := &config.Config{
 				Gardens: []config.Garden{{
 					Name:       "g1",
 					Kubeconfig: "kubeconfig",
-					DefaultKubeconfigAccessLevel: &config.KubeconfigAccessLevels{
+					KubeconfigAccessLevelDefaults: &config.KubeconfigAccessLevels{
 						Shoots: config.KubeconfigAccessLevel("guest"),
 					},
 				}},
@@ -514,7 +514,7 @@ provider:
 				Gardens: []config.Garden{{
 					Name:       "g1",
 					Kubeconfig: "kubeconfig",
-					DefaultKubeconfigAccessLevel: &config.KubeconfigAccessLevels{
+					KubeconfigAccessLevelDefaults: &config.KubeconfigAccessLevels{
 						ManagedSeeds: config.KubeconfigAccessLevel("guest"),
 					},
 				}},
@@ -526,10 +526,10 @@ provider:
 			cfg := &config.Config{
 				Gardens: []config.Garden{
 					{Name: "g1", Kubeconfig: "kubeconfig"},
-					{Name: "g2", Kubeconfig: "kubeconfig", DefaultKubeconfigAccessLevel: &config.KubeconfigAccessLevels{
+					{Name: "g2", Kubeconfig: "kubeconfig", KubeconfigAccessLevelDefaults: &config.KubeconfigAccessLevels{
 						Shoots: config.KubeconfigAccessLevelViewer,
 					}},
-					{Name: "g3", Kubeconfig: "kubeconfig", DefaultKubeconfigAccessLevel: &config.KubeconfigAccessLevels{
+					{Name: "g3", Kubeconfig: "kubeconfig", KubeconfigAccessLevelDefaults: &config.KubeconfigAccessLevels{
 						Shoots:       config.KubeconfigAccessLevelViewer,
 						ManagedSeeds: config.KubeconfigAccessLevelAdmin,
 					}},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -509,17 +509,17 @@ provider:
 			Expect(cfg.Validate()).To(MatchError(ContainSubstring(`shoots: invalid kubeconfig access level "guest"`)))
 		})
 
-		It("rejects an unknown managedSeeds access level", func() {
+		It("rejects an unknown seeds access level", func() {
 			cfg := &config.Config{
 				Gardens: []config.Garden{{
 					Name:       "g1",
 					Kubeconfig: "kubeconfig",
 					KubeconfigAccessLevelDefaults: &config.KubeconfigAccessLevels{
-						ManagedSeeds: config.KubeconfigAccessLevel("guest"),
+						Seeds: config.KubeconfigAccessLevel("guest"),
 					},
 				}},
 			}
-			Expect(cfg.Validate()).To(MatchError(ContainSubstring(`managedSeeds: invalid kubeconfig access level "guest"`)))
+			Expect(cfg.Validate()).To(MatchError(ContainSubstring(`seeds: invalid kubeconfig access level "guest"`)))
 		})
 
 		It("accepts a missing, partial, or valid access level config", func() {
@@ -530,8 +530,8 @@ provider:
 						Shoots: config.KubeconfigAccessLevelViewer,
 					}},
 					{Name: "g3", Kubeconfig: "kubeconfig", KubeconfigAccessLevelDefaults: &config.KubeconfigAccessLevels{
-						Shoots:       config.KubeconfigAccessLevelViewer,
-						ManagedSeeds: config.KubeconfigAccessLevelAdmin,
+						Shoots: config.KubeconfigAccessLevelViewer,
+						Seeds:  config.KubeconfigAccessLevelAdmin,
 					}},
 				},
 			}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -455,7 +455,7 @@ provider:
 				func(value config.KubeconfigAccessLevel) {
 					Expect(value.Validate()).To(Succeed())
 				},
-				Entry("empty (use built-in default)", config.KubeconfigAccessLevel("")),
+				Entry("empty (delegate to gardenlogin's default)", config.KubeconfigAccessLevel("")),
 				Entry("admin", config.KubeconfigAccessLevelAdmin),
 				Entry("viewer", config.KubeconfigAccessLevelViewer),
 				Entry("auto", config.KubeconfigAccessLevelAuto),

--- a/pkg/flags/access_level.go
+++ b/pkg/flags/access_level.go
@@ -17,7 +17,7 @@ import (
 	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
-// AddKubeconfigAccessLevelFlag registers --kubeconfig-access-level (full form,
+// AddKubeconfigAccessLevelFlag registers --access-level (full form,
 // supports admin/viewer/auto) plus --admin and --viewer as mutually-exclusive
 // shorthands on cmd, all bound to value. The shorthands are convenience for
 // the common case; the full form is the canonical way to set "auto" via flag
@@ -28,13 +28,13 @@ import (
 // persistent flag keeps it out of the help output of unrelated commands.
 func AddKubeconfigAccessLevelFlag(cmd *cobra.Command, value *config.KubeconfigAccessLevel) {
 	flags := cmd.PersistentFlags()
-	flags.Var(value, "kubeconfig-access-level",
+	flags.Var(value, "access-level",
 		fmt.Sprintf(`Override default kubeconfig access level for shoots/managed-seeds. One of %q, %q, %q.`,
 			config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelViewer, config.KubeconfigAccessLevelAuto))
 	addBoolAccessLevelFlag(flags, value, "admin", config.KubeconfigAccessLevelAdmin)
 	addBoolAccessLevelFlag(flags, value, "viewer", config.KubeconfigAccessLevelViewer)
-	cmd.MarkFlagsMutuallyExclusive("kubeconfig-access-level", "admin", "viewer")
-	utilruntime.Must(cmd.RegisterFlagCompletionFunc("kubeconfig-access-level", kubeconfigAccessLevelCompletionFunc))
+	cmd.MarkFlagsMutuallyExclusive("access-level", "admin", "viewer")
+	utilruntime.Must(cmd.RegisterFlagCompletionFunc("access-level", kubeconfigAccessLevelCompletionFunc))
 }
 
 // addBoolAccessLevelFlag registers a bool-shaped flag whose presence sets
@@ -42,18 +42,16 @@ func AddKubeconfigAccessLevelFlag(cmd *cobra.Command, value *config.KubeconfigAc
 // `=true` - pflag's parser keys on that field, not the IsBoolFlag interface.
 func addBoolAccessLevelFlag(flags *pflag.FlagSet, target *config.KubeconfigAccessLevel, name string, level config.KubeconfigAccessLevel) {
 	flag := flags.VarPF(newBoolAccessLevel(target, level), name, "",
-		fmt.Sprintf("shorthand for --kubeconfig-access-level=%s", level))
+		fmt.Sprintf("shorthand for --access-level=%s", level))
 	flag.NoOptDefVal = "true"
 }
 
 // boolAccessLevel is a bool-shaped pflag.Value that, when set to true, writes
 // a fixed access level into a shared target pointer. This lets --admin and
-// --viewer funnel into the same KubeconfigAccessLevel value as
-// --kubeconfig-access-level.
+// --viewer funnel into the same KubeconfigAccessLevel value as --access-level.
 type boolAccessLevel struct {
 	target *config.KubeconfigAccessLevel
 	level  config.KubeconfigAccessLevel
-	set    bool
 }
 
 var _ pflag.Value = (*boolAccessLevel)(nil)
@@ -69,22 +67,17 @@ func (b *boolAccessLevel) Set(v string) error {
 	}
 
 	if !parsed {
-		return fmt.Errorf("does not accept false; omit the flag instead, or use --kubeconfig-access-level=... to pick a different level")
+		return fmt.Errorf("does not accept false; omit the flag instead, or use --access-level=... to pick a different level")
 	}
 
 	*b.target = b.level
-	b.set = true
 
 	return nil
 }
 
-func (b *boolAccessLevel) String() string {
-	if b.set {
-		return "true"
-	}
-
-	return "false"
-}
+// String reports the flag's default for help output. Always "false" since
+// these shortcuts default to unset; current state is reflected via *b.target.
+func (b *boolAccessLevel) String() string { return "false" }
 
 func (b *boolAccessLevel) Type() string { return "bool" }
 

--- a/pkg/flags/access_level.go
+++ b/pkg/flags/access_level.go
@@ -1,0 +1,41 @@
+/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package flags
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	"github.com/gardener/gardenctl-v2/pkg/config"
+)
+
+// AddKubeconfigAccessLevelFlag registers the --kubeconfig-access-level flag as a
+// persistent flag on cmd, binding it to value. Shell completion for the flag
+// is registered alongside.
+//
+// This flag is only meaningful for commands that produce a gardenlogin-driven
+// kubeconfig (target, kubeconfig, kubectl-env, ssh, sshpatch). Registering it
+// per-command rather than as a root persistent flag keeps it out of the help
+// output of unrelated commands like `gardenctl config` or `gardenctl version`.
+func AddKubeconfigAccessLevelFlag(cmd *cobra.Command, value *config.KubeconfigAccessLevel) {
+	cmd.PersistentFlags().Var(value, "kubeconfig-access-level",
+		fmt.Sprintf(`Override default kubeconfig access level for shoots/managed-seeds. One of %q, %q, %q.`,
+			config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelViewer, config.KubeconfigAccessLevelAuto))
+	utilruntime.Must(cmd.RegisterFlagCompletionFunc("kubeconfig-access-level", kubeconfigAccessLevelCompletionFunc))
+}
+
+// RegisterKubeconfigAccessLevelCompletion registers the shared admin/viewer/auto
+// shell-completion function on flagName.
+func RegisterKubeconfigAccessLevelCompletion(cmd *cobra.Command, flagName string) {
+	utilruntime.Must(cmd.RegisterFlagCompletionFunc(flagName, kubeconfigAccessLevelCompletionFunc))
+}
+
+func kubeconfigAccessLevelCompletionFunc(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+	return config.AllKubeconfigAccessLevelStrings(), cobra.ShellCompDirectiveNoFileComp
+}

--- a/pkg/flags/access_level.go
+++ b/pkg/flags/access_level.go
@@ -8,27 +8,89 @@ package flags
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/gardener/gardenctl-v2/pkg/config"
 )
 
-// AddKubeconfigAccessLevelFlag registers the --kubeconfig-access-level flag as a
-// persistent flag on cmd, binding it to value. Shell completion for the flag
-// is registered alongside.
+// AddKubeconfigAccessLevelFlag registers --kubeconfig-access-level (full form,
+// supports admin/viewer/auto) plus --admin and --viewer as mutually-exclusive
+// shorthands on cmd, all bound to value. The shorthands are convenience for
+// the common case; the full form is the canonical way to set "auto" via flag
+// (and is what completion targets).
 //
-// This flag is only meaningful for commands that produce a gardenlogin-driven
-// kubeconfig (target, kubeconfig, kubectl-env, ssh, sshpatch). Registering it
-// per-command rather than as a root persistent flag keeps it out of the help
-// output of unrelated commands like `gardenctl config` or `gardenctl version`.
+// This flag set is only meaningful for commands that produce a gardenlogin-
+// driven kubeconfig. Registering it per-command rather than as a root
+// persistent flag keeps it out of the help output of unrelated commands.
 func AddKubeconfigAccessLevelFlag(cmd *cobra.Command, value *config.KubeconfigAccessLevel) {
-	cmd.PersistentFlags().Var(value, "kubeconfig-access-level",
+	flags := cmd.PersistentFlags()
+	flags.Var(value, "kubeconfig-access-level",
 		fmt.Sprintf(`Override default kubeconfig access level for shoots/managed-seeds. One of %q, %q, %q.`,
 			config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelViewer, config.KubeconfigAccessLevelAuto))
+	addBoolAccessLevelFlag(flags, value, "admin", config.KubeconfigAccessLevelAdmin)
+	addBoolAccessLevelFlag(flags, value, "viewer", config.KubeconfigAccessLevelViewer)
+	cmd.MarkFlagsMutuallyExclusive("kubeconfig-access-level", "admin", "viewer")
 	utilruntime.Must(cmd.RegisterFlagCompletionFunc("kubeconfig-access-level", kubeconfigAccessLevelCompletionFunc))
 }
+
+// addBoolAccessLevelFlag registers a bool-shaped flag whose presence sets
+// target to level. Setting NoOptDefVal makes pflag accept `--admin` without
+// `=true` - pflag's parser keys on that field, not the IsBoolFlag interface.
+func addBoolAccessLevelFlag(flags *pflag.FlagSet, target *config.KubeconfigAccessLevel, name string, level config.KubeconfigAccessLevel) {
+	flag := flags.VarPF(newBoolAccessLevel(target, level), name, "",
+		fmt.Sprintf("shorthand for --kubeconfig-access-level=%s", level))
+	flag.NoOptDefVal = "true"
+}
+
+// boolAccessLevel is a bool-shaped pflag.Value that, when set to true, writes
+// a fixed access level into a shared target pointer. This lets --admin and
+// --viewer funnel into the same KubeconfigAccessLevel value as
+// --kubeconfig-access-level.
+type boolAccessLevel struct {
+	target *config.KubeconfigAccessLevel
+	level  config.KubeconfigAccessLevel
+	set    bool
+}
+
+var _ pflag.Value = (*boolAccessLevel)(nil)
+
+func newBoolAccessLevel(target *config.KubeconfigAccessLevel, level config.KubeconfigAccessLevel) *boolAccessLevel {
+	return &boolAccessLevel{target: target, level: level}
+}
+
+func (b *boolAccessLevel) Set(v string) error {
+	parsed, err := strconv.ParseBool(v)
+	if err != nil {
+		return fmt.Errorf("invalid boolean value %q", v)
+	}
+
+	if !parsed {
+		return fmt.Errorf("does not accept false; omit the flag instead, or use --kubeconfig-access-level=... to pick a different level")
+	}
+
+	*b.target = b.level
+	b.set = true
+
+	return nil
+}
+
+func (b *boolAccessLevel) String() string {
+	if b.set {
+		return "true"
+	}
+
+	return "false"
+}
+
+func (b *boolAccessLevel) Type() string { return "bool" }
+
+// IsBoolFlag tells pflag this flag does not require a value, so users can
+// pass `--admin` rather than `--admin=true`.
+func (b *boolAccessLevel) IsBoolFlag() bool { return true }
 
 // RegisterKubeconfigAccessLevelCompletion registers the shared admin/viewer/auto
 // shell-completion function on flagName.

--- a/pkg/flags/access_level.go
+++ b/pkg/flags/access_level.go
@@ -29,7 +29,7 @@ import (
 func AddKubeconfigAccessLevelFlag(cmd *cobra.Command, value *config.KubeconfigAccessLevel) {
 	flags := cmd.PersistentFlags()
 	flags.Var(value, "access-level",
-		fmt.Sprintf(`Override default kubeconfig access level for shoots/managed-seeds. One of %q, %q, %q.`,
+		fmt.Sprintf(`Override the default kubeconfig access level when targeting shoots or seeds. One of %q, %q, %q.`,
 			config.KubeconfigAccessLevelAdmin, config.KubeconfigAccessLevelViewer, config.KubeconfigAccessLevelAuto))
 	addBoolAccessLevelFlag(flags, value, "admin", config.KubeconfigAccessLevelAdmin)
 	addBoolAccessLevelFlag(flags, value, "viewer", config.KubeconfigAccessLevelViewer)

--- a/pkg/flags/access_level.go
+++ b/pkg/flags/access_level.go
@@ -66,6 +66,10 @@ func (b *boolAccessLevel) Set(v string) error {
 		return fmt.Errorf("invalid boolean value %q", v)
 	}
 
+	// false is rejected with a helpful hint rather than silently treated as a
+	// no-op. Treating it as a no-op would still mark the flag as Changed (so
+	// `--admin=false --viewer` would hit the mutex anyway) and would hide the
+	// likely intent error: --admin is a switch, not a toggle.
 	if !parsed {
 		return fmt.Errorf("does not accept false; omit the flag instead, or use --access-level=... to pick a different level")
 	}

--- a/pkg/flags/access_level_test.go
+++ b/pkg/flags/access_level_test.go
@@ -38,9 +38,9 @@ var _ = Describe("AddKubeconfigAccessLevelFlag", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(level).To(Equal(want))
 		},
-		Entry("--kubeconfig-access-level=admin", []string{"--kubeconfig-access-level=admin"}, config.KubeconfigAccessLevelAdmin),
-		Entry("--kubeconfig-access-level=viewer", []string{"--kubeconfig-access-level=viewer"}, config.KubeconfigAccessLevelViewer),
-		Entry("--kubeconfig-access-level=auto", []string{"--kubeconfig-access-level=auto"}, config.KubeconfigAccessLevelAuto),
+		Entry("--access-level=admin", []string{"--access-level=admin"}, config.KubeconfigAccessLevelAdmin),
+		Entry("--access-level=viewer", []string{"--access-level=viewer"}, config.KubeconfigAccessLevelViewer),
+		Entry("--access-level=auto", []string{"--access-level=auto"}, config.KubeconfigAccessLevelAuto),
 		Entry("--admin (NoOptDefVal accepts no =true)", []string{"--admin"}, config.KubeconfigAccessLevelAdmin),
 		Entry("--viewer (NoOptDefVal accepts no =true)", []string{"--viewer"}, config.KubeconfigAccessLevelViewer),
 		Entry("subcommand inherits persistent flag", []string{"child", "--viewer"}, config.KubeconfigAccessLevelViewer),
@@ -52,13 +52,13 @@ var _ = Describe("AddKubeconfigAccessLevelFlag", func() {
 			Expect(err).To(MatchError(ContainSubstring(errSubstring)))
 		},
 		Entry("--admin --viewer (mutually exclusive)", []string{"--admin", "--viewer"}, "none of the others can be"),
-		Entry("--admin --kubeconfig-access-level=viewer (mutually exclusive)", []string{"--admin", "--kubeconfig-access-level=viewer"}, "none of the others can be"),
-		Entry("--viewer --kubeconfig-access-level=admin (mutually exclusive)", []string{"--viewer", "--kubeconfig-access-level=admin"}, "none of the others can be"),
+		Entry("--admin --access-level=viewer (mutually exclusive)", []string{"--admin", "--access-level=viewer"}, "none of the others can be"),
+		Entry("--viewer --access-level=admin (mutually exclusive)", []string{"--viewer", "--access-level=admin"}, "none of the others can be"),
 		Entry("subcommand --admin --viewer still mutex (persistent flags + annotation propagate)", []string{"child", "--admin", "--viewer"}, "none of the others can be"),
 		Entry("--admin=false (rejected, switches not toggles)", []string{"--admin=false"}, "does not accept false"),
 		Entry("--viewer=false (rejected)", []string{"--viewer=false"}, "does not accept false"),
 		Entry("--admin=garbage (not a bool)", []string{"--admin=garbage"}, "invalid boolean value"),
-		Entry("--kubeconfig-access-level=guest (not in enum)", []string{"--kubeconfig-access-level=guest"}, "invalid kubeconfig access level"),
+		Entry("--access-level=guest (not in enum)", []string{"--access-level=guest"}, "invalid kubeconfig access level"),
 	)
 
 	It("leaves the value empty when no flag is set", func() {

--- a/pkg/flags/access_level_test.go
+++ b/pkg/flags/access_level_test.go
@@ -1,0 +1,69 @@
+/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package flags_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/gardener/gardenctl-v2/pkg/config"
+	"github.com/gardener/gardenctl-v2/pkg/flags"
+)
+
+var _ = Describe("AddKubeconfigAccessLevelFlag", func() {
+	parse := func(args []string) (config.KubeconfigAccessLevel, error) {
+		var level config.KubeconfigAccessLevel
+
+		root := &cobra.Command{Use: "root", RunE: func(*cobra.Command, []string) error { return nil }}
+		flags.AddKubeconfigAccessLevelFlag(root, &level)
+
+		// Subcommand to verify persistent inheritance + cross-subcommand mutex.
+		root.AddCommand(&cobra.Command{Use: "child", RunE: func(*cobra.Command, []string) error { return nil }})
+
+		root.SetArgs(args)
+		root.SetOut(GinkgoWriter)
+		root.SetErr(GinkgoWriter)
+
+		return level, root.Execute()
+	}
+
+	DescribeTable("parses each form",
+		func(args []string, want config.KubeconfigAccessLevel) {
+			level, err := parse(args)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(level).To(Equal(want))
+		},
+		Entry("--kubeconfig-access-level=admin", []string{"--kubeconfig-access-level=admin"}, config.KubeconfigAccessLevelAdmin),
+		Entry("--kubeconfig-access-level=viewer", []string{"--kubeconfig-access-level=viewer"}, config.KubeconfigAccessLevelViewer),
+		Entry("--kubeconfig-access-level=auto", []string{"--kubeconfig-access-level=auto"}, config.KubeconfigAccessLevelAuto),
+		Entry("--admin (NoOptDefVal accepts no =true)", []string{"--admin"}, config.KubeconfigAccessLevelAdmin),
+		Entry("--viewer (NoOptDefVal accepts no =true)", []string{"--viewer"}, config.KubeconfigAccessLevelViewer),
+		Entry("subcommand inherits persistent flag", []string{"child", "--viewer"}, config.KubeconfigAccessLevelViewer),
+	)
+
+	DescribeTable("rejects invalid combinations",
+		func(args []string, errSubstring string) {
+			_, err := parse(args)
+			Expect(err).To(MatchError(ContainSubstring(errSubstring)))
+		},
+		Entry("--admin --viewer (mutually exclusive)", []string{"--admin", "--viewer"}, "none of the others can be"),
+		Entry("--admin --kubeconfig-access-level=viewer (mutually exclusive)", []string{"--admin", "--kubeconfig-access-level=viewer"}, "none of the others can be"),
+		Entry("--viewer --kubeconfig-access-level=admin (mutually exclusive)", []string{"--viewer", "--kubeconfig-access-level=admin"}, "none of the others can be"),
+		Entry("subcommand --admin --viewer still mutex (persistent flags + annotation propagate)", []string{"child", "--admin", "--viewer"}, "none of the others can be"),
+		Entry("--admin=false (rejected, switches not toggles)", []string{"--admin=false"}, "does not accept false"),
+		Entry("--viewer=false (rejected)", []string{"--viewer=false"}, "does not accept false"),
+		Entry("--admin=garbage (not a bool)", []string{"--admin=garbage"}, "invalid boolean value"),
+		Entry("--kubeconfig-access-level=guest (not in enum)", []string{"--kubeconfig-access-level=guest"}, "invalid kubeconfig access level"),
+	)
+
+	It("leaves the value empty when no flag is set", func() {
+		level, err := parse([]string{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(level).To(BeEmpty())
+	})
+})

--- a/pkg/flags/target_test.go
+++ b/pkg/flags/target_test.go
@@ -217,7 +217,7 @@ var _ = Describe("Target flags", func() {
 			})
 
 			It("should fail when no target is defined", func() {
-				manager, err := target.NewManager(cfg, fake.NewFakeTargetProvider(nil), nil, sessionDir)
+				manager, err := target.NewManager(cfg, fake.NewFakeTargetProvider(nil), nil, sessionDir, "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = flags.ProjectFlagCompletionFunc(factory.Context(), manager)
@@ -236,7 +236,7 @@ var _ = Describe("Target flags", func() {
 			})
 
 			It("should fail when no target is defined", func() {
-				manager, err := target.NewManager(cfg, fake.NewFakeTargetProvider(nil), nil, sessionDir)
+				manager, err := target.NewManager(cfg, fake.NewFakeTargetProvider(nil), nil, sessionDir, "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = flags.SeedFlagCompletionFunc(factory.Context(), manager)
@@ -255,7 +255,7 @@ var _ = Describe("Target flags", func() {
 			})
 
 			It("should fail when no target is defined", func() {
-				manager, err := target.NewManager(cfg, fake.NewFakeTargetProvider(nil), nil, sessionDir)
+				manager, err := target.NewManager(cfg, fake.NewFakeTargetProvider(nil), nil, sessionDir, "")
 				Expect(err).NotTo(HaveOccurred())
 
 				_, err = flags.ShootFlagCompletionFunc(factory.Context(), manager)

--- a/pkg/target/export_test.go
+++ b/pkg/target/export_test.go
@@ -6,4 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 
 package target
 
+import "github.com/gardener/gardenctl-v2/pkg/config"
+
 var Merge = merge
+
+// ResolveAccessLevel exposes managerImpl.resolveAccessLevel for tests.
+func ResolveAccessLevel(m Manager, t Target, scope AccessScope) config.KubeconfigAccessLevel {
+	return m.(*managerImpl).resolveAccessLevel(t, scope)
+}

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -100,12 +100,6 @@ type Manager interface {
 	// when the target does not produce a gardenlogin kubeconfig (garden/project
 	// targets, or no target).
 	EffectiveAccessLevel(t Target) (config.KubeconfigAccessLevel, bool)
-	// RefreshKubeconfig regenerates the symlinked session kubeconfig for the
-	// current target. Useful after a config change (e.g. a new
-	// defaultKubeconfigAccessLevel) so the on-disk kubeconfig picks up the new
-	// value without the user having to re-target. No-ops when symlinking is
-	// disabled or no target is set.
-	RefreshKubeconfig(ctx context.Context) error
 	// WriteClientConfig creates a kubeconfig file in the session directory of the operating system
 	WriteClientConfig(config clientcmd.ClientConfig) (string, error)
 	// SeedClient controller-runtime client for accessing the configured seed cluster
@@ -692,23 +686,6 @@ func (m *managerImpl) patchTarget(ctx context.Context, patch func(t *targetImpl)
 	err = m.targetProvider.Write(impl)
 	if err != nil {
 		return err
-	}
-
-	if !m.config.SymlinkTargetKubeconfig() {
-		return nil
-	}
-
-	return m.updateClientConfigSymlink(ctx, target)
-}
-
-func (m *managerImpl) RefreshKubeconfig(ctx context.Context) error {
-	target, err := m.targetProvider.Read()
-	if err != nil {
-		return err
-	}
-
-	if target.GardenName() == "" {
-		return nil
 	}
 
 	if !m.config.SymlinkTargetKubeconfig() {

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -270,12 +270,12 @@ func (m *managerImpl) resolveAccessLevel(t Target, scope AccessScope) config.Kub
 	}
 
 	if t.GardenName() != "" {
-		if garden, err := m.config.Garden(t.GardenName()); err == nil && garden.DefaultKubeconfigAccessLevel != nil {
+		if garden, err := m.config.Garden(t.GardenName()); err == nil && garden.KubeconfigAccessLevelDefaults != nil {
 			switch scope {
 			case AccessScopeShoots:
-				return garden.DefaultKubeconfigAccessLevel.Shoots
+				return garden.KubeconfigAccessLevelDefaults.Shoots
 			case AccessScopeManagedSeeds:
-				return garden.DefaultKubeconfigAccessLevel.ManagedSeeds
+				return garden.KubeconfigAccessLevelDefaults.ManagedSeeds
 			}
 		}
 	}

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -179,25 +179,33 @@ const (
 	AccessScopeManagedSeeds AccessScope = "managedSeeds"
 )
 
-// EffectiveAccessLevel returns the access level that ClientConfig would use for the
-// given target. It mirrors ClientConfig's scope dispatch: shoots use the Shoots
-// scope, seeds and control planes use the ManagedSeeds scope. Returns ("", false)
-// for targets that don't produce a gardenlogin-driven kubeconfig.
+// EffectiveAccessLevel returns the access level that gardenctl explicitly chose
+// for the given target. The bool is false when gardenctl did not decide a level
+// (no flag and no per-garden config) — the caller should defer to gardenlogin's
+// own default in that case — and for targets that don't produce a gardenlogin-
+// driven kubeconfig at all.
 func (m *managerImpl) EffectiveAccessLevel(t Target) (config.KubeconfigAccessLevel, bool) {
+	var level config.KubeconfigAccessLevel
+
 	switch {
 	case t.ControlPlane():
-		return m.resolveAccessLevel(t, AccessScopeManagedSeeds), true
+		level = m.resolveAccessLevel(t, AccessScopeManagedSeeds)
 	case t.ShootName() != "":
-		return m.resolveAccessLevel(t, AccessScopeShoots), true
+		level = m.resolveAccessLevel(t, AccessScopeShoots)
 	case t.SeedName() != "":
-		return m.resolveAccessLevel(t, AccessScopeManagedSeeds), true
-	default:
-		return "", false
+		level = m.resolveAccessLevel(t, AccessScopeManagedSeeds)
 	}
+
+	return level, level != ""
 }
 
 // resolveAccessLevel returns the effective kubeconfig access level for a target+scope.
-// Precedence: CLI flag > per-garden default for the requested scope > built-in default ("admin").
+// Precedence: CLI flag > per-garden default for the requested scope > empty.
+//
+// Returning empty when neither a flag nor a config default is set lets the
+// shoot kubeconfig generator omit the --access-level argument entirely, so
+// gardenlogin falls back to its own documented default ("auto") rather than
+// gardenctl silently overriding it.
 func (m *managerImpl) resolveAccessLevel(t Target, scope AccessScope) config.KubeconfigAccessLevel {
 	if m.flagAccessLevel != "" {
 		return m.flagAccessLevel
@@ -205,22 +213,16 @@ func (m *managerImpl) resolveAccessLevel(t Target, scope AccessScope) config.Kub
 
 	if t.GardenName() != "" {
 		if garden, err := m.config.Garden(t.GardenName()); err == nil && garden.DefaultKubeconfigAccessLevel != nil {
-			var configured config.KubeconfigAccessLevel
-
 			switch scope {
 			case AccessScopeShoots:
-				configured = garden.DefaultKubeconfigAccessLevel.Shoots
+				return garden.DefaultKubeconfigAccessLevel.Shoots
 			case AccessScopeManagedSeeds:
-				configured = garden.DefaultKubeconfigAccessLevel.ManagedSeeds
-			}
-
-			if configured != "" {
-				return configured
+				return garden.DefaultKubeconfigAccessLevel.ManagedSeeds
 			}
 		}
 	}
 
-	return config.KubeconfigAccessLevelAdmin
+	return ""
 }
 
 func (m *managerImpl) CurrentTarget() (Target, error) {

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -93,7 +93,7 @@ type Manager interface {
 
 	// ClientConfig returns the client config for a target.
 	// The kubeconfig access level (admin/viewer/auto) is resolved internally from the
-	// global --kubeconfig-access-level flag and the per-garden config default.
+	// global --access-level flag and the per-garden config default.
 	ClientConfig(ctx context.Context, t Target) (clientcmd.ClientConfig, error)
 	// EffectiveAccessLevel returns the kubeconfig access level that gardenctl
 	// would use for the given target. The boolean is false when gardenctl did
@@ -127,7 +127,7 @@ type managerImpl struct {
 	targetProvider   TargetProvider
 	clientProvider   internalclient.Provider
 	sessionDirectory string
-	// flagAccessLevel is the value of the global --kubeconfig-access-level flag.
+	// flagAccessLevel is the value of the global --access-level flag.
 	// Empty when unset. Takes precedence over per-garden config defaults.
 	flagAccessLevel config.KubeconfigAccessLevel
 }
@@ -154,7 +154,7 @@ func newGardenClient(name string, config *config.Config, provider internalclient
 }
 
 // NewManager returns a new manager. flagAccessLevel is the value of the global
-// --kubeconfig-access-level flag (empty when unset); the manager combines it with
+// --access-level flag (empty when unset); the manager combines it with
 // per-garden config defaults when resolving the effective level for kubeconfig requests.
 func NewManager(config *config.Config, targetProvider TargetProvider, clientProvider internalclient.Provider, sessionDirectory string, flagAccessLevel config.KubeconfigAccessLevel) (Manager, error) {
 	return &managerImpl{
@@ -210,8 +210,11 @@ func (m *managerImpl) scopeForTarget(ctx context.Context, t Target) (AccessScope
 		}
 
 		scope, err := scopeForShoot(ctx, c, ns, t.ShootName())
+		if err != nil {
+			return "", false, err
+		}
 
-		return scope, err == nil, err
+		return scope, true, nil
 	case t.SeedName() != "":
 		return AccessScopeManagedSeeds, true, nil
 	}
@@ -572,7 +575,7 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 		// typically a managed seed, so the managed-seeds scope is the right default.
 		// If the seed turns out to be non-managed, GetSeedClientConfig rejects any
 		// non-admin level - the user can override per invocation with
-		// --kubeconfig-access-level=admin.
+		// --access-level=admin.
 		accessLevel := m.resolveAccessLevel(t, AccessScopeManagedSeeds)
 
 		return m.getClientConfig(t, func(client clientgarden.Client) (clientcmd.ClientConfig, error) {

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -95,11 +95,16 @@ type Manager interface {
 	// The kubeconfig access level (admin/viewer/auto) is resolved internally from the
 	// global --kubeconfig-access-level flag and the per-garden config default.
 	ClientConfig(ctx context.Context, t Target) (clientcmd.ClientConfig, error)
-	// EffectiveAccessLevel returns the kubeconfig access level that would be used
-	// for the given target's gardenlogin-driven kubeconfig. The boolean is false
-	// when the target does not produce a gardenlogin kubeconfig (garden/project
-	// targets, or no target).
-	EffectiveAccessLevel(t Target) (config.KubeconfigAccessLevel, bool)
+	// EffectiveAccessLevel returns the kubeconfig access level that gardenctl
+	// would use for the given target. The boolean is false when gardenctl did
+	// not decide a level (the caller should defer to gardenlogin's default) or
+	// the target does not produce a gardenlogin kubeconfig at all.
+	//
+	// For shoot targets, scope resolution consults the garden cluster to detect
+	// whether the shoot backs a managed seed, so the same physical cluster
+	// produces the same access level regardless of whether it was reached via
+	// `target shoot` or `target seed`.
+	EffectiveAccessLevel(ctx context.Context, t Target) (config.KubeconfigAccessLevel, bool, error)
 	// WriteClientConfig creates a kubeconfig file in the session directory of the operating system
 	WriteClientConfig(config clientcmd.ClientConfig) (string, error)
 	// SeedClient controller-runtime client for accessing the configured seed cluster
@@ -173,24 +178,83 @@ const (
 	AccessScopeManagedSeeds AccessScope = "managedSeeds"
 )
 
-// EffectiveAccessLevel returns the access level that gardenctl explicitly chose
-// for the given target. The bool is false when gardenctl did not decide a level
-// (no flag and no per-garden config) — the caller should defer to gardenlogin's
-// own default in that case — and for targets that don't produce a gardenlogin-
-// driven kubeconfig at all.
-func (m *managerImpl) EffectiveAccessLevel(t Target) (config.KubeconfigAccessLevel, bool) {
-	var level config.KubeconfigAccessLevel
-
-	switch {
-	case t.ControlPlane():
-		level = m.resolveAccessLevel(t, AccessScopeManagedSeeds)
-	case t.ShootName() != "":
-		level = m.resolveAccessLevel(t, AccessScopeShoots)
-	case t.SeedName() != "":
-		level = m.resolveAccessLevel(t, AccessScopeManagedSeeds)
+func (m *managerImpl) EffectiveAccessLevel(ctx context.Context, t Target) (config.KubeconfigAccessLevel, bool, error) {
+	scope, ok, err := m.scopeForTarget(ctx, t)
+	if err != nil || !ok {
+		return "", false, err
 	}
 
-	return level, level != ""
+	level := m.resolveAccessLevel(t, scope)
+
+	return level, level != "", nil
+}
+
+// scopeForTarget picks the access scope a target's defaults should follow.
+// Shoot targets take priority over seed: `target shoot foo` records both the
+// shoot and its seed, but the user's intent is the shoot. For shoot targets
+// we consult the garden cluster to upgrade managed-seed-backing shoots to the
+// managedSeeds scope, so a single physical cluster gets a single access level.
+func (m *managerImpl) scopeForTarget(ctx context.Context, t Target) (AccessScope, bool, error) {
+	switch {
+	case t.ControlPlane():
+		return AccessScopeManagedSeeds, true, nil
+	case t.ShootName() != "":
+		c, err := m.GardenClient(t.GardenName())
+		if err != nil {
+			return "", false, err
+		}
+
+		ns, err := resolveShootNamespace(ctx, c, t)
+		if err != nil {
+			return "", false, err
+		}
+
+		scope, err := scopeForShoot(ctx, c, ns, t.ShootName())
+
+		return scope, err == nil, err
+	case t.SeedName() != "":
+		return AccessScopeManagedSeeds, true, nil
+	}
+
+	return "", false, nil
+}
+
+// scopeForShoot picks the access scope for a shoot kubeconfig: managedSeeds
+// when the shoot also backs a managed seed (so it matches `target seed` for
+// the same cluster), shoots otherwise. Shared by ClientConfig and
+// scopeForTarget so both paths use one source of truth.
+func scopeForShoot(ctx context.Context, c clientgarden.Client, namespace, shootName string) (AccessScope, error) {
+	isManagedSeed, err := c.IsManagedSeed(ctx, namespace, shootName)
+	if err != nil {
+		return "", err
+	}
+
+	if isManagedSeed {
+		return AccessScopeManagedSeeds, nil
+	}
+
+	return AccessScopeShoots, nil
+}
+
+// resolveShootNamespace returns the namespace of the shoot identified by t,
+// either from the Project status (when targeted by project) or by finding the
+// shoot cluster-wide.
+func resolveShootNamespace(ctx context.Context, c clientgarden.Client, t Target) (string, error) {
+	if t.ProjectName() != "" {
+		ns, err := getProjectNamespace(ctx, c, t.ProjectName())
+		if err != nil {
+			return "", err
+		}
+
+		return *ns, nil
+	}
+
+	shoot, err := c.FindShoot(ctx, t.AsListOption())
+	if err != nil {
+		return "", err
+	}
+
+	return shoot.Namespace, nil
 }
 
 // resolveAccessLevel returns the effective kubeconfig access level for a target+scope.
@@ -535,26 +599,18 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 	}
 
 	if t.ShootName() != "" {
-		accessLevel := m.resolveAccessLevel(t, AccessScopeShoots)
-
 		return m.getClientConfig(t, func(client clientgarden.Client) (clientcmd.ClientConfig, error) {
-			var namespace string
-
-			if t.ProjectName() != "" {
-				projectNamespace, err := getProjectNamespace(ctx, client, t.ProjectName())
-				if err != nil {
-					return nil, err
-				}
-
-				namespace = *projectNamespace
-			} else {
-				shoot, err := client.FindShoot(ctx, t.AsListOption())
-				if err != nil {
-					return nil, err
-				}
-
-				namespace = shoot.Namespace
+			namespace, err := resolveShootNamespace(ctx, client, t)
+			if err != nil {
+				return nil, err
 			}
+
+			scope, err := scopeForShoot(ctx, client, namespace, t.ShootName())
+			if err != nil {
+				return nil, err
+			}
+
+			accessLevel := m.resolveAccessLevel(t, scope)
 
 			return client.GetShootClientConfig(ctx, namespace, t.ShootName(), accessLevel)
 		})

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -91,8 +91,21 @@ type Manager interface {
 	// of a pattern
 	TargetMatchPattern(ctx context.Context, tf TargetFlags, value string) error
 
-	// ClientConfig returns the client config for a target
+	// ClientConfig returns the client config for a target.
+	// The kubeconfig access level (admin/viewer/auto) is resolved internally from the
+	// global --kubeconfig-access-level flag and the per-garden config default.
 	ClientConfig(ctx context.Context, t Target) (clientcmd.ClientConfig, error)
+	// EffectiveAccessLevel returns the kubeconfig access level that would be used
+	// for the given target's gardenlogin-driven kubeconfig. The boolean is false
+	// when the target does not produce a gardenlogin kubeconfig (garden/project
+	// targets, or no target).
+	EffectiveAccessLevel(t Target) (config.KubeconfigAccessLevel, bool)
+	// RefreshKubeconfig regenerates the symlinked session kubeconfig for the
+	// current target. Useful after a config change (e.g. a new
+	// defaultKubeconfigAccessLevel) so the on-disk kubeconfig picks up the new
+	// value without the user having to re-target. No-ops when symlinking is
+	// disabled or no target is set.
+	RefreshKubeconfig(ctx context.Context) error
 	// WriteClientConfig creates a kubeconfig file in the session directory of the operating system
 	WriteClientConfig(config clientcmd.ClientConfig) (string, error)
 	// SeedClient controller-runtime client for accessing the configured seed cluster
@@ -115,6 +128,9 @@ type managerImpl struct {
 	targetProvider   TargetProvider
 	clientProvider   internalclient.Provider
 	sessionDirectory string
+	// flagAccessLevel is the value of the global --kubeconfig-access-level flag.
+	// Empty when unset. Takes precedence over per-garden config defaults.
+	flagAccessLevel config.KubeconfigAccessLevel
 }
 
 var _ Manager = &managerImpl{}
@@ -138,14 +154,73 @@ func newGardenClient(name string, config *config.Config, provider internalclient
 	return clientgarden.NewClient(clientConfig, client, garden.Name), nil
 }
 
-// NewManager returns a new manager.
-func NewManager(config *config.Config, targetProvider TargetProvider, clientProvider internalclient.Provider, sessionDirectory string) (Manager, error) {
+// NewManager returns a new manager. flagAccessLevel is the value of the global
+// --kubeconfig-access-level flag (empty when unset); the manager combines it with
+// per-garden config defaults when resolving the effective level for kubeconfig requests.
+func NewManager(config *config.Config, targetProvider TargetProvider, clientProvider internalclient.Provider, sessionDirectory string, flagAccessLevel config.KubeconfigAccessLevel) (Manager, error) {
 	return &managerImpl{
 		config:           config,
 		targetProvider:   targetProvider,
 		clientProvider:   clientProvider,
 		sessionDirectory: sessionDirectory,
+		flagAccessLevel:  flagAccessLevel,
 	}, nil
+}
+
+// AccessScope identifies which per-scope default applies when resolving the
+// kubeconfig access level for a target.
+type AccessScope string
+
+const (
+	// AccessScopeShoots is the scope for shoot targets.
+	AccessScopeShoots AccessScope = "shoots"
+	// AccessScopeManagedSeeds is the scope for managed-seed targets, including
+	// a shoot's control plane that runs on a managed seed.
+	AccessScopeManagedSeeds AccessScope = "managedSeeds"
+)
+
+// EffectiveAccessLevel returns the access level that ClientConfig would use for the
+// given target. It mirrors ClientConfig's scope dispatch: shoots use the Shoots
+// scope, seeds and control planes use the ManagedSeeds scope. Returns ("", false)
+// for targets that don't produce a gardenlogin-driven kubeconfig.
+func (m *managerImpl) EffectiveAccessLevel(t Target) (config.KubeconfigAccessLevel, bool) {
+	switch {
+	case t.ControlPlane():
+		return m.resolveAccessLevel(t, AccessScopeManagedSeeds), true
+	case t.ShootName() != "":
+		return m.resolveAccessLevel(t, AccessScopeShoots), true
+	case t.SeedName() != "":
+		return m.resolveAccessLevel(t, AccessScopeManagedSeeds), true
+	default:
+		return "", false
+	}
+}
+
+// resolveAccessLevel returns the effective kubeconfig access level for a target+scope.
+// Precedence: CLI flag > per-garden default for the requested scope > built-in default ("admin").
+func (m *managerImpl) resolveAccessLevel(t Target, scope AccessScope) config.KubeconfigAccessLevel {
+	if m.flagAccessLevel != "" {
+		return m.flagAccessLevel
+	}
+
+	if t.GardenName() != "" {
+		if garden, err := m.config.Garden(t.GardenName()); err == nil && garden.DefaultKubeconfigAccessLevel != nil {
+			var configured config.KubeconfigAccessLevel
+
+			switch scope {
+			case AccessScopeShoots:
+				configured = garden.DefaultKubeconfigAccessLevel.Shoots
+			case AccessScopeManagedSeeds:
+				configured = garden.DefaultKubeconfigAccessLevel.ManagedSeeds
+			}
+
+			if configured != "" {
+				return configured
+			}
+		}
+	}
+
+	return config.KubeconfigAccessLevelAdmin
 }
 
 func (m *managerImpl) CurrentTarget() (Target, error) {
@@ -432,6 +507,14 @@ func (m *managerImpl) updateTarget(ctx context.Context, target Target) error {
 
 func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.ClientConfig, error) {
 	if t.ControlPlane() {
+		// A shoot's control plane runs as pods in its seed; this branch returns the
+		// seed kubeconfig (namespaced to the shoot CP). The seed under a shoot CP is
+		// typically a managed seed, so the managed-seeds scope is the right default.
+		// If the seed turns out to be non-managed, GetSeedClientConfig rejects any
+		// non-admin level - the user can override per invocation with
+		// --kubeconfig-access-level=admin.
+		accessLevel := m.resolveAccessLevel(t, AccessScopeManagedSeeds)
+
 		return m.getClientConfig(t, func(client clientgarden.Client) (clientcmd.ClientConfig, error) {
 			shoot, err := client.FindShoot(ctx, t.WithControlPlane(false).AsListOption())
 			if err != nil {
@@ -446,7 +529,7 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 				return nil, fmt.Errorf("no technicalID has been assigned to the shoot %q yet", t.ShootName())
 			}
 
-			clientConfig, err := client.GetSeedClientConfig(ctx, *shoot.Spec.SeedName)
+			clientConfig, err := client.GetSeedClientConfig(ctx, *shoot.Spec.SeedName, accessLevel)
 			if err != nil {
 				return nil, err
 			}
@@ -456,6 +539,8 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 	}
 
 	if t.ShootName() != "" {
+		accessLevel := m.resolveAccessLevel(t, AccessScopeShoots)
+
 		return m.getClientConfig(t, func(client clientgarden.Client) (clientcmd.ClientConfig, error) {
 			var namespace string
 
@@ -475,13 +560,18 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 				namespace = shoot.Namespace
 			}
 
-			return client.GetShootClientConfig(ctx, namespace, t.ShootName())
+			return client.GetShootClientConfig(ctx, namespace, t.ShootName(), accessLevel)
 		})
 	}
 
 	if t.SeedName() != "" {
+		// Seed targets resolve via GetSeedClientConfig: managed seeds delegate to
+		// GetShootClientConfig (so the access level is honored), while non-managed
+		// seeds use a static seed-login Secret and only support admin access.
+		accessLevel := m.resolveAccessLevel(t, AccessScopeManagedSeeds)
+
 		return m.getClientConfig(t, func(client clientgarden.Client) (clientcmd.ClientConfig, error) {
-			return client.GetSeedClientConfig(ctx, t.SeedName())
+			return client.GetSeedClientConfig(ctx, t.SeedName(), accessLevel)
 		})
 	}
 
@@ -600,6 +690,23 @@ func (m *managerImpl) patchTarget(ctx context.Context, patch func(t *targetImpl)
 	err = m.targetProvider.Write(impl)
 	if err != nil {
 		return err
+	}
+
+	if !m.config.SymlinkTargetKubeconfig() {
+		return nil
+	}
+
+	return m.updateClientConfigSymlink(ctx, target)
+}
+
+func (m *managerImpl) RefreshKubeconfig(ctx context.Context) error {
+	target, err := m.targetProvider.Read()
+	if err != nil {
+		return err
+	}
+
+	if target.GardenName() == "" {
+		return nil
 	}
 
 	if !m.config.SymlinkTargetKubeconfig() {

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -197,7 +197,7 @@ func (m *managerImpl) EffectiveAccessLevel(ctx context.Context, t Target) (confi
 func (m *managerImpl) scopeForTarget(ctx context.Context, t Target) (AccessScope, bool, error) {
 	switch {
 	case t.ControlPlane():
-		return AccessScopeManagedSeeds, true, nil
+		return scopeForSeedTarget(ctx, m, t)
 	case t.ShootName() != "":
 		c, err := m.GardenClient(t.GardenName())
 		if err != nil {
@@ -216,10 +216,30 @@ func (m *managerImpl) scopeForTarget(ctx context.Context, t Target) (AccessScope
 
 		return scope, true, nil
 	case t.SeedName() != "":
-		return AccessScopeManagedSeeds, true, nil
+		return scopeForSeedTarget(ctx, m, t)
 	}
 
 	return "", false, nil
+}
+
+// scopeForSeedTarget returns the managed-seed scope, or no scope for
+// non-managed seeds (static seed-login kubeconfig: access level unknown).
+func scopeForSeedTarget(ctx context.Context, m *managerImpl, t Target) (AccessScope, bool, error) {
+	c, err := m.GardenClient(t.GardenName())
+	if err != nil {
+		return "", false, err
+	}
+
+	isManaged, err := c.IsManagedSeedByName(ctx, t.SeedName())
+	if err != nil {
+		return "", false, err
+	}
+
+	if !isManaged {
+		return "", false, nil
+	}
+
+	return AccessScopeManagedSeeds, true, nil
 }
 
 // scopeForShoot picks the access scope for a shoot kubeconfig: managedSeeds

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -173,9 +173,10 @@ type AccessScope string
 const (
 	// AccessScopeShoots is the scope for shoot targets.
 	AccessScopeShoots AccessScope = "shoots"
-	// AccessScopeManagedSeeds is the scope for managed-seed targets, including
-	// a shoot's control plane that runs on a managed seed.
-	AccessScopeManagedSeeds AccessScope = "managedSeeds"
+	// AccessScopeSeeds is the scope for any seed kubeconfig request: a seed
+	// target, a shoot's control plane (which runs on a seed), and a shoot that
+	// backs a managed seed (because it physically is the seed cluster).
+	AccessScopeSeeds AccessScope = "seeds"
 )
 
 func (m *managerImpl) EffectiveAccessLevel(ctx context.Context, t Target) (config.KubeconfigAccessLevel, bool, error) {
@@ -189,11 +190,11 @@ func (m *managerImpl) EffectiveAccessLevel(ctx context.Context, t Target) (confi
 	return level, level != "", nil
 }
 
-// scopeForTarget picks the access scope a target's defaults should follow.
-// Shoot targets take priority over seed: `target shoot foo` records both the
-// shoot and its seed, but the user's intent is the shoot. For shoot targets
-// we consult the garden cluster to upgrade managed-seed-backing shoots to the
-// managedSeeds scope, so a single physical cluster gets a single access level.
+// scopeForTarget returns the access scope a target's kubeconfig request
+// belongs to, or no scope when the static seed-login kubeconfig's privileges
+// are unknown to gardenctl (non-managed seeds). Shoot is checked before seed
+// because TargetShoot records both (from spec.seedName) but the user's intent
+// is the shoot.
 func (m *managerImpl) scopeForTarget(ctx context.Context, t Target) (AccessScope, bool, error) {
 	switch {
 	case t.ControlPlane():
@@ -222,8 +223,9 @@ func (m *managerImpl) scopeForTarget(ctx context.Context, t Target) (AccessScope
 	return "", false, nil
 }
 
-// scopeForSeedTarget returns the managed-seed scope, or no scope for
-// non-managed seeds (static seed-login kubeconfig: access level unknown).
+// scopeForSeedTarget returns the seeds scope for managed seeds, and no scope
+// for non-managed seeds (whose static seed-login kubeconfig has unknown
+// privileges - displaying a configured level would be misleading).
 func scopeForSeedTarget(ctx context.Context, m *managerImpl, t Target) (AccessScope, bool, error) {
 	c, err := m.GardenClient(t.GardenName())
 	if err != nil {
@@ -239,13 +241,11 @@ func scopeForSeedTarget(ctx context.Context, m *managerImpl, t Target) (AccessSc
 		return "", false, nil
 	}
 
-	return AccessScopeManagedSeeds, true, nil
+	return AccessScopeSeeds, true, nil
 }
 
-// scopeForShoot picks the access scope for a shoot kubeconfig: managedSeeds
-// when the shoot also backs a managed seed (so it matches `target seed` for
-// the same cluster), shoots otherwise. Shared by ClientConfig and
-// scopeForTarget so both paths use one source of truth.
+// scopeForShoot returns seeds when the shoot also backs a managed seed (same
+// physical cluster as `target seed` would reach), shoots otherwise.
 func scopeForShoot(ctx context.Context, c clientgarden.Client, namespace, shootName string) (AccessScope, error) {
 	isManagedSeed, err := c.IsManagedSeed(ctx, namespace, shootName)
 	if err != nil {
@@ -253,7 +253,7 @@ func scopeForShoot(ctx context.Context, c clientgarden.Client, namespace, shootN
 	}
 
 	if isManagedSeed {
-		return AccessScopeManagedSeeds, nil
+		return AccessScopeSeeds, nil
 	}
 
 	return AccessScopeShoots, nil
@@ -297,8 +297,8 @@ func (m *managerImpl) resolveAccessLevel(t Target, scope AccessScope) config.Kub
 			switch scope {
 			case AccessScopeShoots:
 				return garden.KubeconfigAccessLevelDefaults.Shoots
-			case AccessScopeManagedSeeds:
-				return garden.KubeconfigAccessLevelDefaults.ManagedSeeds
+			case AccessScopeSeeds:
+				return garden.KubeconfigAccessLevelDefaults.Seeds
 			}
 		}
 	}
@@ -591,12 +591,12 @@ func (m *managerImpl) updateTarget(ctx context.Context, target Target) error {
 func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.ClientConfig, error) {
 	if t.ControlPlane() {
 		// A shoot's control plane runs as pods in its seed; this branch returns the
-		// seed kubeconfig (namespaced to the shoot CP). The seed under a shoot CP is
-		// typically a managed seed, so the managed-seeds scope is the right default.
-		// If the seed turns out to be non-managed, GetSeedClientConfig rejects any
-		// non-admin level - the user can override per invocation with
-		// --access-level=admin.
-		accessLevel := m.resolveAccessLevel(t, AccessScopeManagedSeeds)
+		// seed kubeconfig (namespaced to the shoot CP). GetSeedClientConfig handles
+		// the managed-vs-non-managed seed split: managed seeds honor the requested
+		// access level, non-managed seeds return the static kubeconfig (and reject
+		// an explicit "viewer" request, since the static kubeconfig's privileges
+		// cannot be verified).
+		accessLevel := m.resolveAccessLevel(t, AccessScopeSeeds)
 
 		return m.getClientConfig(t, func(client clientgarden.Client) (clientcmd.ClientConfig, error) {
 			shoot, err := client.FindShoot(ctx, t.WithControlPlane(false).AsListOption())
@@ -640,10 +640,10 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 	}
 
 	if t.SeedName() != "" {
-		// Seed targets resolve via GetSeedClientConfig: managed seeds delegate to
-		// GetShootClientConfig (so the access level is honored), while non-managed
-		// seeds use a static seed-login Secret and only support admin access.
-		accessLevel := m.resolveAccessLevel(t, AccessScopeManagedSeeds)
+		// GetSeedClientConfig honors the access level for managed seeds (via
+		// GetShootClientConfig) and returns the static seed-login Secret for
+		// non-managed seeds (rejecting an explicit "viewer" request).
+		accessLevel := m.resolveAccessLevel(t, AccessScopeSeeds)
 
 		return m.getClientConfig(t, func(client clientgarden.Client) (clientcmd.ClientConfig, error) {
 			return client.GetSeedClientConfig(ctx, t.SeedName(), accessLevel)

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -179,10 +179,50 @@ const (
 	AccessScopeSeeds AccessScope = "seeds"
 )
 
+// EffectiveAccessLevel returns the access level gardenctl will request for a
+// target. The bool is false when gardenctl has no opinion (caller defers to
+// gardenlogin's default) or when displaying it would mislead - non-managed
+// seeds fall through to a static .login kubeconfig of unverifiable privileges.
 func (m *managerImpl) EffectiveAccessLevel(ctx context.Context, t Target) (config.KubeconfigAccessLevel, bool, error) {
-	scope, ok, err := m.scopeForTarget(ctx, t)
-	if err != nil || !ok {
+	scope, isShootRequest, err := m.scopeForTarget(ctx, t)
+	if err != nil || scope == "" {
 		return "", false, err
+	}
+
+	if !isShootRequest {
+		c, err := m.GardenClient(t.GardenName())
+		if err != nil {
+			return "", false, err
+		}
+
+		seedName := t.SeedName()
+		if seedName == "" {
+			// `target --garden X --shoot Y control-plane` wipes deeper target
+			// levels (#744); recover spec.seedName the same way ClientConfig does.
+			if t.ShootName() == "" {
+				return "", false, nil
+			}
+
+			shoot, err := c.FindShoot(ctx, t.WithControlPlane(false).AsListOption())
+			if err != nil {
+				return "", false, err
+			}
+
+			if shoot.Spec.SeedName == nil {
+				return "", false, nil
+			}
+
+			seedName = *shoot.Spec.SeedName
+		}
+
+		isManaged, err := c.IsManagedSeedByName(ctx, seedName)
+		if err != nil {
+			return "", false, err
+		}
+
+		if !isManaged {
+			return "", false, nil
+		}
 	}
 
 	level := m.resolveAccessLevel(t, scope)
@@ -190,15 +230,17 @@ func (m *managerImpl) EffectiveAccessLevel(ctx context.Context, t Target) (confi
 	return level, level != "", nil
 }
 
-// scopeForTarget returns the access scope a target's kubeconfig request
-// belongs to, or no scope when the static seed-login kubeconfig's privileges
-// are unknown to gardenctl (non-managed seeds). Shoot is checked before seed
-// because TargetShoot records both (from spec.seedName) but the user's intent
-// is the shoot.
+// scopeForTarget returns the access scope plus whether the kubeconfig will be
+// served via the shoot path (gardenlogin) rather than GetSeedClientConfig.
+// The bool lets EffectiveAccessLevel skip the managed-seed check on the shoot
+// path without re-deriving which branch fired.
+//
+// Order matters: ControlPlane and ShootName must be checked before SeedName,
+// since TargetShoot records the seed too (from spec.seedName).
 func (m *managerImpl) scopeForTarget(ctx context.Context, t Target) (AccessScope, bool, error) {
 	switch {
 	case t.ControlPlane():
-		return scopeForSeedTarget(ctx, m, t)
+		return AccessScopeSeeds, false, nil
 	case t.ShootName() != "":
 		c, err := m.GardenClient(t.GardenName())
 		if err != nil {
@@ -211,37 +253,13 @@ func (m *managerImpl) scopeForTarget(ctx context.Context, t Target) (AccessScope
 		}
 
 		scope, err := scopeForShoot(ctx, c, ns, t.ShootName())
-		if err != nil {
-			return "", false, err
-		}
 
-		return scope, true, nil
+		return scope, true, err
 	case t.SeedName() != "":
-		return scopeForSeedTarget(ctx, m, t)
+		return AccessScopeSeeds, false, nil
 	}
 
 	return "", false, nil
-}
-
-// scopeForSeedTarget returns the seeds scope for managed seeds, and no scope
-// for non-managed seeds (whose static seed-login kubeconfig has unknown
-// privileges - displaying a configured level would be misleading).
-func scopeForSeedTarget(ctx context.Context, m *managerImpl, t Target) (AccessScope, bool, error) {
-	c, err := m.GardenClient(t.GardenName())
-	if err != nil {
-		return "", false, err
-	}
-
-	isManaged, err := c.IsManagedSeedByName(ctx, t.SeedName())
-	if err != nil {
-		return "", false, err
-	}
-
-	if !isManaged {
-		return "", false, nil
-	}
-
-	return AccessScopeSeeds, true, nil
 }
 
 // scopeForShoot returns seeds when the shoot also backs a managed seed (same
@@ -590,13 +608,15 @@ func (m *managerImpl) updateTarget(ctx context.Context, target Target) error {
 
 func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.ClientConfig, error) {
 	if t.ControlPlane() {
-		// A shoot's control plane runs as pods in its seed; this branch returns the
-		// seed kubeconfig (namespaced to the shoot CP). GetSeedClientConfig handles
-		// the managed-vs-non-managed seed split: managed seeds honor the requested
-		// access level, non-managed seeds return the static kubeconfig (and reject
-		// an explicit "viewer" request, since the static kubeconfig's privileges
-		// cannot be verified).
-		accessLevel := m.resolveAccessLevel(t, AccessScopeSeeds)
+		scope, _, err := m.scopeForTarget(ctx, t)
+		if err != nil {
+			return nil, err
+		}
+
+		// GetSeedClientConfig handles the managed/non-managed split: managed
+		// seeds honor accessLevel; non-managed seeds return the static
+		// kubeconfig (and reject an explicit "viewer" request).
+		accessLevel := m.resolveAccessLevel(t, scope)
 
 		return m.getClientConfig(t, func(client clientgarden.Client) (clientcmd.ClientConfig, error) {
 			shoot, err := client.FindShoot(ctx, t.WithControlPlane(false).AsListOption())
@@ -640,10 +660,12 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 	}
 
 	if t.SeedName() != "" {
-		// GetSeedClientConfig honors the access level for managed seeds (via
-		// GetShootClientConfig) and returns the static seed-login Secret for
-		// non-managed seeds (rejecting an explicit "viewer" request).
-		accessLevel := m.resolveAccessLevel(t, AccessScopeSeeds)
+		scope, _, err := m.scopeForTarget(ctx, t)
+		if err != nil {
+			return nil, err
+		}
+
+		accessLevel := m.resolveAccessLevel(t, scope)
 
 		return m.getClientConfig(t, func(client clientgarden.Client) (clientcmd.ClientConfig, error) {
 			return client.GetSeedClientConfig(ctx, t.SeedName(), accessLevel)

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -812,6 +813,87 @@ var _ = Describe("Target Manager", func() {
 			m := newManager("", &config.KubeconfigAccessLevels{Shoots: config.KubeconfigAccessLevelViewer})
 			t := target.NewTarget("unknown-garden", "", "", "")
 			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(BeEmpty())
+		})
+	})
+
+	Describe("EffectiveAccessLevel scope routing for managed-seed-backing shoots", func() {
+		const (
+			gardenName  = "g1"
+			projectName = "myproject"
+			namespace   = "garden-myproject"
+			plainShoot  = "plain-shoot"
+			seedShoot   = "seed-shoot"
+		)
+
+		newManagerWithGarden := func(gardenLevels *config.KubeconfigAccessLevels, objs ...client.Object) target.Manager {
+			cfg := &config.Config{
+				Gardens: []config.Garden{{
+					Name:                         gardenName,
+					Kubeconfig:                   "kubeconfig",
+					DefaultKubeconfigAccessLevel: gardenLevels,
+				}},
+			}
+
+			ctrl := gomock.NewController(GinkgoT())
+			provider := clientmocks.NewMockProvider(ctrl)
+			cc, err := cfg.ClientConfig(gardenName)
+			Expect(err).NotTo(HaveOccurred())
+			provider.EXPECT().FromClientConfig(gomock.Eq(cc)).Return(fake.NewClientWithObjects(objs...), nil).AnyTimes()
+
+			tp := fake.NewFakeTargetProvider(target.NewTarget(gardenName, projectName, "", ""))
+			m, err := target.NewManager(cfg, tp, provider, sessionDir, "")
+			Expect(err).NotTo(HaveOccurred())
+
+			return m
+		}
+
+		project := &gardencorev1beta1.Project{
+			ObjectMeta: metav1.ObjectMeta{Name: projectName, UID: "00000000-0000-0000-0000-000000000000"},
+			Spec:       gardencorev1beta1.ProjectSpec{Namespace: ptr.To(namespace)},
+		}
+
+		It("uses the shoots scope for a regular shoot", func() {
+			m := newManagerWithGarden(&config.KubeconfigAccessLevels{
+				Shoots:       config.KubeconfigAccessLevelViewer,
+				ManagedSeeds: config.KubeconfigAccessLevelAdmin,
+			}, project)
+
+			t := target.NewTarget(gardenName, projectName, "", plainShoot)
+			level, ok, err := m.EffectiveAccessLevel(ctx, t)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(level).To(Equal(config.KubeconfigAccessLevelViewer))
+		})
+
+		It("uses the managed-seeds scope for a seed target", func() {
+			m := newManagerWithGarden(&config.KubeconfigAccessLevels{
+				Shoots:       config.KubeconfigAccessLevelViewer,
+				ManagedSeeds: config.KubeconfigAccessLevelAdmin,
+			}, project)
+
+			t := target.NewTarget(gardenName, "", "some-seed", "")
+			level, ok, err := m.EffectiveAccessLevel(ctx, t)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(level).To(Equal(config.KubeconfigAccessLevelAdmin))
+		})
+
+		It("uses the managed-seeds scope for a shoot that backs a managed seed", func() {
+			managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+				ObjectMeta: metav1.ObjectMeta{Name: seedShoot, Namespace: namespace, UID: "00000000-0000-0000-0000-000000000001"},
+				Spec:       seedmanagementv1alpha1.ManagedSeedSpec{Shoot: &seedmanagementv1alpha1.Shoot{Name: seedShoot}},
+			}
+
+			m := newManagerWithGarden(&config.KubeconfigAccessLevels{
+				Shoots:       config.KubeconfigAccessLevelViewer,
+				ManagedSeeds: config.KubeconfigAccessLevelAdmin,
+			}, project, managedSeed)
+
+			t := target.NewTarget(gardenName, projectName, "", seedShoot)
+			level, ok, err := m.EffectiveAccessLevel(ctx, t)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ok).To(BeTrue())
+			Expect(level).To(Equal(config.KubeconfigAccessLevelAdmin))
 		})
 	})
 })

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -754,9 +754,9 @@ var _ = Describe("Target Manager", func() {
 		newManager := func(flagLevel config.KubeconfigAccessLevel, gardenLevels *config.KubeconfigAccessLevels) target.Manager {
 			cfg := &config.Config{
 				Gardens: []config.Garden{{
-					Name:                         gardenName,
-					Kubeconfig:                   "kubeconfig",
-					DefaultKubeconfigAccessLevel: gardenLevels,
+					Name:                          gardenName,
+					Kubeconfig:                    "kubeconfig",
+					KubeconfigAccessLevelDefaults: gardenLevels,
 				}},
 			}
 
@@ -828,9 +828,9 @@ var _ = Describe("Target Manager", func() {
 		newManagerWithGarden := func(gardenLevels *config.KubeconfigAccessLevels, objs ...client.Object) target.Manager {
 			cfg := &config.Config{
 				Gardens: []config.Garden{{
-					Name:                         gardenName,
-					Kubeconfig:                   "kubeconfig",
-					DefaultKubeconfigAccessLevel: gardenLevels,
+					Name:                          gardenName,
+					Kubeconfig:                    "kubeconfig",
+					KubeconfigAccessLevelDefaults: gardenLevels,
 				}},
 			}
 

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -851,49 +851,29 @@ var _ = Describe("Target Manager", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: projectName, UID: "00000000-0000-0000-0000-000000000000"},
 			Spec:       gardencorev1beta1.ProjectSpec{Namespace: ptr.To(namespace)},
 		}
+		managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+			ObjectMeta: metav1.ObjectMeta{Name: seedShoot, Namespace: namespace, UID: "00000000-0000-0000-0000-000000000001"},
+			Spec:       seedmanagementv1alpha1.ManagedSeedSpec{Shoot: &seedmanagementv1alpha1.Shoot{Name: seedShoot}},
+		}
+		levels := &config.KubeconfigAccessLevels{
+			Shoots:       config.KubeconfigAccessLevelViewer,
+			ManagedSeeds: config.KubeconfigAccessLevelAdmin,
+		}
 
-		It("uses the shoots scope for a regular shoot", func() {
-			m := newManagerWithGarden(&config.KubeconfigAccessLevels{
-				Shoots:       config.KubeconfigAccessLevelViewer,
-				ManagedSeeds: config.KubeconfigAccessLevelAdmin,
-			}, project)
-
-			t := target.NewTarget(gardenName, projectName, "", plainShoot)
-			level, ok, err := m.EffectiveAccessLevel(ctx, t)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ok).To(BeTrue())
-			Expect(level).To(Equal(config.KubeconfigAccessLevelViewer))
-		})
-
-		It("uses the managed-seeds scope for a seed target", func() {
-			m := newManagerWithGarden(&config.KubeconfigAccessLevels{
-				Shoots:       config.KubeconfigAccessLevelViewer,
-				ManagedSeeds: config.KubeconfigAccessLevelAdmin,
-			}, project)
-
-			t := target.NewTarget(gardenName, "", "some-seed", "")
-			level, ok, err := m.EffectiveAccessLevel(ctx, t)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ok).To(BeTrue())
-			Expect(level).To(Equal(config.KubeconfigAccessLevelAdmin))
-		})
-
-		It("uses the managed-seeds scope for a shoot that backs a managed seed", func() {
-			managedSeed := &seedmanagementv1alpha1.ManagedSeed{
-				ObjectMeta: metav1.ObjectMeta{Name: seedShoot, Namespace: namespace, UID: "00000000-0000-0000-0000-000000000001"},
-				Spec:       seedmanagementv1alpha1.ManagedSeedSpec{Shoot: &seedmanagementv1alpha1.Shoot{Name: seedShoot}},
-			}
-
-			m := newManagerWithGarden(&config.KubeconfigAccessLevels{
-				Shoots:       config.KubeconfigAccessLevelViewer,
-				ManagedSeeds: config.KubeconfigAccessLevelAdmin,
-			}, project, managedSeed)
-
-			t := target.NewTarget(gardenName, projectName, "", seedShoot)
-			level, ok, err := m.EffectiveAccessLevel(ctx, t)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ok).To(BeTrue())
-			Expect(level).To(Equal(config.KubeconfigAccessLevelAdmin))
-		})
+		DescribeTable("routes to the right scope",
+			func(t target.Target, objs []client.Object, want config.KubeconfigAccessLevel) {
+				m := newManagerWithGarden(levels, objs...)
+				level, ok, err := m.EffectiveAccessLevel(ctx, t)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ok).To(BeTrue())
+				Expect(level).To(Equal(want))
+			},
+			Entry("regular shoot -> shoots scope (viewer)",
+				target.NewTarget(gardenName, projectName, "", plainShoot), []client.Object{project}, config.KubeconfigAccessLevelViewer),
+			Entry("seed target -> managedSeeds scope (admin)",
+				target.NewTarget(gardenName, "", "some-seed", ""), []client.Object{project}, config.KubeconfigAccessLevelAdmin),
+			Entry("managed-seed-backing shoot -> managedSeeds scope (admin) regardless of target path",
+				target.NewTarget(gardenName, projectName, "", seedShoot), []client.Object{project, managedSeed}, config.KubeconfigAccessLevelAdmin),
+		)
 	})
 })

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -86,7 +86,7 @@ func cloneTarget(t target.Target) target.Target {
 func createTestManager(t target.Target, cfg *config.Config, clientProvider internalclient.Provider) (target.Manager, target.TargetProvider) {
 	targetProvider := fake.NewFakeTargetProvider(cloneTarget(t))
 
-	manager, err := target.NewManager(cfg, targetProvider, clientProvider, sessionDir)
+	manager, err := target.NewManager(cfg, targetProvider, clientProvider, sessionDir, "")
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	ExpectWithOffset(1, manager).NotTo(BeNil())
 
@@ -742,6 +742,76 @@ var _ = Describe("Target Manager", func() {
 				Expect(err).ToNot(Succeed())
 				Expect(shootNames).To(BeNil())
 			})
+		})
+	})
+
+	Describe("resolveAccessLevel", func() {
+		const (
+			gardenName = "g1"
+		)
+
+		newManager := func(flagLevel config.KubeconfigAccessLevel, gardenLevels *config.KubeconfigAccessLevels) target.Manager {
+			cfg := &config.Config{
+				Gardens: []config.Garden{{
+					Name:                         gardenName,
+					Kubeconfig:                   "kubeconfig",
+					DefaultKubeconfigAccessLevel: gardenLevels,
+				}},
+			}
+
+			tp := fake.NewFakeTargetProvider(target.NewTarget(gardenName, "", "", ""))
+			m, err := target.NewManager(cfg, tp, nil, sessionDir, flagLevel)
+			Expect(err).NotTo(HaveOccurred())
+
+			return m
+		}
+
+		It("uses the CLI flag value regardless of scope and per-garden defaults", func() {
+			m := newManager(config.KubeconfigAccessLevelViewer, &config.KubeconfigAccessLevels{
+				Shoots:       config.KubeconfigAccessLevelAdmin,
+				ManagedSeeds: config.KubeconfigAccessLevelAdmin,
+			})
+			t := target.NewTarget(gardenName, "", "", "")
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelViewer))
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(Equal(config.KubeconfigAccessLevelViewer))
+		})
+
+		It("uses the scope-matching per-garden default when no flag is set", func() {
+			m := newManager("", &config.KubeconfigAccessLevels{
+				Shoots:       config.KubeconfigAccessLevelViewer,
+				ManagedSeeds: config.KubeconfigAccessLevelAuto,
+			})
+			t := target.NewTarget(gardenName, "", "", "")
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelViewer))
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(Equal(config.KubeconfigAccessLevelAuto))
+		})
+
+		It("falls back to admin per-scope when only the other scope is configured", func() {
+			m := newManager("", &config.KubeconfigAccessLevels{
+				Shoots: config.KubeconfigAccessLevelViewer,
+			})
+			t := target.NewTarget(gardenName, "", "", "")
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelViewer))
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(Equal(config.KubeconfigAccessLevelAdmin))
+		})
+
+		It("falls back to admin when neither flag nor per-garden default is set", func() {
+			m := newManager("", nil)
+			t := target.NewTarget(gardenName, "", "", "")
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelAdmin))
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(Equal(config.KubeconfigAccessLevelAdmin))
+		})
+
+		It("returns admin when the target has no garden", func() {
+			m := newManager("", &config.KubeconfigAccessLevels{Shoots: config.KubeconfigAccessLevelViewer})
+			t := target.NewTarget("", "", "", "")
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelAdmin))
+		})
+
+		It("returns admin when the target's garden is not in the config", func() {
+			m := newManager("", &config.KubeconfigAccessLevels{Shoots: config.KubeconfigAccessLevelViewer})
+			t := target.NewTarget("unknown-garden", "", "", "")
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelAdmin))
 		})
 	})
 })

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -786,32 +786,32 @@ var _ = Describe("Target Manager", func() {
 			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(Equal(config.KubeconfigAccessLevelAuto))
 		})
 
-		It("falls back to admin per-scope when only the other scope is configured", func() {
+		It("falls back to empty per-scope when only the other scope is configured", func() {
 			m := newManager("", &config.KubeconfigAccessLevels{
 				Shoots: config.KubeconfigAccessLevelViewer,
 			})
 			t := target.NewTarget(gardenName, "", "", "")
 			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelViewer))
-			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(Equal(config.KubeconfigAccessLevelAdmin))
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(BeEmpty())
 		})
 
-		It("falls back to admin when neither flag nor per-garden default is set", func() {
+		It("returns empty when neither flag nor per-garden default is set, so gardenlogin's own default applies", func() {
 			m := newManager("", nil)
 			t := target.NewTarget(gardenName, "", "", "")
-			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelAdmin))
-			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(Equal(config.KubeconfigAccessLevelAdmin))
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(BeEmpty())
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(BeEmpty())
 		})
 
-		It("returns admin when the target has no garden", func() {
+		It("returns empty when the target has no garden", func() {
 			m := newManager("", &config.KubeconfigAccessLevels{Shoots: config.KubeconfigAccessLevelViewer})
 			t := target.NewTarget("", "", "", "")
-			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelAdmin))
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(BeEmpty())
 		})
 
-		It("returns admin when the target's garden is not in the config", func() {
+		It("returns empty when the target's garden is not in the config", func() {
 			m := newManager("", &config.KubeconfigAccessLevels{Shoots: config.KubeconfigAccessLevelViewer})
 			t := target.NewTarget("unknown-garden", "", "", "")
-			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelAdmin))
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -861,19 +861,21 @@ var _ = Describe("Target Manager", func() {
 		}
 
 		DescribeTable("routes to the right scope",
-			func(t target.Target, objs []client.Object, want config.KubeconfigAccessLevel) {
+			func(t target.Target, objs []client.Object, wantOK bool, want config.KubeconfigAccessLevel) {
 				m := newManagerWithGarden(levels, objs...)
 				level, ok, err := m.EffectiveAccessLevel(ctx, t)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(ok).To(BeTrue())
+				Expect(ok).To(Equal(wantOK))
 				Expect(level).To(Equal(want))
 			},
 			Entry("regular shoot -> shoots scope (viewer)",
-				target.NewTarget(gardenName, projectName, "", plainShoot), []client.Object{project}, config.KubeconfigAccessLevelViewer),
-			Entry("seed target -> managedSeeds scope (admin)",
-				target.NewTarget(gardenName, "", "some-seed", ""), []client.Object{project}, config.KubeconfigAccessLevelAdmin),
+				target.NewTarget(gardenName, projectName, "", plainShoot), []client.Object{project}, true, config.KubeconfigAccessLevelViewer),
+			Entry("managed seed target -> managedSeeds scope (admin)",
+				target.NewTarget(gardenName, "", seedShoot, ""), []client.Object{project, managedSeed}, true, config.KubeconfigAccessLevelAdmin),
+			Entry("non-managed seed target -> no scope (static seed-login kubeconfig)",
+				target.NewTarget(gardenName, "", "some-seed", ""), []client.Object{project}, false, config.KubeconfigAccessLevel("")),
 			Entry("managed-seed-backing shoot -> managedSeeds scope (admin) regardless of target path",
-				target.NewTarget(gardenName, projectName, "", seedShoot), []client.Object{project, managedSeed}, config.KubeconfigAccessLevelAdmin),
+				target.NewTarget(gardenName, projectName, "", seedShoot), []client.Object{project, managedSeed}, true, config.KubeconfigAccessLevelAdmin),
 		)
 	})
 })

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	corev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/golang/mock/gomock"
@@ -769,22 +770,22 @@ var _ = Describe("Target Manager", func() {
 
 		It("uses the CLI flag value regardless of scope and per-garden defaults", func() {
 			m := newManager(config.KubeconfigAccessLevelViewer, &config.KubeconfigAccessLevels{
-				Shoots:       config.KubeconfigAccessLevelAdmin,
-				ManagedSeeds: config.KubeconfigAccessLevelAdmin,
+				Shoots: config.KubeconfigAccessLevelAdmin,
+				Seeds:  config.KubeconfigAccessLevelAdmin,
 			})
 			t := target.NewTarget(gardenName, "", "", "")
 			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelViewer))
-			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(Equal(config.KubeconfigAccessLevelViewer))
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeSeeds)).To(Equal(config.KubeconfigAccessLevelViewer))
 		})
 
 		It("uses the scope-matching per-garden default when no flag is set", func() {
 			m := newManager("", &config.KubeconfigAccessLevels{
-				Shoots:       config.KubeconfigAccessLevelViewer,
-				ManagedSeeds: config.KubeconfigAccessLevelAuto,
+				Shoots: config.KubeconfigAccessLevelViewer,
+				Seeds:  config.KubeconfigAccessLevelAuto,
 			})
 			t := target.NewTarget(gardenName, "", "", "")
 			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelViewer))
-			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(Equal(config.KubeconfigAccessLevelAuto))
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeSeeds)).To(Equal(config.KubeconfigAccessLevelAuto))
 		})
 
 		It("falls back to empty per-scope when only the other scope is configured", func() {
@@ -793,14 +794,14 @@ var _ = Describe("Target Manager", func() {
 			})
 			t := target.NewTarget(gardenName, "", "", "")
 			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(Equal(config.KubeconfigAccessLevelViewer))
-			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(BeEmpty())
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeSeeds)).To(BeEmpty())
 		})
 
 		It("returns empty when neither flag nor per-garden default is set, so gardenlogin's own default applies", func() {
 			m := newManager("", nil)
 			t := target.NewTarget(gardenName, "", "", "")
 			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeShoots)).To(BeEmpty())
-			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeManagedSeeds)).To(BeEmpty())
+			Expect(target.ResolveAccessLevel(m, t, target.AccessScopeSeeds)).To(BeEmpty())
 		})
 
 		It("returns empty when the target has no garden", func() {
@@ -818,11 +819,12 @@ var _ = Describe("Target Manager", func() {
 
 	Describe("EffectiveAccessLevel scope routing for managed-seed-backing shoots", func() {
 		const (
-			gardenName  = "g1"
-			projectName = "myproject"
-			namespace   = "garden-myproject"
-			plainShoot  = "plain-shoot"
-			seedShoot   = "seed-shoot"
+			gardenName        = "g1"
+			userProjectName   = "myproject"
+			userNamespace     = "garden-myproject"
+			gardenProjectName = "garden-project"
+			plainShoot        = "plain-shoot"
+			seedShoot         = "seed-shoot"
 		)
 
 		newManagerWithGarden := func(gardenLevels *config.KubeconfigAccessLevels, objs ...client.Object) target.Manager {
@@ -840,24 +842,32 @@ var _ = Describe("Target Manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 			provider.EXPECT().FromClientConfig(gomock.Eq(cc)).Return(fake.NewClientWithObjects(objs...), nil).AnyTimes()
 
-			tp := fake.NewFakeTargetProvider(target.NewTarget(gardenName, projectName, "", ""))
+			tp := fake.NewFakeTargetProvider(target.NewTarget(gardenName, userProjectName, "", ""))
 			m, err := target.NewManager(cfg, tp, provider, sessionDir, "")
 			Expect(err).NotTo(HaveOccurred())
 
 			return m
 		}
 
-		project := &gardencorev1beta1.Project{
-			ObjectMeta: metav1.ObjectMeta{Name: projectName, UID: "00000000-0000-0000-0000-000000000000"},
-			Spec:       gardencorev1beta1.ProjectSpec{Namespace: ptr.To(namespace)},
+		// Regular user project: shoots live in its own garden-<name> namespace.
+		userProject := &gardencorev1beta1.Project{
+			ObjectMeta: metav1.ObjectMeta{Name: userProjectName, UID: "00000000-0000-0000-0000-000000000000"},
+			Spec:       gardencorev1beta1.ProjectSpec{Namespace: ptr.To(userNamespace)},
+		}
+		// Operator-side project whose namespace is "garden" - shoots that back
+		// managed seeds must live there per the Gardener API server's enforcement
+		// (see docs/operations/managed_seed.md in upstream Gardener).
+		gardenProject := &gardencorev1beta1.Project{
+			ObjectMeta: metav1.ObjectMeta{Name: gardenProjectName, UID: "00000000-0000-0000-0000-000000000002"},
+			Spec:       gardencorev1beta1.ProjectSpec{Namespace: ptr.To(corev1beta1constants.GardenNamespace)},
 		}
 		managedSeed := &seedmanagementv1alpha1.ManagedSeed{
-			ObjectMeta: metav1.ObjectMeta{Name: seedShoot, Namespace: namespace, UID: "00000000-0000-0000-0000-000000000001"},
+			ObjectMeta: metav1.ObjectMeta{Name: seedShoot, Namespace: corev1beta1constants.GardenNamespace, UID: "00000000-0000-0000-0000-000000000001"},
 			Spec:       seedmanagementv1alpha1.ManagedSeedSpec{Shoot: &seedmanagementv1alpha1.Shoot{Name: seedShoot}},
 		}
 		levels := &config.KubeconfigAccessLevels{
-			Shoots:       config.KubeconfigAccessLevelViewer,
-			ManagedSeeds: config.KubeconfigAccessLevelAdmin,
+			Shoots: config.KubeconfigAccessLevelViewer,
+			Seeds:  config.KubeconfigAccessLevelAdmin,
 		}
 
 		DescribeTable("routes to the right scope",
@@ -869,13 +879,13 @@ var _ = Describe("Target Manager", func() {
 				Expect(level).To(Equal(want))
 			},
 			Entry("regular shoot -> shoots scope (viewer)",
-				target.NewTarget(gardenName, projectName, "", plainShoot), []client.Object{project}, true, config.KubeconfigAccessLevelViewer),
-			Entry("managed seed target -> managedSeeds scope (admin)",
-				target.NewTarget(gardenName, "", seedShoot, ""), []client.Object{project, managedSeed}, true, config.KubeconfigAccessLevelAdmin),
+				target.NewTarget(gardenName, userProjectName, "", plainShoot), []client.Object{userProject}, true, config.KubeconfigAccessLevelViewer),
+			Entry("managed seed target -> seeds scope (admin)",
+				target.NewTarget(gardenName, "", seedShoot, ""), []client.Object{managedSeed}, true, config.KubeconfigAccessLevelAdmin),
 			Entry("non-managed seed target -> no scope (static seed-login kubeconfig)",
-				target.NewTarget(gardenName, "", "some-seed", ""), []client.Object{project}, false, config.KubeconfigAccessLevel("")),
-			Entry("managed-seed-backing shoot -> managedSeeds scope (admin) regardless of target path",
-				target.NewTarget(gardenName, projectName, "", seedShoot), []client.Object{project, managedSeed}, true, config.KubeconfigAccessLevelAdmin),
+				target.NewTarget(gardenName, "", "some-seed", ""), []client.Object{}, false, config.KubeconfigAccessLevel("")),
+			Entry("managed-seed-backing shoot -> seeds scope (admin) regardless of target path",
+				target.NewTarget(gardenName, gardenProjectName, "", seedShoot), []client.Object{gardenProject, managedSeed}, true, config.KubeconfigAccessLevelAdmin),
 		)
 	})
 })

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -884,6 +884,20 @@ var _ = Describe("Target Manager", func() {
 				target.NewTarget(gardenName, "", seedShoot, ""), []client.Object{managedSeed}, true, config.KubeconfigAccessLevelAdmin),
 			Entry("non-managed seed target -> no scope (static seed-login kubeconfig)",
 				target.NewTarget(gardenName, "", "some-seed", ""), []client.Object{}, false, config.KubeconfigAccessLevel("")),
+			Entry("control plane of managed-seed shoot -> seeds scope (admin)",
+				target.NewTarget(gardenName, gardenProjectName, seedShoot, seedShoot).WithControlPlane(true), []client.Object{gardenProject, managedSeed}, true, config.KubeconfigAccessLevelAdmin),
+			Entry("control plane of non-managed seed -> no scope (static seed-login kubeconfig)",
+				target.NewTarget(gardenName, gardenProjectName, "some-seed", "some-shoot").WithControlPlane(true), []client.Object{gardenProject}, false, config.KubeconfigAccessLevel("")),
+			// `target --garden X --shoot Y control-plane` wipes deeper target
+			// levels (gardener/gardenctl-v2#744); SeedName arrives empty.
+			// EffectiveAccessLevel recovers spec.seedName the same way
+			// ClientConfig does, so a managed-seed-backing shoot still displays.
+			Entry("control plane with empty SeedName (merge-wipe artifact) -> seeds scope (admin)",
+				target.NewTarget(gardenName, gardenProjectName, "", seedShoot).WithControlPlane(true),
+				[]client.Object{gardenProject, managedSeed, &gardencorev1beta1.Shoot{
+					ObjectMeta: metav1.ObjectMeta{Name: seedShoot, Namespace: corev1beta1constants.GardenNamespace, UID: "00000000-0000-0000-0000-000000000003"},
+					Spec:       gardencorev1beta1.ShootSpec{SeedName: ptr.To(seedShoot)},
+				}}, true, config.KubeconfigAccessLevelAdmin),
 			Entry("managed-seed-backing shoot -> seeds scope (admin) regardless of target path",
 				target.NewTarget(gardenName, gardenProjectName, "", seedShoot), []client.Object{gardenProject, managedSeed}, true, config.KubeconfigAccessLevelAdmin),
 		)

--- a/pkg/target/mocks/mock_manager.go
+++ b/pkg/target/mocks/mock_manager.go
@@ -83,6 +83,21 @@ func (mr *MockManagerMockRecorder) CurrentTarget() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentTarget", reflect.TypeOf((*MockManager)(nil).CurrentTarget))
 }
 
+// EffectiveAccessLevel mocks base method.
+func (m *MockManager) EffectiveAccessLevel(arg0 target.Target) (config.KubeconfigAccessLevel, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EffectiveAccessLevel", arg0)
+	ret0, _ := ret[0].(config.KubeconfigAccessLevel)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// EffectiveAccessLevel indicates an expected call of EffectiveAccessLevel.
+func (mr *MockManagerMockRecorder) EffectiveAccessLevel(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EffectiveAccessLevel", reflect.TypeOf((*MockManager)(nil).EffectiveAccessLevel), arg0)
+}
+
 // GardenClient mocks base method.
 func (m *MockManager) GardenClient(arg0 string) (garden.Client, error) {
 	m.ctrl.T.Helper()
@@ -126,6 +141,20 @@ func (m *MockManager) ProjectNames(arg0 context.Context) ([]string, error) {
 func (mr *MockManagerMockRecorder) ProjectNames(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProjectNames", reflect.TypeOf((*MockManager)(nil).ProjectNames), arg0)
+}
+
+// RefreshKubeconfig mocks base method.
+func (m *MockManager) RefreshKubeconfig(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshKubeconfig", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RefreshKubeconfig indicates an expected call of RefreshKubeconfig.
+func (mr *MockManagerMockRecorder) RefreshKubeconfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshKubeconfig", reflect.TypeOf((*MockManager)(nil).RefreshKubeconfig), arg0)
 }
 
 // SeedClient mocks base method.

--- a/pkg/target/mocks/mock_manager.go
+++ b/pkg/target/mocks/mock_manager.go
@@ -143,20 +143,6 @@ func (mr *MockManagerMockRecorder) ProjectNames(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProjectNames", reflect.TypeOf((*MockManager)(nil).ProjectNames), arg0)
 }
 
-// RefreshKubeconfig mocks base method.
-func (m *MockManager) RefreshKubeconfig(arg0 context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RefreshKubeconfig", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RefreshKubeconfig indicates an expected call of RefreshKubeconfig.
-func (mr *MockManagerMockRecorder) RefreshKubeconfig(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshKubeconfig", reflect.TypeOf((*MockManager)(nil).RefreshKubeconfig), arg0)
-}
-
 // SeedClient mocks base method.
 func (m *MockManager) SeedClient(arg0 context.Context, arg1 target.Target) (client.Client, error) {
 	m.ctrl.T.Helper()

--- a/pkg/target/mocks/mock_manager.go
+++ b/pkg/target/mocks/mock_manager.go
@@ -84,18 +84,19 @@ func (mr *MockManagerMockRecorder) CurrentTarget() *gomock.Call {
 }
 
 // EffectiveAccessLevel mocks base method.
-func (m *MockManager) EffectiveAccessLevel(arg0 target.Target) (config.KubeconfigAccessLevel, bool) {
+func (m *MockManager) EffectiveAccessLevel(arg0 context.Context, arg1 target.Target) (config.KubeconfigAccessLevel, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EffectiveAccessLevel", arg0)
+	ret := m.ctrl.Call(m, "EffectiveAccessLevel", arg0, arg1)
 	ret0, _ := ret[0].(config.KubeconfigAccessLevel)
 	ret1, _ := ret[1].(bool)
-	return ret0, ret1
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // EffectiveAccessLevel indicates an expected call of EffectiveAccessLevel.
-func (mr *MockManagerMockRecorder) EffectiveAccessLevel(arg0 interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) EffectiveAccessLevel(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EffectiveAccessLevel", reflect.TypeOf((*MockManager)(nil).EffectiveAccessLevel), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EffectiveAccessLevel", reflect.TypeOf((*MockManager)(nil).EffectiveAccessLevel), arg0, arg1)
 }
 
 // GardenClient mocks base method.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area usability
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|cost|dev-productivity|documentation|high-availability|logging|monitoring|networking|open-source|ops-productivity|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area ops-productivity
/area security
/kind enhancement

**What this PR does / why we need it**:

Implements admin/viewer/auto kubeconfig access-level support in `gardenctl`, so admins working on production gardens can default to a read-only kubeconfig and be confident they cannot accidentally break things.

Added new fields to the gardenctl config:
```yaml
gardens:
- identity: prd-garden
  kubeconfig: ~/path/to/kubeconfig.yaml
  kubeconfigAccessLevelDefaults:
    shoots: viewer        # admin (default) | viewer | auto
    managedSeeds: admin   # admin (default) | viewer | auto
```

Added a `--access-level` flag to relevant commands (`target`, `kubeconfig`) to allow overwriting the setting in the config for the currently targeted `Garden`.

Added `--default-shoot-access-level` and `--default-managed-seed-access-level` flags to the `gardenctl config set-garden` command to set the fields in the config. When `set-garden` changes the access levels, `gardenctl` prints a hint that existing session kubeconfigs are not regenerated and that `gardenctl target` may need to be re-run.

The flag value is plumbed through `gardenlogin`'s existing `--access-level` flag, which already supports admin/viewer/auto end-to-end. For non-managed seeds (and the garden cluster) `gardenlogin`'s access-level mechanism is unavailable, so an explicit viewer request returns an error; `admin` and `auto` use the static seed-login kubeconfig as-is.

**Behavior**:
- Defers to gardenlogin's own default when nothing is set.
- Scope by cluster role, not target path (that is if doing `target shoot xy` and this `Shoot` is backend by a `ManagedSeed` you would get the permissions configured under `kubeconfigAccessLevelDefaults.managedSeeds`.
 
**Which issue(s) this PR fixes**:
Fixes gardener/hackathon#71

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`gardenctl` now supports requesting a read-only viewer kubeconfig instead of admin via the `--access-level` flag (`admin` / `viewer` / `auto`) and the per-garden `kubeconfigAccessLevelDefaults.{shoots,managedSeeds}` config block (also editable via `gardenctl config set-garden`).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add kubeconfig access-level support (admin/viewer/auto) with --access-level and --admin/--viewer shorthands across target, kubeconfig, kubectl-env and related commands.
  * Add per-garden defaults flags (--default-shoot-access-level, --default-seed-access-level) in config set-garden; changing defaults prints a hint to re-run target.
  * Commands now report the effective access level (and append it to target success messages when applicable); kubectl-env warns when symlink mode makes --access-level ineffective.

* **Documentation**
  * README, configuration guide, and CLI help updated with examples, flag behavior, validation rules, and verification guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->