### PR TITLE
chore(renovate): drop "Update" from tools group name

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -50,7 +50,7 @@
       rangeStrategy: 'bump',
     },
     {
-      groupName: 'Update tools',
+      groupName: 'tools',
       matchFileNames: [
         'hack/tools\\.mk',
       ],


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Renames the `Update tools` Renovate group to `tools`. Renovate prepends "Update" to PR titles, which produced redundant titles like `Update Update tools to v2.27.1`. Renaming the group avoids the duplication.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other dependency
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted tool dependency update grouping configuration for improved workflow organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->