### PR TITLE
ci(renovate): allow Go version patch updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -93,17 +93,5 @@
         'github-actions',
       ],
     },
-    {
-      matchManagers: [
-        'gomod',
-      ],
-      matchUpdateTypes: [
-        'patch',
-      ],
-      enabled: false,
-      matchPackageNames: [
-        '/go/',
-      ],
-    },
   ],
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Removes the Renovate package rule that disabled patch-level updates for the Go version directive in `go.mod`.

The rule was added when builds ran on Concourse with hardcoded build images, so bumps to the Go directive in `go.mod` had no effect on the actual build. Builds now run on GitHub Actions and use the Go version from `go.mod` via `setup-go`'s `go-version-file`, so patch bumps actually propagate to CI and are worth taking (mostly security fixes).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other dependency
NONE
```