### PR TITLE
feat(provider-env,ssh): honour `--control-plane`

### DIFF
--- a/docs/help/gardenctl.md
+++ b/docs/help/gardenctl.md
@@ -59,7 +59,7 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 * [gardenctl provider-env](gardenctl_provider-env.md)	 - Generate the cloud provider CLI configuration script for the specified shell
 * [gardenctl rc](gardenctl_rc.md)	 - Generate a gardenctl startup script for the specified shell
 * [gardenctl resolve](gardenctl_resolve.md)	 - Resolve the current target
-* [gardenctl ssh](gardenctl_ssh.md)	 - Establish an SSH connection to a node of a Shoot cluster
+* [gardenctl ssh](gardenctl_ssh.md)	 - Establish an SSH connection to a node of a shoot cluster
 * [gardenctl ssh-patch](gardenctl_ssh-patch.md)	 - Update a bastion host previously created through the ssh command
 * [gardenctl target](gardenctl_target.md)	 - Set scope for next operations, using subcommands or pattern
 * [gardenctl version](gardenctl_version.md)	 - Print the gardenctl version information

--- a/docs/help/gardenctl_config.md
+++ b/docs/help/gardenctl_config.md
@@ -41,8 +41,8 @@ The loading order follows these rules:
 ### SEE ALSO
 
 * [gardenctl](gardenctl.md)	 - Gardenctl is a utility to interact with Gardener installations
-* [gardenctl config delete-garden](gardenctl_config_delete-garden.md)	 - Delete the specified Garden from the gardenctl configuration
-* [gardenctl config set-garden](gardenctl_config_set-garden.md)	 - Modify or add a Garden to the gardenctl configuration
+* [gardenctl config delete-garden](gardenctl_config_delete-garden.md)	 - Delete the specified garden from the gardenctl configuration
+* [gardenctl config set-garden](gardenctl_config_set-garden.md)	 - Modify or add a garden to the gardenctl configuration
 * [gardenctl config set-openstack-authurl](gardenctl_config_set-openstack-authurl.md)	 - Configure allowed OpenStack auth URLs
 * [gardenctl config view](gardenctl_config_view.md)	 - Print the gardenctl configuration
 

--- a/docs/help/gardenctl_config_delete-garden.md
+++ b/docs/help/gardenctl_config_delete-garden.md
@@ -1,6 +1,6 @@
 ## gardenctl config delete-garden
 
-Delete the specified Garden from the gardenctl configuration
+Delete the specified garden from the gardenctl configuration
 
 ```
 gardenctl config delete-garden [flags]

--- a/docs/help/gardenctl_config_set-garden.md
+++ b/docs/help/gardenctl_config_set-garden.md
@@ -1,11 +1,11 @@
 ## gardenctl config set-garden
 
-Modify or add a Garden to the gardenctl configuration
+Modify or add a garden to the gardenctl configuration
 
 ### Synopsis
 
-Modify or add a Garden to the gardenctl configuration.
-A valid Garden configuration consists of a name (required), kubeconfig path (required), a context as well as any number of patterns.
+Modify or add a garden to the gardenctl configuration.
+A valid garden configuration consists of a name (required), kubeconfig path (required), a context as well as any number of patterns.
 In order to share the configuration with gardenlogin, you need to set the name to the cluster identity.
 
 ```
@@ -15,10 +15,10 @@ gardenctl config set-garden [flags]
 ### Examples
 
 ```
-# add new Garden my-garden with no additional values
+# add new garden my-garden with no additional values
 gardenctl config set-garden my-garden
 
-# add new Garden with name set to cluster identity and path to kubeconfig file configured
+# add new garden with name set to cluster identity and path to kubeconfig file configured
 export KUBECONFIG=~/path/to/garden-cluster/kubeconfig.yaml
 CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
 gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
@@ -33,12 +33,12 @@ gardenctl config set-garden prd-garden --default-shoot-access-level viewer
 ### Options
 
 ```
-      --alias string                        unique alias of this Garden that can be used instead of the name to target this Garden
+      --alias string                        unique alias of this garden that can be used instead of the name to target this garden
       --context string                      override the current-context of the garden cluster kubeconfig
       --default-seed-access-level string    default kubeconfig access level when targeting seeds in this garden (and shoots that back a managed seed, since they physically are the seed cluster). One of "admin", "viewer", "auto". Pass an empty value to unset and delegate to gardenlogin's default.
       --default-shoot-access-level string   default kubeconfig access level when targeting shoots in this garden. One of "admin", "viewer", "auto". Pass an empty value to unset and delegate to gardenlogin's default.
   -h, --help                                help for set-garden
-      --kubeconfig string                   path to kubeconfig file for this Garden cluster
+      --kubeconfig string                   path to kubeconfig file for this garden cluster
       --pattern stringArray                 define regex match patterns for this garden for custom input formats for targeting.
                                             Use named capturing groups to match target values.
                                             Supported capturing groups: project, namespace, shoot.

--- a/docs/help/gardenctl_kubeconfig.md
+++ b/docs/help/gardenctl_kubeconfig.md
@@ -15,10 +15,10 @@ gardenctl kubeconfig
 # Print the kubeconfig for the current target in json format
 gardenctl kubeconfig --output json
 
-# Print the Shoot cluster kubeconfig for my-shoot
+# Print the shoot cluster kubeconfig for my-shoot
 gardenctl kubeconfig --garden my-garden --project my-project --shoot my-shoot
 
-# Print the Garden cluster kubeconfig of my-garden. The namespace of the project my-project is set as default
+# Print the garden cluster kubeconfig of my-garden. The namespace of the project my-project is set as default
 gardenctl kubeconfig --garden my-garden --project my-project
 ```
 

--- a/docs/help/gardenctl_provider-env.md
+++ b/docs/help/gardenctl_provider-env.md
@@ -8,6 +8,10 @@ Generate the cloud provider CLI configuration script for the specified shell.
 See each sub-command's help for details on how to use the generated script.
 
 The generated script sets the environment variables for the cloud provider CLI of the targeted shoot.
+When targeting a shoot control plane, the generated script configures the provider CLI for the seed
+infrastructure account that hosts that control plane.
+Only managed seeds are supported, because gardenctl needs the backing shoot to resolve the seed
+infrastructure credentials.
 In addition, the Azure CLI requires to sign in with a service principal and the gcloud CLI requires to activate a service-account.
 Thereby the configuration location of the corresponding cloud provider CLI is pointed to a temporary folder in the
 session directory, so that the standard configuration files in the user's home folder are not affected.

--- a/docs/help/gardenctl_provider-env_bash.md
+++ b/docs/help/gardenctl_provider-env_bash.md
@@ -6,8 +6,11 @@ Generate the cloud provider CLI configuration script for bash
 
 Generate the cloud provider CLI configuration script for bash.
 
-To load the cloud provider CLI configuration script in your current shell session:
+To configure the provider CLI for the currently targeted shoot:
 $ eval "$(gardenctl provider-env bash)"
+
+To configure the provider CLI for the seed infrastructure account hosting the shoot control plane:
+$ eval "$(gardenctl provider-env bash --control-plane)"
 
 
 ```

--- a/docs/help/gardenctl_provider-env_fish.md
+++ b/docs/help/gardenctl_provider-env_fish.md
@@ -6,8 +6,11 @@ Generate the cloud provider CLI configuration script for fish
 
 Generate the cloud provider CLI configuration script for fish.
 
-To load the cloud provider CLI configuration script in your current shell session:
+To configure the provider CLI for the currently targeted shoot:
 $ eval (gardenctl provider-env fish)
+
+To configure the provider CLI for the seed infrastructure account hosting the shoot control plane:
+$ eval (gardenctl provider-env fish --control-plane)
 
 
 ```

--- a/docs/help/gardenctl_provider-env_powershell.md
+++ b/docs/help/gardenctl_provider-env_powershell.md
@@ -6,8 +6,11 @@ Generate the cloud provider CLI configuration script for powershell
 
 Generate the cloud provider CLI configuration script for powershell.
 
-To load the cloud provider CLI configuration script in your current shell session:
+To configure the provider CLI for the currently targeted shoot:
 PS /> & gardenctl provider-env powershell | Invoke-Expression
+
+To configure the provider CLI for the seed infrastructure account hosting the shoot control plane:
+PS /> & gardenctl provider-env powershell --control-plane | Invoke-Expression
 
 
 ```

--- a/docs/help/gardenctl_provider-env_zsh.md
+++ b/docs/help/gardenctl_provider-env_zsh.md
@@ -6,8 +6,11 @@ Generate the cloud provider CLI configuration script for zsh
 
 Generate the cloud provider CLI configuration script for zsh.
 
-To load the cloud provider CLI configuration script in your current shell session:
+To configure the provider CLI for the currently targeted shoot:
 $ eval "$(gardenctl provider-env zsh)"
+
+To configure the provider CLI for the seed infrastructure account hosting the shoot control plane:
+$ eval "$(gardenctl provider-env zsh --control-plane)"
 
 
 ```

--- a/docs/help/gardenctl_ssh.md
+++ b/docs/help/gardenctl_ssh.md
@@ -1,14 +1,19 @@
 ## gardenctl ssh
 
-Establish an SSH connection to a node of a Shoot cluster
+Establish an SSH connection to a node of a shoot cluster
 
 ### Synopsis
 
-Establish an SSH connection to a node of a Shoot cluster by specifying its name.
+Establish an SSH connection to a node of a shoot cluster by specifying its name.
 
 A bastion is created to access the node and is automatically cleaned up afterwards.
 
-If a node name is not provided, gardenctl will display the hostnames/IPs of the Shoot worker nodes and the corresponding SSH command.
+When targeting a shoot control plane, gardenctl connects to nodes of the seed shoot that hosts the
+targeted shoot's control plane.
+Only managed seeds are supported, because gardenctl needs the backing shoot to create the bastion
+and determine its worker nodes.
+
+If a node name is not provided, gardenctl will display the hostnames/IPs of the shoot worker nodes and the corresponding SSH command.
 To connect to a desired node, copy the printed SSH command, replace the target hostname accordingly, and execute the command.
 
 ```
@@ -18,13 +23,16 @@ gardenctl ssh [NODE_NAME] [flags]
 ### Examples
 
 ```
-# Establish an SSH connection to a specific Shoot cluster node
+# Establish an SSH connection to a specific shoot cluster node
 gardenctl ssh my-shoot-node-1
+
+# Establish an SSH connection to a node of the seed shoot hosting a shoot control plane
+gardenctl ssh my-seed-node-1 --garden my-garden --project my-project --shoot my-shoot --control-plane
 
 # Establish an SSH connection with custom CIDRs to allow access to the bastion host
 gardenctl ssh my-shoot-node-1 --cidr 10.1.2.3/32
 
-# Establish an SSH connection to any Shoot cluster node
+# Establish an SSH connection to any shoot cluster node
 # Copy the printed SSH command, replace the 'IP_OR_HOSTNAME' placeholder for the target hostname/IP, and execute the command to connect to the desired node
 gardenctl ssh
 
@@ -62,7 +70,7 @@ gardenctl ssh --keep-bastion --bastion-name cli-xxxxxxxx --public-key-file /path
       --shell string                              Shell to use for escaping arguments when printing out the SSH command. If not provided, it defaults to the GCTL_SHELL environment variable or bash.
       --shoot string                              target the given shoot cluster
       --skip-availability-check                   Skip checking for SSH bastion host availability.
-      --user string                               user is the name of the Shoot cluster node ssh login username. (default "gardener")
+      --user string                               user is the name of the shoot cluster node ssh login username. (default "gardener")
       --wait-timeout duration                     Maximum duration to wait for the bastion to become available. (default 10m0s)
 ```
 

--- a/docs/usage/provider-env.md
+++ b/docs/usage/provider-env.md
@@ -1,6 +1,6 @@
 # Configure Cloud Provider CLIs with provider-env
 
-The `provider-env` command generates a shell script to configure cloud provider CLIs (aws, az, gcloud, openstack, aliyun, hcloud) for the currently targeted Shoot. Evaluate the generated script in your shell to export the required environment variables and perform any necessary provider CLI setup.
+The `provider-env` command generates a shell script to configure cloud provider CLIs (aws, az, gcloud, openstack, aliyun, hcloud) for the currently targeted shoot or managed seed. Evaluate the generated script in your shell to export the required environment variables and perform any necessary provider CLI setup.
 
 ## Basic usage
 
