### PR TITLE
ci: add CVE categorisation labels to component descriptor

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,6 +80,19 @@ jobs:
               type: localBlob
               localReference: >-
                 gardenctl-v2-${{ matrix.args.os }}-${{ matrix.args.arch }}${{ matrix.args.os == 'windows' && '.exe' || '' }}
+            labels:
+              # `network_exposure: protected` (not `private`): no listening
+              # sockets, but consumes attacker-influenceable data from remote
+              # control planes — CVEs reachable via that path (e.g. in
+              # parsers/protocols) should not be treated as network-isolated.
+              - name: gardener.cloud/cve-categorisation
+                value:
+                  network_exposure: protected
+                  authentication_enforced: false
+                  user_interaction: end-user
+                  confidentiality_requirement: high
+                  integrity_requirement: high
+                  availability_requirement: low
 
   build-gardenctl-summary:
     name: Build Summary


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area security
/kind enhancement

**What this PR does / why we need it**:

Annotates the gardenctl binary resource in the component descriptor with `gardener.cloud/cve-categorisation` so downstream CVE triage can assess exploit reachability.

`network_exposure` is set to `protected` (not `private`): gardenctl does not listen on any socket, but it consumes data from remote control planes, so CVEs in parsers or protocols reachable via that path should not be treated as network-isolated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other dependency
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security metadata configuration in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->