### PR TITLE
chore(ci): use client-id for gardener-github-pkg-mngr app token

### DIFF
--- a/.github/workflows/publish-to-package-repositories.yaml
+++ b/.github/workflows/publish-to-package-repositories.yaml
@@ -13,9 +13,9 @@ on:
         description: |
           the OCM-Component-Descriptor from which to publish built artefacts
     secrets:
-      GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID:
+      GARDENER_GITHUB_WORKFLOW_PKG_MNGR_CLIENT_ID:
         required: false
-        description: App ID for the gardener-github-pkg-mngr GitHub App
+        description: Client ID for the gardener-github-pkg-mngr GitHub App
       GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_PRIVATE_KEY:
         required: false
         description: Private key for the gardener-github-pkg-mngr GitHub App
@@ -58,7 +58,7 @@ jobs:
         id: gardener-github-workflows
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1   # v3.2.0
         with:
-          app-id:      ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID }}
+          client-id:   ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_CLIENT_ID }}
           private-key: ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_PRIVATE_KEY }}
           owner:       ${{ github.repository_owner }}
           repositories: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
     needs:
       - release-to-github-and-bump
     secrets:
-      GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID: ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID }}
+      GARDENER_GITHUB_WORKFLOW_PKG_MNGR_CLIENT_ID: ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_CLIENT_ID }}
       GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_PRIVATE_KEY: ${{ secrets.GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_PRIVATE_KEY }}
     uses: ./.github/workflows/publish-to-package-repositories.yaml
     with:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
The `app-id` input of `actions/create-github-app-token` is deprecated in favor of `client-id`. This PR renames the workflow secret from `GARDENER_GITHUB_WORKFLOW_PKG_MNGR_APP_ID` to `GARDENER_GITHUB_WORKFLOW_PKG_MNGR_CLIENT_ID` and passes it as `client-id` to the action.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The new secret `GARDENER_GITHUB_WORKFLOW_PKG_MNGR_CLIENT_ID` is already in place at the org level and ready to be consumed by the repos.

**Release note**:
```other dependency
NONE
```