@@ -10,12 +10,17 @@ Generate and evaluate the script for your shell. Example for `bash`:
 eval "$(gardenctl provider-env bash)"
 ```
 
+The `gardenctl rc` aliases described in the [Recommended Shell Configuration](../../README.md#recommended-shell-configuration) provide shortcuts for these commands: `gp` for the default provider environment and `gpc` for `--control-plane`.
+
 Alternatively, you can generate the script for other shells using subcommands: `bash`, `zsh`, `fish`, `powershell`.
 
 The generated script:
-- Sets provider-specific environment variables for the targeted Shoot
+- Sets provider-specific environment variables for the target
 - Uses a temporary session directory so your default CLI configs are not modified
 - Supports `--unset` to clean up and log out/revoke credentials
+
+> [!NOTE]
+> `provider-env` can resolve provider credentials for shoots and managed seeds. It cannot generate provider credentials for non-managed seeds.
 
 Ensure the respective provider CLI is installed on your system. See the `gardenctl provider-env` [help](https://github.com/gardener/gardenctl-v2/blob/master/docs/help/gardenctl_provider-env.md#synopsis) for links.
 
@@ -25,7 +30,7 @@ To override templates or add support for an out-of-tree provider, place a templa
 
 ## OpenStack: Allowed `authURL` patterns (required)
 
-For Shoots with provider type `openstack`, `gardenctl` validates the `authURL` (the OpenStack Keystone authentication endpoint) from the credentials against a list of allowed patterns.  
+For OpenStack targets, `gardenctl` validates the `authURL` (the OpenStack Keystone authentication endpoint) from the credentials against a list of allowed patterns.  
 You can configure allowed patterns via the gardenctl configuration file or via command-line flags.  
 
 > [!NOTE]

--- a/internal/client/garden/client.go
+++ b/internal/client/garden/client.go
@@ -627,10 +627,7 @@ func (g *clientImpl) GetSeedClientConfig(ctx context.Context, name string, acces
 
 	if !apierrors.IsNotFound(err) {
 		logger.V(1).Info("using referred shoot of managed seed",
-			"shoot", klog.ObjectRef{
-				Namespace: corev1beta1constants.GardenNamespace,
-				Name:      shoot.Name,
-			},
+			"shoot", klog.KRef(corev1beta1constants.GardenNamespace, shoot.Name),
 			"seed", name)
 
 		return g.GetShootClientConfig(ctx, corev1beta1constants.GardenNamespace, shoot.Name, accessLevel)

--- a/pkg/cmd/config/delete_garden.go
+++ b/pkg/cmd/config/delete_garden.go
@@ -27,7 +27,7 @@ func NewCmdConfigDeleteGarden(f util.Factory, ioStreams util.IOStreams) *cobra.C
 	}
 	cmd := &cobra.Command{
 		Use:   "delete-garden",
-		Short: "Delete the specified Garden from the gardenctl configuration",
+		Short: "Delete the specified garden from the gardenctl configuration",
 		Example: `# delete my-garden
 gardenctl config delete-garden my-garden`,
 		ValidArgsFunction: validGardenArgsFunctionWrapper(f, ioStreams),

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -36,14 +36,14 @@ func NewCmdConfigSetGarden(f util.Factory, ioStreams util.IOStreams) *cobra.Comm
 	}
 	cmd := &cobra.Command{
 		Use:   "set-garden",
-		Short: "Modify or add a Garden to the gardenctl configuration",
-		Long: `Modify or add a Garden to the gardenctl configuration.
-A valid Garden configuration consists of a name (required), kubeconfig path (required), a context as well as any number of patterns.
+		Short: "Modify or add a garden to the gardenctl configuration",
+		Long: `Modify or add a garden to the gardenctl configuration.
+A valid garden configuration consists of a name (required), kubeconfig path (required), a context as well as any number of patterns.
 In order to share the configuration with gardenlogin, you need to set the name to the cluster identity.`,
-		Example: `# add new Garden my-garden with no additional values
+		Example: `# add new garden my-garden with no additional values
 gardenctl config set-garden my-garden
 
-# add new Garden with name set to cluster identity and path to kubeconfig file configured
+# add new garden with name set to cluster identity and path to kubeconfig file configured
 export KUBECONFIG=~/path/to/garden-cluster/kubeconfig.yaml
 CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonpath={.data.cluster-identity})
 gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
@@ -157,9 +157,9 @@ func (o *setGardenOptions) Validate() error {
 
 // AddFlags adds flags to adjust the output to a cobra command.
 func (o *setGardenOptions) AddFlags(flags *pflag.FlagSet) {
-	flags.Var(&o.KubeconfigFlag, "kubeconfig", "path to kubeconfig file for this Garden cluster")
+	flags.Var(&o.KubeconfigFlag, "kubeconfig", "path to kubeconfig file for this garden cluster")
 	flags.Var(&o.ContextFlag, "context", "override the current-context of the garden cluster kubeconfig")
-	flags.Var(&o.Alias, "alias", "unique alias of this Garden that can be used instead of the name to target this Garden")
+	flags.Var(&o.Alias, "alias", "unique alias of this garden that can be used instead of the name to target this garden")
 	flags.StringArrayVar(&o.Patterns, "pattern", nil, `define regex match patterns for this garden for custom input formats for targeting.
 Use named capturing groups to match target values.
 Supported capturing groups: project, namespace, shoot.

--- a/pkg/cmd/kubeconfig/kubeconfig.go
+++ b/pkg/cmd/kubeconfig/kubeconfig.go
@@ -39,10 +39,10 @@ gardenctl kubeconfig
 # Print the kubeconfig for the current target in json format
 gardenctl kubeconfig --output json
 
-# Print the Shoot cluster kubeconfig for my-shoot
+# Print the shoot cluster kubeconfig for my-shoot
 gardenctl kubeconfig --garden my-garden --project my-project --shoot my-shoot
 
-# Print the Garden cluster kubeconfig of my-garden. The namespace of the project my-project is set as default
+# Print the garden cluster kubeconfig of my-garden. The namespace of the project my-project is set as default
 gardenctl kubeconfig --garden my-garden --project my-project`,
 		RunE: base.WrapRunE(o, f),
 	}

--- a/pkg/cmd/providerenv/options.go
+++ b/pkg/cmd/providerenv/options.go
@@ -20,7 +20,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 
 	clientgarden "github.com/gardener/gardenctl-v2/internal/client/garden"
@@ -51,6 +50,8 @@ type options struct {
 	CmdPath string
 	// Target is the target used when executing the command
 	Target target.Target
+	// OriginalTarget is the target before resolving managed seeds and control planes.
+	OriginalTarget target.Target
 	// TargetFlags are the target override flags
 	TargetFlags target.TargetFlags
 	// Template is the script template
@@ -321,20 +322,24 @@ The URI is parsed and host and path are set accordingly. These are merged with d
 func (o *options) Run(f util.Factory) error {
 	ctx := f.Context()
 
-	logger := klog.FromContext(ctx)
-
 	manager, err := f.Manager()
 	if err != nil {
 		return err
 	}
 
-	o.Target, err = manager.CurrentTarget()
+	o.OriginalTarget, err = manager.CurrentTarget()
 	if err != nil {
 		return err
 	}
 
+	o.Target = o.OriginalTarget
+
 	if o.Target.GardenName() == "" {
 		return target.ErrNoGardenTargeted
+	}
+
+	if o.Target.ControlPlane() && o.Target.SeedName() != "" && o.Target.ShootName() == "" {
+		return fmt.Errorf("cannot use --control-plane with seed target %q", o.Target.SeedName())
 	}
 
 	client, err := manager.GardenClient(o.Target.GardenName())
@@ -342,34 +347,21 @@ func (o *options) Run(f util.Factory) error {
 		return fmt.Errorf("failed to create garden cluster client: %w", err)
 	}
 
-	if o.Target.ShootName() == "" && o.Target.SeedName() != "" {
-		shoot, err := client.GetShootOfManagedSeed(ctx, o.Target.SeedName())
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return fmt.Errorf("cannot generate cloud provider CLI configuration script for non-managed seeds: %w", err)
-			}
+	requiresAccessRestrictionConfirmation := o.TargetFlags != nil && (o.TargetFlags.ShootName() != "" || o.TargetFlags.ControlPlane())
 
-			return err
-		}
+	resolver := target.NewResolver(client)
 
-		logger.V(1).Info("using referred shoot of managed seed",
-			"shoot", klog.ObjectRef{
-				Namespace: "garden",
-				Name:      shoot.Name,
-			},
-			"seed", o.Target.SeedName())
-
-		o.Target = o.Target.WithProjectName("garden").WithShootName(shoot.Name)
-	}
-
-	if o.Target.ShootName() == "" {
-		return target.ErrNoShootTargeted
-	}
-
-	shoot, err := client.FindShoot(ctx, o.Target.AsListOption())
+	resolvedTarget, err := resolver.ResolveShootTarget(ctx, o.Target)
 	if err != nil {
 		return err
 	}
+
+	shoot, err := resolver.FindShoot(ctx, resolvedTarget)
+	if err != nil {
+		return err
+	}
+
+	o.Target = resolvedTarget
 
 	if (shoot.Spec.SecretBindingName == nil || *shoot.Spec.SecretBindingName == "") &&
 		(shoot.Spec.CredentialsBindingName == nil || *shoot.Spec.CredentialsBindingName == "") {
@@ -414,7 +406,7 @@ func (o *options) Run(f util.Factory) error {
 		return err
 	}
 
-	aborted, err := maybeAbortDueToAccessRestrictions(o, messages)
+	aborted, err := maybeAbortDueToAccessRestrictions(o, messages, requiresAccessRestrictionConfirmation)
 	if err != nil {
 		return err
 	}
@@ -610,7 +602,7 @@ func generateMetadata(o *options, cli string, credentialKind string) map[string]
 	metadata["unset"] = o.Unset
 	metadata["commandPath"] = o.CmdPath
 	metadata["cli"] = cli
-	metadata["targetFlags"] = getTargetFlags(o.Target)
+	metadata["targetFlags"] = getTargetFlags(o.originalTarget())
 	metadata["credentialKind"] = credentialKind
 
 	if o.Shell != "" {
@@ -619,6 +611,14 @@ func generateMetadata(o *options, cli string, credentialKind string) map[string]
 	}
 
 	return metadata
+}
+
+func (o *options) originalTarget() target.Target {
+	if o.OriginalTarget != nil {
+		return o.OriginalTarget
+	}
+
+	return o.Target
 }
 
 func getProviderCLI(providerType string) string {
@@ -635,22 +635,30 @@ func getProviderCLI(providerType string) string {
 }
 
 func getTargetFlags(t target.Target) string {
+	var targetFlags string
+
 	if t.ProjectName() != "" {
-		return fmt.Sprintf("--garden %s --project %s --shoot %s", t.GardenName(), t.ProjectName(), t.ShootName())
+		targetFlags = fmt.Sprintf("--garden %s --project %s --shoot %s", t.GardenName(), t.ProjectName(), t.ShootName())
+	} else {
+		targetFlags = fmt.Sprintf("--garden %s --seed %s --shoot %s", t.GardenName(), t.SeedName(), t.ShootName())
 	}
 
-	return fmt.Sprintf("--garden %s --seed %s --shoot %s", t.GardenName(), t.SeedName(), t.ShootName())
+	if t.ControlPlane() {
+		targetFlags += " --control-plane"
+	}
+
+	return targetFlags
 }
 
 // maybeAbortDueToAccessRestrictions processes access restriction messages and updates metadata or outputs
 // a confirmation prompt. It returns (aborted=true) when it has already written output and the caller
 // should stop further processing. When no messages or when only metadata is updated, it returns aborted=false.
-func maybeAbortDueToAccessRestrictions(o *options, messages ac.AccessRestrictionMessages) (bool, error) {
+func maybeAbortDueToAccessRestrictions(o *options, messages ac.AccessRestrictionMessages, requiresConfirmation bool) (bool, error) {
 	if len(messages) == 0 {
 		return false, nil
 	}
 
-	if o.TargetFlags.ShootName() == "" || o.ConfirmAccessRestriction {
+	if !requiresConfirmation || o.ConfirmAccessRestriction {
 		return false, nil
 	}
 
@@ -661,13 +669,14 @@ func maybeAbortDueToAccessRestrictions(o *options, messages ac.AccessRestriction
 	}
 
 	s := env.Shell(o.Shell)
+	confirmCommand := fmt.Sprintf("%s %s --confirm-access-restriction %s", o.CmdPath, getTargetFlags(o.originalTarget()), o.Shell)
 
 	if err := o.Template.ExecuteTemplate(o.IOStreams.Out, "printf", map[string]interface{}{
 		"format": messages.String() + "\n%s %s\n%s\n",
 		"arguments": []string{
 			"The cloud provider CLI configuration script can only be generated if you confirm the access despite the existing restrictions.",
 			"Use the --confirm-access-restriction flag to confirm the access.",
-			s.Prompt(runtime.GOOS) + s.EvalCommand(fmt.Sprintf("%s --confirm-access-restriction %s", o.CmdPath, o.Shell)),
+			s.Prompt(runtime.GOOS) + s.EvalCommand(confirmCommand),
 		},
 	}); err != nil {
 		return false, err

--- a/pkg/cmd/providerenv/options_test.go
+++ b/pkg/cmd/providerenv/options_test.go
@@ -26,6 +26,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	corev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardensecurityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -33,6 +34,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -40,6 +42,7 @@ import (
 	clientgarden "github.com/gardener/gardenctl-v2/internal/client/garden"
 	gardenclientmocks "github.com/gardener/gardenctl-v2/internal/client/garden/mocks"
 	utilmocks "github.com/gardener/gardenctl-v2/internal/util/mocks"
+	"github.com/gardener/gardenctl-v2/pkg/ac"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/providerenv"
 	"github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/env"
@@ -434,6 +437,228 @@ var _ = Describe("Env Commands - Options", func() {
 				})
 			})
 
+			Context("when the control plane is targeted", func() {
+				var (
+					currentTarget              target.Target
+					seedName                   string
+					seedShootName              string
+					seedRegion                 string
+					seedCredentialsBinding     *gardensecurityv1alpha1.CredentialsBinding
+					seedCredentialsBindingName string
+					seedSecretRef              *corev1.SecretReference
+					seedSecret                 *corev1.Secret
+					seedCloudProfileRef        *gardencorev1beta1.CloudProfileReference
+					seedCloudProfile           *clientgarden.CloudProfileUnion
+					seedShoot                  *gardencorev1beta1.Shoot
+				)
+
+				BeforeEach(func() {
+					factory.EXPECT().Manager().Return(manager, nil).Times(2)
+					manager.EXPECT().GardenClient(t.GardenName()).Return(client, nil)
+
+					factory.EXPECT().TargetFlags().Return(tf)
+					factory.EXPECT().GardenHomeDir().Return(gardenHomeDir)
+					manager.EXPECT().SessionDir().Return(sessionDir)
+					manager.EXPECT().Configuration().Return(cfg)
+					factory.EXPECT().GetSessionID().Return("test-session-id", nil)
+					Expect(options.Complete(factory, mockCmd, nil)).To(Succeed())
+
+					seedName = "seed"
+					seedShootName = "seed-shoot"
+					seedRegion = "seed-region"
+					seedCredentialsBindingName = "seed-credentials-binding"
+					currentTarget = t.WithSeedName("").WithControlPlane(true)
+					seedSecretRef = &corev1.SecretReference{
+						Namespace: "seed-private",
+						Name:      "seed-secret",
+					}
+					seedCloudProfileRef = &gardencorev1beta1.CloudProfileReference{
+						Kind: corev1beta1constants.CloudProfileReferenceKindCloudProfile,
+						Name: "seed-cloud-profile",
+					}
+				})
+
+				JustBeforeEach(func() {
+					shoot.Spec.SeedName = &seedName
+
+					seedShoot = &gardencorev1beta1.Shoot{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      seedShootName,
+							Namespace: corev1beta1constants.GardenNamespace,
+							UID:       "00000000-0000-0000-0000-000000000001",
+						},
+						Spec: gardencorev1beta1.ShootSpec{
+							CloudProfile:           seedCloudProfileRef,
+							Region:                 seedRegion,
+							CredentialsBindingName: &seedCredentialsBindingName,
+							Provider:               *provider.DeepCopy(),
+						},
+					}
+					seedCredentialsBinding = &gardensecurityv1alpha1.CredentialsBinding{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      seedCredentialsBindingName,
+							Namespace: seedShoot.Namespace,
+							UID:       "00000000-0000-0000-0000-000000000001",
+						},
+						CredentialsRef: corev1.ObjectReference{
+							Kind:       "Secret",
+							APIVersion: corev1.SchemeGroupVersion.String(),
+							Namespace:  seedSecretRef.Namespace,
+							Name:       seedSecretRef.Name,
+						},
+					}
+					seedSecret = &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: seedSecretRef.Namespace,
+							Name:      seedSecretRef.Name,
+							UID:       "00000000-0000-0000-0000-000000000001",
+						},
+						Data: map[string][]byte{
+							"serviceaccount.json": []byte(`{"type":"service_account","project_id":"seed-project-12345","client_email":"seed-service-account@seed-project-12345.iam.gserviceaccount.com"}`),
+						},
+					}
+					seedCloudProfile = &clientgarden.CloudProfileUnion{
+						CloudProfile: &gardencorev1beta1.CloudProfile{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: seedCloudProfileRef.Name,
+								UID:  "00000000-0000-0000-0000-000000000001",
+							},
+							Spec: gardencorev1beta1.CloudProfileSpec{
+								Type: provider.Type,
+								ProviderConfig: &runtime.RawExtension{
+									Object: providerConfig,
+									Raw:    nil,
+								},
+							},
+						},
+					}
+				})
+
+				It("uses the managed seed shoot credentials for a control-plane target", func() {
+					manager.EXPECT().CurrentTarget().Return(currentTarget, nil)
+					client.EXPECT().FindShoot(ctx, currentTarget.AsListOption()).Return(shoot, nil)
+					client.EXPECT().GetShootOfManagedSeed(ctx, seedName).Return(&seedmanagementv1alpha1.Shoot{Name: seedShootName}, nil)
+					client.EXPECT().FindShoot(ctx, clientgarden.ProjectFilter{
+						"metadata.name": seedShootName,
+						"project":       corev1beta1constants.GardenNamespace,
+					}).Return(seedShoot, nil)
+					client.EXPECT().GetCredentialsBinding(ctx, seedShoot.Namespace, seedCredentialsBindingName).Return(seedCredentialsBinding, nil)
+					client.EXPECT().GetCloudProfile(ctx, *seedShoot.Spec.CloudProfile, seedShoot.Namespace).Return(seedCloudProfile, nil)
+					manager.EXPECT().Configuration().Return(cfg)
+					client.EXPECT().GetSecret(ctx, seedSecretRef.Namespace, seedSecretRef.Name).Return(seedSecret, nil)
+
+					Expect(options.Run(factory)).To(Succeed())
+
+					hash := computeTestHash("test-session-id", t.GardenName(), seedShoot.Namespace, seedShoot.Name)
+					expected := strings.NewReplacer(
+						"PLACEHOLDER_CONFIG_DIR", filepath.Join(sessionDir, ".config", "gcloud"),
+						"PLACEHOLDER_SESSION_DIR", sessionDir,
+						"PLACEHOLDER_HASH", hash,
+					).Replace(readTestFile("gcp/export.bash"))
+					expected = strings.Replace(expected, "--project project --shoot shoot -u bash", "--project project --shoot shoot --control-plane -u bash", 1)
+					Expect(options.String()).To(Equal(expected))
+
+					projectID, err := os.ReadFile(filepath.Join(sessionDir, "provider-env", "."+hash+"-project_id.txt"))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(projectID)).To(Equal("seed-project-12345"))
+				})
+
+				It("requires confirmation for access restrictions on the managed seed shoot", func() {
+					options.TargetFlags = target.NewTargetFlags("", "", "", "", true)
+					cfg.Gardens[0].AccessRestrictions = []ac.AccessRestriction{
+						{
+							Key: "controlled-access",
+							Msg: "Shoot access is restricted",
+							Options: []ac.AccessRestrictionOption{
+								{
+									Key:      "support",
+									NotifyIf: true,
+									Msg:      "Support access must be confirmed",
+								},
+							},
+						},
+					}
+					seedShoot.Spec.AccessRestrictions = []gardencorev1beta1.AccessRestrictionWithOptions{
+						{
+							AccessRestriction: gardencorev1beta1.AccessRestriction{
+								Name: "controlled-access",
+							},
+							Options: map[string]string{
+								"support": "true",
+							},
+						},
+					}
+
+					manager.EXPECT().CurrentTarget().Return(currentTarget, nil)
+					client.EXPECT().FindShoot(ctx, currentTarget.AsListOption()).Return(shoot, nil)
+					client.EXPECT().GetShootOfManagedSeed(ctx, seedName).Return(&seedmanagementv1alpha1.Shoot{Name: seedShootName}, nil)
+					client.EXPECT().FindShoot(ctx, clientgarden.ProjectFilter{
+						"metadata.name": seedShootName,
+						"project":       corev1beta1constants.GardenNamespace,
+					}).Return(seedShoot, nil)
+					client.EXPECT().GetCredentialsBinding(ctx, seedShoot.Namespace, seedCredentialsBindingName).Return(seedCredentialsBinding, nil)
+					client.EXPECT().GetCloudProfile(ctx, *seedShoot.Spec.CloudProfile, seedShoot.Namespace).Return(seedCloudProfile, nil)
+					manager.EXPECT().Configuration().Return(cfg)
+
+					Expect(options.Run(factory)).To(Succeed())
+					Expect(options.String()).To(ContainSubstring("Shoot access is restricted"))
+					Expect(options.String()).To(ContainSubstring("Support access must be confirmed"))
+					Expect(options.String()).To(ContainSubstring("gardenctl provider-env --garden test --project project --shoot shoot --control-plane --confirm-access-restriction bash"))
+				})
+
+				It("does not require confirmation again when the control plane was already targeted", func() {
+					cfg.Gardens[0].AccessRestrictions = []ac.AccessRestriction{
+						{
+							Key: "controlled-access",
+							Msg: "Shoot access is restricted",
+							Options: []ac.AccessRestrictionOption{
+								{
+									Key:      "support",
+									NotifyIf: true,
+									Msg:      "Support access must be confirmed",
+								},
+							},
+						},
+					}
+					seedShoot.Spec.AccessRestrictions = []gardencorev1beta1.AccessRestrictionWithOptions{
+						{
+							AccessRestriction: gardencorev1beta1.AccessRestriction{
+								Name: "controlled-access",
+							},
+							Options: map[string]string{
+								"support": "true",
+							},
+						},
+					}
+
+					manager.EXPECT().CurrentTarget().Return(currentTarget, nil)
+					client.EXPECT().FindShoot(ctx, currentTarget.AsListOption()).Return(shoot, nil)
+					client.EXPECT().GetShootOfManagedSeed(ctx, seedName).Return(&seedmanagementv1alpha1.Shoot{Name: seedShootName}, nil)
+					client.EXPECT().FindShoot(ctx, clientgarden.ProjectFilter{
+						"metadata.name": seedShootName,
+						"project":       corev1beta1constants.GardenNamespace,
+					}).Return(seedShoot, nil)
+					client.EXPECT().GetCredentialsBinding(ctx, seedShoot.Namespace, seedCredentialsBindingName).Return(seedCredentialsBinding, nil)
+					client.EXPECT().GetCloudProfile(ctx, *seedShoot.Spec.CloudProfile, seedShoot.Namespace).Return(seedCloudProfile, nil)
+					manager.EXPECT().Configuration().Return(cfg)
+					client.EXPECT().GetSecret(ctx, seedSecretRef.Namespace, seedSecretRef.Name).Return(seedSecret, nil)
+
+					Expect(options.Run(factory)).To(Succeed())
+					Expect(options.String()).To(ContainSubstring("Shoot access is restricted"))
+					Expect(options.String()).To(ContainSubstring("Support access must be confirmed"))
+					Expect(options.String()).NotTo(ContainSubstring("--confirm-access-restriction"))
+				})
+
+				It("fails clearly when the shoot's seed is not managed", func() {
+					manager.EXPECT().CurrentTarget().Return(currentTarget, nil)
+					client.EXPECT().FindShoot(ctx, currentTarget.AsListOption()).Return(shoot, nil)
+					client.EXPECT().GetShootOfManagedSeed(ctx, seedName).Return(nil, apierrors.NewNotFound(seedmanagementv1alpha1.Resource("managedseed"), seedName))
+
+					err := options.Run(factory)
+					Expect(err).To(MatchError(ContainSubstring(`seed "seed" is not a managed seed`)))
+				})
+			})
+
 			Context("when an error occurs before running the command", func() {
 				err := errors.New("error")
 
@@ -460,6 +685,12 @@ var _ = Describe("Env Commands - Options", func() {
 					manager.EXPECT().CurrentTarget().Return(t.WithSeedName(""), nil)
 					manager.EXPECT().GardenClient(t.GardenName()).Return(nil, err)
 					Expect(options.Run(factory)).To(MatchError("failed to create garden cluster client: error"))
+				})
+
+				It("should fail when control-plane is requested for a seed target", func() {
+					factory.EXPECT().Manager().Return(manager, nil)
+					manager.EXPECT().CurrentTarget().Return(target.NewTarget(t.GardenName(), "", t.SeedName(), "").WithControlPlane(true), nil)
+					Expect(options.Run(factory)).To(MatchError(`cannot use --control-plane with seed target "seed"`))
 				})
 
 				Context("and the error occurs with the GardenClient instance", func() {

--- a/pkg/cmd/providerenv/providerenv.go
+++ b/pkg/cmd/providerenv/providerenv.go
@@ -35,6 +35,10 @@ func NewCmdProviderEnv(f util.Factory, ioStreams util.IOStreams) *cobra.Command 
 See each sub-command's help for details on how to use the generated script.
 
 The generated script sets the environment variables for the cloud provider CLI of the targeted shoot.
+When targeting a shoot control plane, the generated script configures the provider CLI for the seed
+infrastructure account that hosts that control plane.
+Only managed seeds are supported, because gardenctl needs the backing shoot to resolve the seed
+infrastructure credentials.
 In addition, the Azure CLI requires to sign in with a service principal and the gcloud CLI requires to activate a service-account.
 Thereby the configuration location of the corresponding cloud provider CLI is pointed to a temporary folder in the
 session directory, so that the standard configuration files in the user's home folder are not affected.
@@ -77,12 +81,15 @@ Alternatively, you can use the --openstack-allowed-patterns or --openstack-allow
 	o.Options.AddFlags(cmdFlags)
 
 	for _, s := range env.ValidShells() {
+		currentTargetCommand := s.Prompt(runtime.GOOS) + s.EvalCommand(fmt.Sprintf("gardenctl %s %s", cmd.Name(), s))
+		controlPlaneCommand := s.Prompt(runtime.GOOS) + s.EvalCommand(fmt.Sprintf("gardenctl %s %s --control-plane", cmd.Name(), s))
 		cmd.AddCommand(&cobra.Command{
 			Use:   string(s),
 			Short: fmt.Sprintf("Generate the cloud provider CLI configuration script for %s", s),
 			Long: fmt.Sprintf("Generate the cloud provider CLI configuration script for %s.\n\n"+
-				"To load the cloud provider CLI configuration script in your current shell session:\n%s\n",
-				s, s.Prompt(runtime.GOOS)+s.EvalCommand(fmt.Sprintf("gardenctl %s %s", cmd.Name(), s)),
+				"To configure the provider CLI for the currently targeted shoot:\n%s\n\n"+
+				"To configure the provider CLI for the seed infrastructure account hosting the shoot control plane:\n%s\n",
+				s, currentTargetCommand, controlPlaneCommand,
 			),
 			RunE: runE,
 		})

--- a/pkg/cmd/rc/rc_test.go
+++ b/pkg/cmd/rc/rc_test.go
@@ -74,6 +74,7 @@ alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
 alias gk='eval "$(gardenctl kubectl-env bash)"'
 alias gp='eval "$(gardenctl provider-env bash)"'
+alias gpc='eval "$(gardenctl provider-env --control-plane bash)"'
 alias gcv='gardenctl config view'
 source <(gardenctl completion bash)
 complete -o default -F __start_gardenctl g
@@ -94,6 +95,7 @@ alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
 alias gk='eval "$(gardenctl kubectl-env zsh)"'
 alias gp='eval "$(gardenctl provider-env zsh)"'
+alias gpc='eval "$(gardenctl provider-env --control-plane zsh)"'
 alias gcv='gardenctl config view'
 if (( $+commands[gardenctl] )); then
   if [ -d "$ZSH_CACHE_DIR/completions" ] && (($fpath[(Ie)$ZSH_CACHE_DIR/completions])); then
@@ -126,6 +128,7 @@ alias gtc='gardenctl target control-plane'
 alias gtc-='gardenctl target unset control-plane'
 alias gk='eval (gardenctl kubectl-env fish)'
 alias gp='eval (gardenctl provider-env fish)'
+alias gpc='eval (gardenctl provider-env --control-plane fish)'
 alias gcv='gardenctl config view'
 gardenctl completion fish | source
 complete -c g -w gardenctl
@@ -161,6 +164,10 @@ function Gardenctl-ProviderEnv {
   gardenctl provider-env powershell | Out-String | Invoke-Expression
 }
 Set-Alias -Name gp -Value Gardenctl-ProviderEnv -Option AllScope -Force
+function Gardenctl-ProviderEnv-ControlPlane {
+  gardenctl provider-env --control-plane powershell | Out-String | Invoke-Expression
+}
+Set-Alias -Name gpc -Value Gardenctl-ProviderEnv-ControlPlane -Option AllScope -Force
 function Gardenctl-Config-View {
   gardenctl config view
 }

--- a/pkg/cmd/resolve/options.go
+++ b/pkg/cmd/resolve/options.go
@@ -7,15 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package resolve
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/spf13/cobra"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	clientgarden "github.com/gardener/gardenctl-v2/internal/client/garden"
 	"github.com/gardener/gardenctl-v2/internal/util"
@@ -202,7 +198,9 @@ func (o *options) Run(f util.Factory) error {
 		return o.PrintObject(resolvedTarget)
 	}
 
-	shoot, err := findShoot(ctx, o.GardenClient, o.CurrentTarget)
+	resolver := target.NewResolver(o.GardenClient)
+
+	shoot, err := resolver.ResolveShoot(ctx, o.CurrentTarget)
 	if err != nil {
 		if errors.Is(err, target.ErrNoShootTargeted) {
 			switch o.Kind {
@@ -216,19 +214,16 @@ func (o *options) Run(f util.Factory) error {
 		return err
 	}
 
+	if shoot.Spec.SeedName == nil || *shoot.Spec.SeedName == "" {
+		return fmt.Errorf("no seed assigned to shoot %s/%s", shoot.Namespace, shoot.Name)
+	}
+
 	if o.Kind == KindSeed {
 		resolvedTarget.Seed = &Seed{
 			Name: *shoot.Spec.SeedName,
 		}
 
 		return o.PrintObject(resolvedTarget)
-	}
-
-	if o.CurrentTarget.ControlPlane() {
-		shoot, err = findShoot(ctx, o.GardenClient, o.CurrentTarget.WithSeedName("").WithProjectName("garden").WithShootName(*shoot.Spec.SeedName).WithControlPlane(false))
-		if err != nil {
-			return err
-		}
 	}
 
 	resolvedTarget.Seed = &Seed{
@@ -263,48 +258,4 @@ func (o *options) Run(f util.Factory) error {
 	}
 
 	return o.PrintObject(resolvedTarget)
-}
-
-func findShoot(ctx context.Context, gardenclient clientgarden.Client, t target.Target) (*gardencorev1beta1.Shoot, error) {
-	opt, err := shootListOption(ctx, gardenclient, t)
-	if err != nil {
-		return nil, err
-	}
-
-	shoot, err := gardenclient.FindShoot(ctx, opt)
-	if err != nil {
-		return nil, err
-	}
-
-	if shoot.Spec.SeedName == nil {
-		return nil, fmt.Errorf("no seed assigned to shoot %s/%s", shoot.Namespace, shoot.Name)
-	}
-
-	return shoot, nil
-}
-
-// shootListOption returns the list options for the shoot.
-// If no shoot or seed (that is a managed seed) was targeted, target.ErrNoShootTargeted is returned.
-func shootListOption(ctx context.Context, gardenClient clientgarden.Client, t target.Target) (client.ListOption, error) {
-	if t.ShootName() != "" {
-		return t.AsListOption(), nil
-	}
-
-	if t.SeedName() != "" {
-		shootOfManagedSeed, err := gardenClient.GetShootOfManagedSeed(ctx, t.SeedName())
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return nil, fmt.Errorf("%s is not a managed seed: %w", t.SeedName(), err)
-			}
-
-			return nil, err
-		}
-
-		return clientgarden.ProjectFilter{
-			"metadata.name": shootOfManagedSeed.Name,
-			"project":       "garden",
-		}, nil
-	}
-
-	return nil, target.ErrNoShootTargeted
 }

--- a/pkg/cmd/resolve/options_test.go
+++ b/pkg/cmd/resolve/options_test.go
@@ -436,6 +436,7 @@ shoot:
 					shoot2Target := target.NewTarget(gardenName, "garden", "", seedName).WithControlPlane(true)
 
 					gardenClient.EXPECT().FindShoot(ctx, t.AsListOption()).Return(shoot, nil)
+					gardenClient.EXPECT().GetShootOfManagedSeed(ctx, seedName).Return(&seedmanagementv1alpha1.Shoot{Name: shoot2.Name}, nil)
 					gardenClient.EXPECT().FindShoot(ctx, shoot2Target.AsListOption()).Return(shoot2, nil)
 					gardenClient.EXPECT().GetProjectByNamespace(ctx, "garden").Return(projectGarden, nil)
 
@@ -467,7 +468,7 @@ shoot:
 
 				gardenClient.EXPECT().GetShootOfManagedSeed(ctx, "seed").Return(nil, apierrors.NewNotFound(seedmanagementv1alpha1.Resource("managedseed"), "my-seed"))
 
-				Expect(o.Run(factory)).To(MatchError(MatchRegexp("^seed is not a managed seed")))
+				Expect(o.Run(factory)).To(MatchError(MatchRegexp(`^seed "seed" is not a managed seed`)))
 			})
 		})
 	})

--- a/pkg/cmd/ssh/connect_information.go
+++ b/pkg/cmd/ssh/connect_information.go
@@ -19,12 +19,12 @@ import (
 )
 
 // ConnectInformation holds connect information required to establish an SSH connection
-// to Shoot worker nodes.
+// to shoot worker nodes.
 type ConnectInformation struct {
 	// Bastion holds information about the bastion host used to connect to the worker nodes.
 	Bastion Bastion `json:"bastion"`
 
-	// NodeHostname is the name of the Shoot cluster node that the user wants to connect to.
+	// NodeHostname is the name of the shoot cluster node that the user wants to connect to.
 	NodeHostname string `json:"nodeHostname,omitempty"`
 
 	// NodePrivateKeyFiles is a list of file paths containing the private SSH keys for the worker nodes.
@@ -33,7 +33,7 @@ type ConnectInformation struct {
 	// Nodes is a list of Node objects containing information about the worker nodes.
 	Nodes []Node `json:"nodes"`
 
-	// User is the name of the Shoot cluster node ssh login username
+	// User is the name of the shoot cluster node ssh login username
 	User string `json:"user,omitempty"`
 
 	// Shell is the shell to use for escaping arguments (bash, zsh, fish, powershell)

--- a/pkg/cmd/ssh/export_test.go
+++ b/pkg/cmd/ssh/export_test.go
@@ -11,9 +11,12 @@ import (
 	"os"
 	"time"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/config"
+	"github.com/gardener/gardenctl-v2/pkg/target"
 )
 
 func SetBastionAvailabilityChecker(f func(hostname string, port string, privateKey []byte, hostKeyCallback ssh.HostKeyCallback) error) {
@@ -61,6 +64,11 @@ var (
 	ValidateSSHPublicKey  = validateSSHPublicKey
 	ValidateHost          = validateHost
 )
+
+// CheckAccessRestrictions exposes the unexported checkAccessRestrictions method for tests.
+func (o *SSHOptions) CheckAccessRestrictions(cfg *config.Config, gardenName string, tf target.TargetFlags, shoot *gardencorev1beta1.Shoot) (bool, error) {
+	return o.checkAccessRestrictions(cfg, gardenName, tf, shoot)
+}
 
 type TestArguments struct {
 	arguments

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -688,40 +688,22 @@ func (o *SSHOptions) Run(f util.Factory) error {
 		return err
 	}
 
-	if currentTarget.ShootName() == "" && currentTarget.SeedName() != "" {
-		shoot, err := gardenClient.GetShootOfManagedSeed(ctx, currentTarget.SeedName())
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return fmt.Errorf("cannot ssh to non-managed seeds: %w", err)
-			}
-
-			return err
-		}
-
-		logger.V(1).Info("using referred shoot of managed seed",
-			"shoot", klog.ObjectRef{
-				Namespace: "garden",
-				Name:      shoot.Name,
-			},
-			"seed", currentTarget.SeedName())
-
-		currentTarget = currentTarget.WithProjectName("garden").WithShootName(shoot.Name)
-	}
-
-	if currentTarget.ShootName() == "" {
-		return target.ErrNoShootTargeted
-	}
-
-	printTargetInformation(logger, currentTarget)
-
-	// fetch targeted shoot (ctx is cancellable to stop the keep alive goroutine later)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	shoot, err := gardenClient.FindShoot(ctx, currentTarget.AsListOption())
+	resolver := target.NewResolver(gardenClient)
+
+	currentTarget, err = resolver.ResolveShootTarget(ctx, currentTarget)
 	if err != nil {
 		return err
 	}
+
+	shoot, err := resolver.FindShoot(ctx, currentTarget)
+	if err != nil {
+		return err
+	}
+
+	printTargetInformation(logger, currentTarget)
 
 	// check access restrictions
 	ok, err := o.checkAccessRestrictions(manager.Configuration(), currentTarget.GardenName(), f.TargetFlags(), shoot)

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -63,7 +63,7 @@ import (
 const (
 	// SSHBastionUsername is the system username on the bastion host.
 	SSHBastionUsername = "gardener"
-	// DefaultUsername is the default Shoot cluster node ssh login username.
+	// DefaultUsername is the default shoot cluster node ssh login username.
 	DefaultUsername = "gardener"
 	// SSHPort is the TCP port on a bastion instance that allows incoming SSH.
 	SSHPort = 22
@@ -218,12 +218,12 @@ type SSHOptions struct {
 	// NodeStrictHostKeyChecking controls the SSH strict host key checking behavior for the shoot node.
 	NodeStrictHostKeyChecking StrictHostKeyChecking
 
-	// NodeName is the name of the Shoot cluster node that the user wants to
+	// NodeName is the name of the shoot cluster node that the user wants to
 	// connect to. If this is left empty, gardenctl will only establish the
 	// connection to the bastion host and leave it up to the user to SSH to the node themselves.
 	NodeName string
 
-	// User is the name of the Shoot cluster node ssh login username
+	// User is the name of the shoot cluster node ssh login username
 	User string
 
 	// Shell is the shell to use for escaping arguments (bash, zsh, fish, powershell)
@@ -313,7 +313,7 @@ func (o *SSHOptions) AddFlags(flagSet *pflag.FlagSet) {
 	flagSet.StringSliceVar(&o.NodeUserKnownHostsFiles, "node-user-known-hosts-file", o.NodeUserKnownHostsFiles, "Path to a custom known hosts file for verifying remote hosts' public keys during SSH connection to the shoot node. If not provided, defaults to <garden_home_dir>/cache/<shoot_uid>/.ssh/known_hosts.")
 	flagSet.Var(&o.NodeStrictHostKeyChecking, "node-strict-host-key-checking", "Specifies how the SSH client performs host key checking for the shoot node. Valid options are 'yes', 'no', or 'ask'.")
 	flagSet.BoolVarP(&o.ConfirmAccessRestriction, "confirm-access-restriction", "y", o.ConfirmAccessRestriction, "Bypasses the need for confirmation of any access restrictions. Set this flag only if you are fully aware of the access restrictions.")
-	flagSet.StringVar(&o.User, "user", o.User, "user is the name of the Shoot cluster node ssh login username.")
+	flagSet.StringVar(&o.User, "user", o.User, "user is the name of the shoot cluster node ssh login username.")
 	flagSet.StringVar(&o.Shell, "shell", o.Shell, "Shell to use for escaping arguments when printing out the SSH command. If not provided, it defaults to the GCTL_SHELL environment variable or bash.")
 	o.Options.AddFlags(flagSet)
 }
@@ -1067,7 +1067,7 @@ func getNodeNamesFromMachinesOrNodes(ctx context.Context, manager target.Manager
 	}
 
 	if currentTarget.ShootName() == "" {
-		return nil, errors.New("no Shoot cluster targeted")
+		return nil, errors.New("no shoot cluster targeted")
 	}
 
 	nodeNames, err := getNodeNamesFromMachines(ctx, manager, currentTarget)

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -1455,7 +1455,7 @@ func (o *SSHOptions) checkAccessRestrictions(cfg *config.Config, gardenName stri
 		return false, err
 	}
 
-	askForConfirmation := tf.ShootName() != "" && !o.ConfirmAccessRestriction
+	askForConfirmation := (tf.ShootName() != "" || tf.ControlPlane()) && !o.ConfirmAccessRestriction
 	handler := ac.NewAccessRestrictionHandler(o.IOStreams.In, o.IOStreams.ErrOut, askForConfirmation) // do not write access restriction to stdout, otherwise it would break the output format
 
 	return handler(ac.CheckAccessRestrictions(garden.AccessRestrictions, shoot)), nil

--- a/pkg/cmd/ssh/ssh.go
+++ b/pkg/cmd/ssh/ssh.go
@@ -21,20 +21,20 @@ import (
 func NewCmdSSH(f util.Factory, o *SSHOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ssh [NODE_NAME]",
-		Short: "Establish an SSH connection to a node of a Shoot cluster",
-		Long: `Establish an SSH connection to a node of a Shoot cluster by specifying its name.
+		Short: "Establish an SSH connection to a node of a shoot cluster",
+		Long: `Establish an SSH connection to a node of a shoot cluster by specifying its name.
 
 A bastion is created to access the node and is automatically cleaned up afterwards.
 
-If a node name is not provided, gardenctl will display the hostnames/IPs of the Shoot worker nodes and the corresponding SSH command.
+If a node name is not provided, gardenctl will display the hostnames/IPs of the shoot worker nodes and the corresponding SSH command.
 To connect to a desired node, copy the printed SSH command, replace the target hostname accordingly, and execute the command.`,
-		Example: `# Establish an SSH connection to a specific Shoot cluster node
+		Example: `# Establish an SSH connection to a specific shoot cluster node
 gardenctl ssh my-shoot-node-1
 
 # Establish an SSH connection with custom CIDRs to allow access to the bastion host
 gardenctl ssh my-shoot-node-1 --cidr 10.1.2.3/32
 
-# Establish an SSH connection to any Shoot cluster node
+# Establish an SSH connection to any shoot cluster node
 # Copy the printed SSH command, replace the 'IP_OR_HOSTNAME' placeholder for the target hostname/IP, and execute the command to connect to the desired node
 gardenctl ssh
 

--- a/pkg/cmd/ssh/ssh.go
+++ b/pkg/cmd/ssh/ssh.go
@@ -26,10 +26,18 @@ func NewCmdSSH(f util.Factory, o *SSHOptions) *cobra.Command {
 
 A bastion is created to access the node and is automatically cleaned up afterwards.
 
+When targeting a shoot control plane, gardenctl connects to nodes of the seed shoot that hosts the
+targeted shoot's control plane.
+Only managed seeds are supported, because gardenctl needs the backing shoot to create the bastion
+and determine its worker nodes.
+
 If a node name is not provided, gardenctl will display the hostnames/IPs of the shoot worker nodes and the corresponding SSH command.
 To connect to a desired node, copy the printed SSH command, replace the target hostname accordingly, and execute the command.`,
 		Example: `# Establish an SSH connection to a specific shoot cluster node
 gardenctl ssh my-shoot-node-1
+
+# Establish an SSH connection to a node of the seed shoot hosting a shoot control plane
+gardenctl ssh my-seed-node-1 --garden my-garden --project my-project --shoot my-shoot --control-plane
 
 # Establish an SSH connection with custom CIDRs to allow access to the bastion host
 gardenctl ssh my-shoot-node-1 --cidr 10.1.2.3/32

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -27,6 +27,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	corev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/golang/mock/gomock"
@@ -89,6 +90,47 @@ func waitForBastionThenSetBastionReady(ctx context.Context, gardenClient client.
 	})
 }
 
+func newShootSSHKeypairSecret(shootName, namespace string) *corev1.Secret {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	privateKeyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	})
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s.ssh-keypair", shootName),
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			secrets.DataKeyRSAPrivateKey: privateKeyPEM,
+		},
+	}
+}
+
+func newShootCAConfigMap(shootName, namespace string) *corev1.ConfigMap {
+	csc := &secrets.CertificateSecretConfig{
+		Name:       "ca-test",
+		CommonName: "ca-test",
+		CertType:   secrets.CACert,
+	}
+	ca, err := csc.GenerateCertificate()
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shootName + ".ca-cluster",
+			Namespace: namespace,
+			UID:       "00000000-0000-0000-0000-000000000000",
+		},
+		Data: map[string]string{
+			"ca.crt": string(ca.CertificatePEM),
+		},
+	}
+}
+
 var _ = Describe("SSH Command", func() {
 	const (
 		gardenName           = "mygarden"
@@ -100,32 +142,33 @@ var _ = Describe("SSH Command", func() {
 	)
 
 	var (
-		ctrl                 *gomock.Controller
-		clientProvider       *clientmocks.MockProvider
-		cfg                  *config.Config
-		streams              util.IOStreams
-		out                  *util.SafeBytesBuffer
-		factory              *internalfake.Factory
-		ctx                  context.Context
-		cancel               context.CancelFunc
-		ctxTimeout           context.Context
-		cancelTimeout        context.CancelFunc
-		currentTarget        target.Target
-		testProject          *gardencorev1beta1.Project
-		testSeed             *gardencorev1beta1.Seed
-		testShoot            *gardencorev1beta1.Shoot
-		testNode             *corev1.Node
-		testMachine          *machinev1alpha1.Machine
-		pendingMachine       *machinev1alpha1.Machine
-		seedKubeconfigSecret *corev1.Secret
-		gardenClient         client.Client
-		shootClient          client.Client
-		seedClient           client.Client
-		nodePrivateKeyFile   string
-		logs                 *util.SafeBytesBuffer
-		signalChan           chan os.Signal
-		gardenHomeDir        string
-		gardenTempDir        string
+		ctrl                            *gomock.Controller
+		clientProvider                  *clientmocks.MockProvider
+		cfg                             *config.Config
+		streams                         util.IOStreams
+		out                             *util.SafeBytesBuffer
+		factory                         *internalfake.Factory
+		ctx                             context.Context
+		cancel                          context.CancelFunc
+		ctxTimeout                      context.Context
+		cancelTimeout                   context.CancelFunc
+		currentTarget                   target.Target
+		testProject                     *gardencorev1beta1.Project
+		testSeed                        *gardencorev1beta1.Seed
+		testShoot                       *gardencorev1beta1.Shoot
+		testNode                        *corev1.Node
+		testMachine                     *machinev1alpha1.Machine
+		pendingMachine                  *machinev1alpha1.Machine
+		seedKubeconfigSecret            *corev1.Secret
+		expectedShootClientConfigTarget *gardencorev1beta1.Shoot
+		gardenClient                    client.Client
+		shootClient                     client.Client
+		seedClient                      client.Client
+		nodePrivateKeyFile              string
+		logs                            *util.SafeBytesBuffer
+		signalChan                      chan os.Signal
+		gardenHomeDir                   string
+		gardenTempDir                   string
 	)
 
 	BeforeEach(func() {
@@ -218,25 +261,7 @@ var _ = Describe("SSH Command", func() {
 			},
 		}
 
-		testShootKeypair := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s.ssh-keypair", testShoot.Name),
-				Namespace: *testProject.Spec.Namespace,
-				UID:       "00000000-0000-0000-0000-000000000000",
-			},
-		}
-
-		privateKey, err := rsa.GenerateKey(rand.Reader, 1024)
-		Expect(err).NotTo(HaveOccurred())
-
-		privateKeyPEM := pem.EncodeToMemory(&pem.Block{
-			Type:  "RSA PRIVATE KEY",
-			Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
-		})
-
-		testShootKeypair.Data = map[string][]byte{
-			secrets.DataKeyRSAPrivateKey: privateKeyPEM,
-		}
+		testShootKeypair := newShootSSHKeypairSecret(testShoot.Name, *testProject.Spec.Namespace)
 
 		testSeedKubeconfig, err := internalfake.NewConfigData("test-seed")
 		Expect(err).ToNot(HaveOccurred())
@@ -252,24 +277,7 @@ var _ = Describe("SSH Command", func() {
 			},
 		}
 
-		csc := &secrets.CertificateSecretConfig{
-			Name:       "ca-test",
-			CommonName: "ca-test",
-			CertType:   secrets.CACert,
-		}
-		ca, err := csc.GenerateCertificate()
-		Expect(err).NotTo(HaveOccurred())
-
-		caConfigMap := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      testShoot.Name + ".ca-cluster",
-				Namespace: testShoot.Namespace,
-				UID:       "00000000-0000-0000-0000-000000000000",
-			},
-			Data: map[string]string{
-				"ca.crt": string(ca.CertificatePEM),
-			},
-		}
+		caConfigMap := newShootCAConfigMap(testShoot.Name, testShoot.Namespace)
 
 		gardenClient = internalfake.Wrap(
 			fakeclient.NewClientBuilder().
@@ -329,6 +337,7 @@ var _ = Describe("SSH Command", func() {
 		clientProvider.EXPECT().FromClientConfig(gomock.Eq(clientConfig)).Return(gardenClient, nil).AnyTimes()
 
 		currentTarget = target.NewTarget(gardenName, testProject.Name, "", testShoot.Name)
+		expectedShootClientConfigTarget = testShoot
 		targetProvider := internalfake.NewFakeTargetProvider(currentTarget)
 
 		factory = internalfake.NewFakeFactory(cfg, nil, clientProvider, targetProvider)
@@ -370,7 +379,8 @@ var _ = Describe("SSH Command", func() {
 				Do(func(clientConfig clientcmd.ClientConfig) {
 					config, err := clientConfig.RawConfig()
 					Expect(err).NotTo(HaveOccurred())
-					Expect(config.CurrentContext).To(Equal(testShoot.Namespace + "--" + testShoot.Name + "-" + testShoot.Status.AdvertisedAddresses[0].Name))
+					Expect(expectedShootClientConfigTarget).NotTo(BeNil())
+					Expect(config.CurrentContext).To(Equal(expectedShootClientConfigTarget.Namespace + "--" + expectedShootClientConfigTarget.Name + "-" + expectedShootClientConfigTarget.Status.AdvertisedAddresses[0].Name))
 				})
 		})
 
@@ -487,6 +497,125 @@ var _ = Describe("SSH Command", func() {
 
 			_, err = os.Stat(options.SSHPrivateKeyFile.String())
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("should connect to a node of the backing shoot when control-plane target flags select a shoot control plane", func() {
+			gardenProject := &gardencorev1beta1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: corev1beta1constants.GardenNamespace,
+					UID:  "00000000-0000-0000-0000-000000000001",
+				},
+				Spec: gardencorev1beta1.ProjectSpec{
+					Namespace: ptr.To(corev1beta1constants.GardenNamespace),
+				},
+			}
+			seedShoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "seed-shoot",
+					Namespace: corev1beta1constants.GardenNamespace,
+					UID:       "00000000-0000-0000-0000-000000000002",
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					SeedName: ptr.To("infrastructure-seed"),
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						Version: "1.20.0",
+					},
+					Provider: gardencorev1beta1.Provider{
+						WorkersSettings: &gardencorev1beta1.WorkersSettings{
+							SSHAccess: &gardencorev1beta1.SSHAccess{
+								Enabled: true,
+							},
+						},
+					},
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{
+						{
+							Name: "external",
+							URL:  "https://api.seed-shoot.invalid",
+						},
+					},
+					TechnicalID: "shoot--garden--seed-shoot",
+				},
+			}
+			managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testSeed.Name,
+					Namespace: corev1beta1constants.GardenNamespace,
+					UID:       "00000000-0000-0000-0000-000000000003",
+				},
+				Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+					Shoot: &seedmanagementv1alpha1.Shoot{
+						Name: seedShoot.Name,
+					},
+				},
+			}
+
+			Expect(gardenClient.Create(ctx, gardenProject)).To(Succeed())
+			Expect(gardenClient.Create(ctx, seedShoot)).To(Succeed())
+			Expect(gardenClient.Create(ctx, managedSeed)).To(Succeed())
+			Expect(gardenClient.Create(ctx, newShootSSHKeypairSecret(seedShoot.Name, seedShoot.Namespace))).To(Succeed())
+			Expect(gardenClient.Create(ctx, newShootCAConfigMap(seedShoot.Name, seedShoot.Namespace))).To(Succeed())
+
+			factory.TargetFlagsImpl = target.NewTargetFlags("", "", "", "", false)
+			factory.TargetProviderImpl = target.NewTargetProvider(filepath.Join(gardenTempDir, "target"), factory.TargetFlagsImpl)
+			expectedShootClientConfigTarget = seedShoot
+
+			options := ssh.NewSSHOptions(streams)
+			cmd := ssh.NewCmdSSH(factory, options)
+			Expect(cmd.Flags().Set("garden", gardenName)).To(Succeed())
+			Expect(cmd.Flags().Set("project", testProject.Name)).To(Succeed())
+			Expect(cmd.Flags().Set("shoot", testShoot.Name)).To(Succeed())
+			Expect(cmd.Flags().Set("control-plane", "true")).To(Succeed())
+
+			go waitForBastionThenSetBastionReady(ctx, gardenClient, bastionName, seedShoot.Namespace, bastionHostname, bastionIP)
+
+			bastionKey := client.ObjectKey{Name: bastionName, Namespace: seedShoot.Namespace}
+			executedCommands := 0
+
+			ssh.SetExecSSHCommand(func(ctx context.Context, args []string, ioStreams util.IOStreams) error {
+				defer func() {
+					signalChan <- os.Interrupt
+				}()
+
+				executedCommands++
+
+				bastion := &operationsv1alpha1.Bastion{}
+				Expect(gardenClient.Get(ctx, bastionKey, bastion)).To(Succeed())
+				Expect(bastion.Spec.ShootRef.Name).To(Equal(seedShoot.Name))
+
+				bastionUID := string(bastion.UID)
+				shootUID := string(seedShoot.UID)
+
+				defaultBastionKnownHostsFile := filepath.Join(gardenTempDir, "cache", bastionUID, ".ssh", "known_hosts")
+				defaultNodeKnownHostsFile := filepath.Join(gardenHomeDir, "cache", shootUID, ".ssh", "known_hosts")
+
+				Expect(args).To(Equal([]string{
+					"-oIdentitiesOnly=yes",
+					"-oStrictHostKeyChecking=ask",
+					fmt.Sprintf("-oUserKnownHostsFile='%s'", defaultNodeKnownHostsFile),
+					fmt.Sprintf("-i%s", nodePrivateKeyFile),
+					fmt.Sprintf(
+						"-oProxyCommand=ssh '-W[%%h]:%%p' -oStrictHostKeyChecking=ask -oIdentitiesOnly=yes '-i%s' '-oUserKnownHostsFile='\"'\"'%s'\"'\"'' '%s@%s' '-p22'",
+						options.SSHPrivateKeyFile,
+						defaultBastionKnownHostsFile,
+						ssh.SSHBastionUsername,
+						bastionIP,
+					),
+					fmt.Sprintf("%s@%s", options.User, nodeHostname),
+				}))
+
+				return nil
+			})
+
+			Expect(cmd.RunE(cmd, []string{testNode.Name})).To(Succeed())
+
+			Expect(executedCommands).To(Equal(1))
+			Expect(logs.String()).To(ContainSubstring("Preparing SSH access"))
+			Expect(logs.String()).To(ContainSubstring("garden/seed-shoot"))
+
+			bastion := &operationsv1alpha1.Bastion{}
+			Expect(gardenClient.Get(ctx, bastionKey, bastion)).NotTo(Succeed())
 		})
 
 		It("should connect to a given node that has not yet joined the cluster", func() {

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -49,6 +49,7 @@ import (
 	clientmocks "github.com/gardener/gardenctl-v2/internal/client/mocks"
 	internalfake "github.com/gardener/gardenctl-v2/internal/fake"
 	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/ac"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/ssh"
 	"github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/target"
@@ -1530,5 +1531,106 @@ var _ = Describe("SSH Options", func() {
 				Expect(ssh.ValidateSSHPublicKey(ecPublicKeyFile)).To(Succeed())
 			})
 		})
+	})
+})
+
+var _ = Describe("SSH Options checkAccessRestrictions", func() {
+	const gardenName = "test-garden"
+
+	var (
+		cfg   *config.Config
+		shoot *gardencorev1beta1.Shoot
+	)
+
+	BeforeEach(func() {
+		cfg = &config.Config{
+			Gardens: []config.Garden{
+				{
+					Name: gardenName,
+					AccessRestrictions: []ac.AccessRestriction{
+						{
+							Key: "controlled-access",
+							Msg: "Shoot access is restricted",
+							Options: []ac.AccessRestrictionOption{
+								{
+									Key:      "support",
+									NotifyIf: true,
+									Msg:      "Support access must be confirmed",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shoot",
+				Namespace: "garden-project",
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				AccessRestrictions: []gardencorev1beta1.AccessRestrictionWithOptions{
+					{
+						AccessRestriction: gardencorev1beta1.AccessRestriction{
+							Name: "controlled-access",
+						},
+						Options: map[string]string{
+							"support": "true",
+						},
+					},
+				},
+			},
+		}
+	})
+
+	It("requires confirmation when --control-plane is set even if --shoot is not in target flags", func() {
+		// shoot is pre-targeted; user runs `gardenctl ssh --control-plane`.
+		// Scope flips to the backing shoot of the seed, so confirmation must be requested.
+		streams, in, _, _ := util.NewTestIOStreams()
+		_, _ = in.Write([]byte("\n")) // decline the prompt
+
+		options := ssh.NewSSHOptions(streams)
+		tf := target.NewTargetFlags("", "", "", "", true)
+
+		ok, err := options.CheckAccessRestrictions(cfg, gardenName, tf, shoot)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeFalse(), "user declined the prompt, so the run must abort")
+	})
+
+	It("proceeds without prompting when --confirm-access-restriction is set with --control-plane", func() {
+		streams, _, _, _ := util.NewTestIOStreams()
+
+		options := ssh.NewSSHOptions(streams)
+		options.ConfirmAccessRestriction = true
+		tf := target.NewTargetFlags("", "", "", "", true)
+
+		ok, err := options.CheckAccessRestrictions(cfg, gardenName, tf, shoot)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+	})
+
+	It("does not prompt when neither --shoot nor --control-plane is in target flags", func() {
+		// Already-targeted shoot scope without the user changing it: no fresh confirmation needed.
+		streams, _, _, _ := util.NewTestIOStreams()
+
+		options := ssh.NewSSHOptions(streams)
+		tf := target.NewTargetFlags("", "", "", "", false)
+
+		ok, err := options.CheckAccessRestrictions(cfg, gardenName, tf, shoot)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
+	})
+
+	It("requires confirmation when --shoot is set in target flags", func() {
+		streams, in, _, _ := util.NewTestIOStreams()
+		_, _ = in.Write([]byte("y\n"))
+
+		options := ssh.NewSSHOptions(streams)
+		tf := target.NewTargetFlags("", "", "", "shoot", false)
+
+		ok, err := options.CheckAccessRestrictions(cfg, gardenName, tf, shoot)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ok).To(BeTrue())
 	})
 })

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -10,10 +10,12 @@ import (
 	"fmt"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -110,7 +112,9 @@ var _ = Describe("Target Command", func() {
 	JustBeforeEach(func() {
 		clientConfig, err := cfg.ClientConfig(gardenName)
 		Expect(err).ToNot(HaveOccurred())
-		clientProvider.EXPECT().FromClientConfig(gomock.Eq(clientConfig)).Return(gardenClient, nil).AnyTimes()
+		clientProvider.EXPECT().FromClientConfig(gomock.Eq(clientConfig)).DoAndReturn(func(_ clientcmd.ClientConfig) (client.Client, error) {
+			return gardenClient, nil
+		}).AnyTimes()
 	})
 
 	AfterEach(func() {
@@ -214,6 +218,56 @@ var _ = Describe("Target Command", func() {
 			Expect(currentTarget.ProjectName()).To(Equal(projectName))
 			Expect(currentTarget.SeedName()).To(BeEmpty())
 			Expect(currentTarget.ShootName()).To(Equal(shootName))
+			Expect(currentTarget.ControlPlane()).To(BeTrue())
+		})
+
+		It("should display access restrictions of the managed seed backing shoot when targeting a control plane", func() {
+			seedShootName := "seed-shoot"
+			gardenProject := &gardencorev1beta1.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+					UID:  "00000000-0000-0000-0000-000000000003",
+				},
+				Spec: gardencorev1beta1.ProjectSpec{
+					Namespace: ptr.To(namespace),
+				},
+			}
+			managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      seedName,
+					Namespace: namespace,
+					UID:       "00000000-0000-0000-0000-000000000001",
+				},
+				Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+					Shoot: &seedmanagementv1alpha1.Shoot{Name: seedShootName},
+				},
+			}
+			seedShoot := &gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      seedShootName,
+					Namespace: namespace,
+					UID:       "00000000-0000-0000-0000-000000000002",
+				},
+				Spec: gardencorev1beta1.ShootSpec{
+					AccessRestrictions: []gardencorev1beta1.AccessRestrictionWithOptions{
+						{
+							AccessRestriction: gardencorev1beta1.AccessRestriction{
+								Name: "a",
+							},
+						},
+					},
+				},
+			}
+			gardenClient = internalfake.NewClientWithObjects(project, gardenProject, seed, shoot, managedSeed, seedShoot)
+
+			targetProvider.Target = target.NewTarget(gardenName, projectName, "", shootName)
+			cmd := cmdtarget.NewCmdTargetControlPlane(factory, streams)
+
+			Expect(cmd.RunE(cmd, []string{})).To(Succeed())
+			Expect(out.String()).To(MatchRegexp(`(?s)Access strictly prohibited.*Successfully targeted control plane of shoot %q\n`, shootName))
+
+			currentTarget, err := targetProvider.Read()
+			Expect(err).NotTo(HaveOccurred())
 			Expect(currentTarget.ControlPlane()).To(BeTrue())
 		})
 

--- a/pkg/env/templates/rc.tmpl
+++ b/pkg/env/templates/rc.tmpl
@@ -9,6 +9,7 @@ alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval "$(gardenctl kubectl-env {{.shell}})"'
 alias {{.prefix}}p='eval "$(gardenctl provider-env {{.shell}})"'
+alias {{.prefix}}pc='eval "$(gardenctl provider-env --control-plane {{.shell}})"'
 alias {{.prefix}}cv='gardenctl config view'
 {{if not .noCompletion -}}
 source <(gardenctl completion {{.shell}})
@@ -30,6 +31,7 @@ alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval "$(gardenctl kubectl-env {{.shell}})"'
 alias {{.prefix}}p='eval "$(gardenctl provider-env {{.shell}})"'
+alias {{.prefix}}pc='eval "$(gardenctl provider-env --control-plane {{.shell}})"'
 alias {{.prefix}}cv='gardenctl config view'
 {{if not .noCompletion -}}
 if (( $+commands[gardenctl] )); then
@@ -63,6 +65,7 @@ alias {{.prefix}}tc='gardenctl target control-plane'
 alias {{.prefix}}tc-='gardenctl target unset control-plane'
 alias {{.prefix}}k='eval (gardenctl kubectl-env {{.shell}})'
 alias {{.prefix}}p='eval (gardenctl provider-env {{.shell}})'
+alias {{.prefix}}pc='eval (gardenctl provider-env --control-plane {{.shell}})'
 alias {{.prefix}}cv='gardenctl config view'
 {{if not .noCompletion -}}
 gardenctl completion {{.shell}} | source
@@ -99,6 +102,10 @@ function Gardenctl-ProviderEnv {
   gardenctl provider-env {{.shell}} | Out-String | Invoke-Expression
 }
 Set-Alias -Name {{.prefix}}p -Value Gardenctl-ProviderEnv -Option AllScope -Force
+function Gardenctl-ProviderEnv-ControlPlane {
+  gardenctl provider-env --control-plane {{.shell}} | Out-String | Invoke-Expression
+}
+Set-Alias -Name {{.prefix}}pc -Value Gardenctl-ProviderEnv-ControlPlane -Option AllScope -Force
 function Gardenctl-Config-View {
   gardenctl config view
 }

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -247,12 +248,12 @@ func (m *managerImpl) scopeForTarget(ctx context.Context, t Target) (AccessScope
 			return "", false, err
 		}
 
-		ns, err := resolveShootNamespace(ctx, c, t)
+		shootKey, err := resolveShootKey(ctx, c, t)
 		if err != nil {
 			return "", false, err
 		}
 
-		scope, err := scopeForShoot(ctx, c, ns, t.ShootName())
+		scope, err := scopeForShoot(ctx, c, shootKey.Namespace, shootKey.Name)
 
 		return scope, true, err
 	case t.SeedName() != "":
@@ -277,25 +278,30 @@ func scopeForShoot(ctx context.Context, c clientgarden.Client, namespace, shootN
 	return AccessScopeShoots, nil
 }
 
-// resolveShootNamespace returns the namespace of the shoot identified by t,
-// either from the Project status (when targeted by project) or by finding the
-// shoot cluster-wide.
-func resolveShootNamespace(ctx context.Context, c clientgarden.Client, t Target) (string, error) {
-	if t.ProjectName() != "" {
-		ns, err := getProjectNamespace(ctx, c, t.ProjectName())
+// resolveShootKey returns the namespace/name of the effective shoot identified
+// by t, either from the resolved target's project namespace or by finding the
+// shoot cluster-wide when no project is targeted.
+func resolveShootKey(ctx context.Context, c clientgarden.Client, t Target) (types.NamespacedName, error) {
+	resolvedTarget, err := NewResolver(c).ResolveShootTarget(ctx, t)
+	if err != nil {
+		return types.NamespacedName{}, err
+	}
+
+	if resolvedTarget.ProjectName() != "" {
+		namespace, err := getProjectNamespace(ctx, c, resolvedTarget.ProjectName())
 		if err != nil {
-			return "", err
+			return types.NamespacedName{}, err
 		}
 
-		return *ns, nil
+		return types.NamespacedName{Namespace: *namespace, Name: resolvedTarget.ShootName()}, nil
 	}
 
-	shoot, err := c.FindShoot(ctx, t.AsListOption())
+	shoot, err := c.FindShoot(ctx, resolvedTarget.AsListOption())
 	if err != nil {
-		return "", err
+		return types.NamespacedName{}, err
 	}
 
-	return shoot.Namespace, nil
+	return types.NamespacedName{Namespace: shoot.Namespace, Name: shoot.Name}, nil
 }
 
 // resolveAccessLevel returns the effective kubeconfig access level for a target+scope.
@@ -625,7 +631,7 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 			}
 
 			if shoot.Spec.SeedName == nil || *shoot.Spec.SeedName == "" {
-				return nil, fmt.Errorf("shoot %q has not yet been assigned to a seed", t.ShootName())
+				return nil, fmt.Errorf("no seed assigned to shoot %s/%s", shoot.Namespace, shoot.Name)
 			}
 
 			if shoot.Status.TechnicalID == "" {
@@ -643,19 +649,19 @@ func (m *managerImpl) ClientConfig(ctx context.Context, t Target) (clientcmd.Cli
 
 	if t.ShootName() != "" {
 		return m.getClientConfig(t, func(client clientgarden.Client) (clientcmd.ClientConfig, error) {
-			namespace, err := resolveShootNamespace(ctx, client, t)
+			shootKey, err := resolveShootKey(ctx, client, t)
 			if err != nil {
 				return nil, err
 			}
 
-			scope, err := scopeForShoot(ctx, client, namespace, t.ShootName())
+			scope, err := scopeForShoot(ctx, client, shootKey.Namespace, shootKey.Name)
 			if err != nil {
 				return nil, err
 			}
 
 			accessLevel := m.resolveAccessLevel(t, scope)
 
-			return client.GetShootClientConfig(ctx, namespace, t.ShootName(), accessLevel)
+			return client.GetShootClientConfig(ctx, shootKey.Namespace, shootKey.Name, accessLevel)
 		})
 	}
 
@@ -940,19 +946,6 @@ func writeRawConfig(config clientcmd.ClientConfig) ([]byte, error) {
 	}
 
 	return clientcmd.Write(rawConfig)
-}
-
-func getProjectNamespace(ctx context.Context, client clientgarden.Client, name string) (*string, error) {
-	project, err := client.GetProject(ctx, name)
-	if err != nil {
-		return nil, err
-	}
-
-	if project.Spec.Namespace == nil || *project.Spec.Namespace == "" {
-		return nil, fmt.Errorf("project %q has not yet been assigned to a namespace", name)
-	}
-
-	return project.Spec.Namespace, nil
 }
 
 func clientConfigWithNamespace(clientConfig clientcmd.ClientConfig, namespace string) (clientcmd.ClientConfig, error) {

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package target_test
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -26,6 +27,7 @@ import (
 	internalclient "github.com/gardener/gardenctl-v2/internal/client"
 	clientmocks "github.com/gardener/gardenctl-v2/internal/client/mocks"
 	"github.com/gardener/gardenctl-v2/internal/fake"
+	"github.com/gardener/gardenctl-v2/pkg/ac"
 	"github.com/gardener/gardenctl-v2/pkg/config"
 	"github.com/gardener/gardenctl-v2/pkg/target"
 )
@@ -403,12 +405,101 @@ var _ = Describe("Target Manager", func() {
 		})
 	})
 
+	prepareManagedSeedBackingShootWithAccessRestriction := func() {
+		cfg.Gardens[0].AccessRestrictions = []ac.AccessRestriction{
+			{
+				Key: "restricted-access",
+				Msg: "Shoot access is restricted",
+				Options: []ac.AccessRestrictionOption{
+					{
+						Key:      "support",
+						NotifyIf: true,
+						Msg:      "Support access must be confirmed",
+					},
+				},
+			},
+		}
+
+		gardenProject := &gardencorev1beta1.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: corev1beta1constants.GardenNamespace,
+				UID:  "00000000-0000-0000-0000-000000000001",
+			},
+			Spec: gardencorev1beta1.ProjectSpec{
+				Namespace: ptr.To(corev1beta1constants.GardenNamespace),
+			},
+		}
+		managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      seed.Name,
+				Namespace: corev1beta1constants.GardenNamespace,
+				UID:       "00000000-0000-0000-0000-000000000002",
+			},
+			Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+				Shoot: &seedmanagementv1alpha1.Shoot{Name: "seed-shoot"},
+			},
+		}
+		seedShoot := createTestShoot("seed-shoot", corev1beta1constants.GardenNamespace, nil)
+		seedShoot.Spec.AccessRestrictions = []gardencorev1beta1.AccessRestrictionWithOptions{
+			{
+				AccessRestriction: gardencorev1beta1.AccessRestriction{
+					Name: "restricted-access",
+				},
+				Options: map[string]string{
+					"support": "true",
+				},
+			},
+		}
+
+		Expect(gardenClient.Create(ctx, gardenProject)).To(Succeed())
+		Expect(gardenClient.Create(ctx, managedSeed)).To(Succeed())
+		Expect(gardenClient.Create(ctx, seedShoot)).To(Succeed())
+	}
+
 	It("should be able to target control plane for a shoot", func() {
 		t := target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name)
 		manager, targetProvider := createTestManager(t, cfg, clientProvider)
 
 		Expect(manager.TargetControlPlane(ctx)).To(Succeed())
 		assertTargetProvider(targetProvider, t.WithControlPlane(true))
+	})
+
+	It("should check access restrictions on the managed seed backing shoot when targeting a control plane", func() {
+		prepareManagedSeedBackingShootWithAccessRestriction()
+
+		t := target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
+
+		var handled ac.AccessRestrictionMessages
+
+		ctx := ac.WithAccessRestrictionHandler(ctx, func(messages ac.AccessRestrictionMessages) bool {
+			handled = messages
+			return true
+		})
+
+		Expect(manager.TargetControlPlane(ctx)).To(Succeed())
+		Expect(handled).To(Equal(ac.AccessRestrictionMessages{
+			{
+				Header: "Shoot access is restricted",
+				Items:  []string{"Support access must be confirmed"},
+			},
+		}))
+		assertTargetProvider(targetProvider, t.WithControlPlane(true))
+	})
+
+	It("should abort control plane targeting when managed seed backing shoot access restrictions are rejected", func() {
+		prepareManagedSeedBackingShootWithAccessRestriction()
+
+		t := target.NewTarget(gardenName, prod1Project.Name, "", prod1GoldenShoot.Name)
+		manager, targetProvider := createTestManager(t, cfg, clientProvider)
+		ctx := ac.WithAccessRestrictionHandler(ctx, func(ac.AccessRestrictionMessages) bool {
+			return false
+		})
+
+		err := manager.TargetControlPlane(ctx)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, target.ErrAborted)).To(BeTrue())
+		assertTargetProvider(targetProvider, t)
 	})
 
 	It("should fail to target control plane if shoot is not set", func() {
@@ -601,6 +692,20 @@ var _ = Describe("Target Manager", func() {
 			})
 
 			It("should return the client configuration", func() {
+				clientConfig, err := manager.ClientConfig(ctx, t)
+				Expect(err).NotTo(HaveOccurred())
+
+				currentContextName := prod1GoldenShoot.Namespace + "--" + prod1GoldenShoot.Name + "-" + prod1GoldenShoot.Status.AdvertisedAddresses[0].Name
+				assertClientConfig(clientConfig, currentContextName, "default")
+			})
+		})
+
+		Context("when shoot is targeted without a project", func() {
+			BeforeEach(func() {
+				t = target.NewTarget(gardenName, "", "", prod1GoldenShoot.Name)
+			})
+
+			It("should resolve the shoot and return the client configuration", func() {
 				clientConfig, err := manager.ClientConfig(ctx, t)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/target/resolve.go
+++ b/pkg/target/resolve.go
@@ -1,0 +1,110 @@
+/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package target
+
+import (
+	"context"
+	"fmt"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	corev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/klog/v2"
+
+	clientgarden "github.com/gardener/gardenctl-v2/internal/client/garden"
+)
+
+// Resolver resolves targets that require garden cluster lookups.
+type Resolver struct {
+	gardenClient clientgarden.Client
+}
+
+// NewResolver returns a resolver using the given garden client.
+func NewResolver(gardenClient clientgarden.Client) *Resolver {
+	return &Resolver{gardenClient: gardenClient}
+}
+
+// ResolveShootTarget resolves seed and control-plane targets to the underlying
+// shoot target. If neither case applies, it returns t when t already targets a shoot.
+func (r *Resolver) ResolveShootTarget(ctx context.Context, t Target) (Target, error) {
+	if t.ShootName() == "" && t.SeedName() != "" {
+		return r.resolveManagedSeedTarget(ctx, t, t.SeedName())
+	}
+
+	if t.ShootName() == "" {
+		return nil, ErrNoShootTargeted
+	}
+
+	if t.ControlPlane() {
+		workloadShoot, err := r.FindShoot(ctx, t.WithControlPlane(false))
+		if err != nil {
+			return nil, err
+		}
+
+		if workloadShoot.Spec.SeedName == nil || *workloadShoot.Spec.SeedName == "" {
+			return nil, fmt.Errorf("no seed assigned to shoot %s/%s", workloadShoot.Namespace, workloadShoot.Name)
+		}
+
+		return r.resolveManagedSeedTarget(ctx, t, *workloadShoot.Spec.SeedName)
+	}
+
+	return t, nil
+}
+
+// ResolveShoot resolves and returns the effective shoot targeted by t.
+func (r *Resolver) ResolveShoot(ctx context.Context, t Target) (*gardencorev1beta1.Shoot, error) {
+	resolvedTarget, err := r.ResolveShootTarget(ctx, t)
+	if err != nil {
+		return nil, err
+	}
+
+	shoot, err := r.FindShoot(ctx, resolvedTarget)
+	if err != nil {
+		return nil, err
+	}
+
+	return shoot, nil
+}
+
+// FindShoot returns the shoot identified by the given target.
+func (r *Resolver) FindShoot(ctx context.Context, t Target) (*gardencorev1beta1.Shoot, error) {
+	return r.gardenClient.FindShoot(ctx, t.AsListOption())
+}
+
+func (r *Resolver) resolveManagedSeedTarget(ctx context.Context, t Target, seedName string) (Target, error) {
+	shootOfManagedSeed, err := r.gardenClient.GetShootOfManagedSeed(ctx, seedName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("seed %q is not a managed seed: %w", seedName, err)
+		}
+
+		return nil, err
+	}
+
+	klog.FromContext(ctx).V(1).Info("resolved managed seed to referred shoot",
+		"seed", seedName,
+		"shoot", klog.KRef(corev1beta1constants.GardenNamespace, shootOfManagedSeed.Name))
+
+	return t.
+		WithProjectName(corev1beta1constants.GardenNamespace).
+		WithSeedName("").
+		WithShootName(shootOfManagedSeed.Name).
+		WithControlPlane(false), nil
+}
+
+func getProjectNamespace(ctx context.Context, client clientgarden.Client, name string) (*string, error) {
+	project, err := client.GetProject(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if project.Spec.Namespace == nil || *project.Spec.Namespace == "" {
+		return nil, fmt.Errorf("project %q has not yet been assigned to a namespace", name)
+	}
+
+	return project.Spec.Namespace, nil
+}

--- a/pkg/target/resolve_test.go
+++ b/pkg/target/resolve_test.go
@@ -1,0 +1,123 @@
+/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package target_test
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	corev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	clientgarden "github.com/gardener/gardenctl-v2/internal/client/garden"
+	"github.com/gardener/gardenctl-v2/internal/fake"
+	"github.com/gardener/gardenctl-v2/pkg/target"
+)
+
+var _ = Describe("Resolver", func() {
+	createTestProject := func(name, namespace string) *gardencorev1beta1.Project {
+		return &gardencorev1beta1.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+				UID:  "00000000-0000-0000-0000-000000000000",
+			},
+			Spec: gardencorev1beta1.ProjectSpec{
+				Namespace: ptr.To(namespace),
+			},
+		}
+	}
+
+	createTestManagedSeed := func(name, shootName string) *seedmanagementv1alpha1.ManagedSeed {
+		return &seedmanagementv1alpha1.ManagedSeed{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: corev1beta1constants.GardenNamespace,
+				UID:       "00000000-0000-0000-0000-000000000000",
+			},
+			Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+				Shoot: &seedmanagementv1alpha1.Shoot{
+					Name: shootName,
+				},
+			},
+		}
+	}
+
+	Describe("#ResolveShoot", func() {
+		It("fails when no shoot is targeted", func() {
+			resolver := target.NewResolver(clientgarden.NewClient(nil, fake.NewClientWithObjects(), gardenName))
+
+			shoot, err := resolver.ResolveShoot(ctx, target.NewTarget(gardenName, "prod", "", ""))
+
+			Expect(err).To(MatchError(target.ErrNoShootTargeted))
+			Expect(shoot).To(BeNil())
+		})
+
+		It("finds the shoot in the project namespace when a project is targeted", func() {
+			project := createTestProject("prod", "garden-prod")
+			shoot := createTestShoot("golden-shoot", *project.Spec.Namespace, nil)
+			resolver := target.NewResolver(clientgarden.NewClient(nil, fake.NewClientWithObjects(project, shoot), gardenName))
+
+			resolvedShoot, err := resolver.ResolveShoot(ctx, target.NewTarget(gardenName, project.Name, "", shoot.Name))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resolvedShoot.Namespace).To(Equal(shoot.Namespace))
+			Expect(resolvedShoot.Name).To(Equal(shoot.Name))
+		})
+
+		It("finds the shoot cluster-wide when no project is targeted", func() {
+			shoot := createTestShoot("golden-shoot", "garden-prod", nil)
+			resolver := target.NewResolver(clientgarden.NewClient(nil, fake.NewClientWithObjects(shoot), gardenName))
+
+			resolvedShoot, err := resolver.ResolveShoot(ctx, target.NewTarget(gardenName, "", "", shoot.Name))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resolvedShoot.Namespace).To(Equal(shoot.Namespace))
+			Expect(resolvedShoot.Name).To(Equal(shoot.Name))
+		})
+
+		It("resolves a managed seed target to its backing shoot", func() {
+			shoot := createTestShoot("seed-shoot", corev1beta1constants.GardenNamespace, nil)
+			managedSeed := createTestManagedSeed("seed", shoot.Name)
+			project := createTestProject(corev1beta1constants.GardenNamespace, corev1beta1constants.GardenNamespace)
+			resolver := target.NewResolver(clientgarden.NewClient(nil, fake.NewClientWithObjects(project, managedSeed, shoot), gardenName))
+
+			resolvedShoot, err := resolver.ResolveShoot(ctx, target.NewTarget(gardenName, "", "seed", ""))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resolvedShoot.Namespace).To(Equal(shoot.Namespace))
+			Expect(resolvedShoot.Name).To(Equal(shoot.Name))
+		})
+
+		It("resolves a control-plane target to the backing shoot of the hosting managed seed", func() {
+			project := createTestProject("prod", "garden-prod")
+			gardenProject := createTestProject(corev1beta1constants.GardenNamespace, corev1beta1constants.GardenNamespace)
+			workloadShoot := createTestShoot("workload-shoot", *project.Spec.Namespace, ptr.To("seed"))
+			seedShoot := createTestShoot("seed-shoot", corev1beta1constants.GardenNamespace, nil)
+			managedSeed := createTestManagedSeed("seed", seedShoot.Name)
+			resolver := target.NewResolver(clientgarden.NewClient(nil, fake.NewClientWithObjects(project, gardenProject, workloadShoot, managedSeed, seedShoot), gardenName))
+
+			resolvedShoot, err := resolver.ResolveShoot(ctx, target.NewTarget(gardenName, project.Name, "", workloadShoot.Name).WithControlPlane(true))
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resolvedShoot.Namespace).To(Equal(seedShoot.Namespace))
+			Expect(resolvedShoot.Name).To(Equal(seedShoot.Name))
+		})
+
+		It("fails clearly when a control-plane target's shoot has no seed assigned", func() {
+			project := createTestProject("prod", "garden-prod")
+			workloadShoot := createTestShoot("workload-shoot", *project.Spec.Namespace, nil)
+			resolver := target.NewResolver(clientgarden.NewClient(nil, fake.NewClientWithObjects(project, workloadShoot), gardenName))
+
+			shoot, err := resolver.ResolveShoot(ctx, target.NewTarget(gardenName, project.Name, "", workloadShoot.Name).WithControlPlane(true))
+
+			Expect(err).To(MatchError("no seed assigned to shoot garden-prod/workload-shoot"))
+			Expect(shoot).To(BeNil())
+		})
+	})
+})

--- a/pkg/target/target_builder.go
+++ b/pkg/target/target_builder.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	internalclient "github.com/gardener/gardenctl-v2/internal/client"
 	clientgarden "github.com/gardener/gardenctl-v2/internal/client/garden"
@@ -176,7 +177,7 @@ func (b *targetBuilderImpl) SetShoot(ctx context.Context, name string) TargetBui
 	return b
 }
 
-func (b *targetBuilderImpl) SetControlPlane(_ context.Context) TargetBuilder {
+func (b *targetBuilderImpl) SetControlPlane(ctx context.Context) TargetBuilder {
 	b.actions = append(b.actions, func(t *targetImpl) error {
 		if t.Garden == "" {
 			return ErrNoGardenTargeted
@@ -187,6 +188,10 @@ func (b *targetBuilderImpl) SetControlPlane(_ context.Context) TargetBuilder {
 		}
 
 		t.ControlPlaneFlag = true
+
+		if err := b.handleControlPlaneAccessRestrictions(ctx, t); err != nil {
+			return err
+		}
 
 		return nil
 	})
@@ -208,7 +213,7 @@ func (b *targetBuilderImpl) completeTargetForShoot(ctx context.Context, t *targe
 	if handler := ac.AccessRestrictionHandlerFromContext(ctx); handler != nil {
 		if garden, err := b.config.Garden(t.GardenName()); err == nil {
 			if !handler(ac.CheckAccessRestrictions(garden.AccessRestrictions, shoot)) {
-				return fmt.Errorf("%w", ErrAborted)
+				return ErrAborted
 			}
 		}
 	}
@@ -236,6 +241,42 @@ func (b *targetBuilderImpl) completeTargetForShoot(ctx context.Context, t *targe
 
 	t.Shoot = shoot.Name
 	t.ControlPlaneFlag = false
+
+	return nil
+}
+
+func (b *targetBuilderImpl) handleControlPlaneAccessRestrictions(ctx context.Context, t *targetImpl) error {
+	if !t.ControlPlane() {
+		return ErrNoControlPlaneTargeted
+	}
+
+	handler := ac.AccessRestrictionHandlerFromContext(ctx)
+	if handler == nil {
+		return nil
+	}
+
+	garden, err := b.config.Garden(t.GardenName())
+	if err != nil || len(garden.AccessRestrictions) == 0 {
+		return nil
+	}
+
+	gardenClient, err := b.getGardenClient(t.GardenName())
+	if err != nil {
+		return err
+	}
+
+	backingShoot, err := NewResolver(gardenClient).ResolveShoot(ctx, t)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if !handler(ac.CheckAccessRestrictions(garden.AccessRestrictions, backingShoot)) {
+		return ErrAborted
+	}
 
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area usability
/kind enhancement

**What this PR does / why we need it**:

`gardenctl provider-env` and `gardenctl ssh` now honour the `--control-plane` flag when targeting a shoot. If the targeted shoot is a managed seed, both commands operate on the seed's backing shoot — configuring the provider CLI or opening an SSH session against the seed infrastructure instead of the workload shoot. Only managed seeds are supported; non-managed seed targets are rejected with a clear error. Access restrictions are evaluated against the backing shoot. A new `gpc` rc alias exposes the shortcut for `provider-env --control-plane`. Shared shoot resolution is consolidated in a new `target.Resolver` used by `providerenv`, `ssh`, `resolve` and the target manager.

**Which issue(s) this PR fixes**:
Fixes #748

**Release note**:
```feature operator
`gardenctl provider-env` and `gardenctl ssh` now support `--control-plane` for shoot targets backed by a managed seed, operating on the seed infrastructure instead of the workload shoot. A new `gpc` alias is provided as a shortcut for `provider-env --control-plane`.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--control-plane` flag to configure provider environment for seed infrastructure accounts hosting shoot control planes.
  * Added convenient shell aliases (`gpc`) for control-plane provider environment access.
  * Enhanced SSH to support targeting and connecting through shoot control planes on managed seeds.

* **Bug Fixes**
  * Improved validation and error messages for seed and shoot targeting.

* **Documentation**
  * Updated help text and examples across gardenctl commands for clarity and consistency.

* **Tests**
  * Added comprehensive test coverage for control-plane functionality and managed seed scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->