### PR TITLE
ci: Enable automerge for gardener/gardener dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,7 @@
     ':semanticCommitsDisabled',
     'customManagers:githubActionsVersions',
     'github>gardener/ci-infra//config/renovate/group-gardener-updates.json5',
+    'github>gardener/ci-infra//config/renovate/automerge-with-tide.json5',
   ],
   labels: [
     'kind/enhancement',
@@ -13,6 +14,7 @@
     'gomodTidy',
   ],
   automergeStrategy: 'squash',
+  minimumReleaseAge: '3 days',
   customManagers: [
     {
       customType: 'regex',
@@ -38,8 +40,14 @@
   ],
   packageRules: [
     {
-      matchUpdateTypes: [
-        'patch',
+      matchDatasources: [
+        'go',
+      ],
+      matchPackageNames: [
+        'github.com/gardener/gardener',
+        'github.com/gardener/gardener/pkg/apis',
+        'github.com/gardener/gardener-extension-provider-openstack',
+        'github.com/gardener/machine-controller-manager',
       ],
       automerge: true,
     },
@@ -73,8 +81,6 @@
         'github.com/Masterminds/semver',
         'github.com/Masterminds/sprig/v3',
         'github.com/fatih/color',
-        'github.com/gardener/gardener-extension-provider-openstack',
-        'github.com/gardener/machine-controller-manager',
         'github.com/golang/mock',
         'github.com/google/uuid',
         'github.com/mitchellh/go-homedir',

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   prepare:
-    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
+    uses: gardener/cc-utils/.github/workflows/prepare.yaml@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     with:
       mode: ${{ inputs.mode }}
       version-commit-callback-action-path: ./.github/actions/prepare-release
@@ -45,9 +45,9 @@ jobs:
             runner: ubuntu-latest
     runs-on: ${{ matrix.args.runner }}
     steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
       - name: import-release-commit
-        uses: gardener/cc-utils/.github/actions/import-commit@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+        uses: gardener/cc-utils/.github/actions/import-commit@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         with:
           commit-objects-artefact: release-commit-objects
           after-import: rebase
@@ -66,7 +66,7 @@ jobs:
           GOARCH=${{ matrix.args.arch }} \
           out_file="/tmp/blobs.d/gardenctl-v2-${{ matrix.args.os }}-${{ matrix.args.arch }}${{ matrix.args.os == 'windows' && '.exe' || '' }}" \
             hack/build.sh
-      - uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+      - uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         with:
           blobs-directory: /tmp/blobs.d
           ocm-resources: |
@@ -125,9 +125,9 @@ jobs:
           - lint
           - go-test
     steps:
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
       - name: import-release-commit
-        uses: gardener/cc-utils/.github/actions/import-commit@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+        uses: gardener/cc-utils/.github/actions/import-commit@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         with:
           commit-objects-artefact: release-commit-objects
           after-import: rebase
@@ -135,7 +135,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache: ${{ inputs.mode != 'release' }}  # disable cache for release builds
-      - uses: gardener/cc-utils/.github/actions/setup-git-identity@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+      - uses: gardener/cc-utils/.github/actions/setup-git-identity@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         if: ${{ matrix.target == 'check-generate' }}
 
       - shell: bash
@@ -146,7 +146,7 @@ jobs:
           tar czf /tmp/blobs.d/logs.tar.gz -C/tmp/blobs.d logs.txt
       - name: add-reports-to-component-descriptor
         if: ${{ matrix.target == 'go-test' }}
-        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+        uses: gardener/cc-utils/.github/actions/export-ocm-fragments@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
         with:
           blobs-directory: /tmp/blobs.d
           ocm-resources: |
@@ -161,7 +161,7 @@ jobs:
                   - test
 
   verify-sast:
-    uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
+    uses: gardener/cc-utils/.github/workflows/sastlint-ocm.yaml@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     permissions:
       contents: read
     with:

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
 
   component-descriptor:
-    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
+    uses: gardener/cc-utils/.github/workflows/post-build.yaml@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
     permissions:

--- a/.github/workflows/pr-release-notes-validation.yaml
+++ b/.github/workflows/pr-release-notes-validation.yaml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate-release-notes:
-    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
+    uses: gardener/cc-utils/.github/workflows/validate-release-notes.yaml@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     permissions:
       pull-requests: read
     with:

--- a/.github/workflows/prepare-hotfix-branch.yaml
+++ b/.github/workflows/prepare-hotfix-branch.yaml
@@ -13,6 +13,6 @@ permissions:
 
 jobs:
   call-dashboard-workflow:
-    uses: gardener/dashboard/.github/workflows/prepare-hotfix-branch.yaml@master # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally tracks master as the trusted source for the latest hotfix preparation logic
+    uses: gardener/dashboard/.github/workflows/prepare-hotfix-branch.yaml@master # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org reusable workflow; intentionally tracks master as the trusted source for the latest hotfix preparation logic
     with:
       tag: ${{ inputs.tag }}

--- a/.github/workflows/publish-to-package-repositories.yaml
+++ b/.github/workflows/publish-to-package-repositories.yaml
@@ -66,7 +66,7 @@ jobs:
             chocolatey-packages
           permission-contents: write
 
-      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
+      - uses: gardener/cc-utils/.github/actions/trusted-checkout@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org action; intentionally allowed for now, planned to pin to a version in the future
       - name: export-version-from-input
         id: export-version
         if: ${{ inputs.version != '' && inputs.component-descriptor == '' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       mode: release
 
   release-to-github-and-bump:
-    uses: gardener/cc-utils/.github/workflows/release.yaml@v1 # zizmor: ignore[unpinned-uses] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
+    uses: gardener/cc-utils/.github/workflows/release.yaml@v1 # zizmor: ignore[unpinned-uses,ref-confusion] -- same-org reusable workflow; intentionally allowed for now, planned to pin to a version in the future
     needs:
       - build
     secrets:


### PR DESCRIPTION
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

- Extend Renovate config with `automerge-with-tide.json5` preset to enable tide-compatible automerging
- Add automerge rule for `gardener/gardener` (and subpath modules like `pkg/apis`) updates
- Also automerge `gardener-extension-provider-openstack` and `machine-controller-manager` updates
- Remove blanket patch automerge rule (was non-functional without tide preset, keeping it disabled intentionally for now)
- Add `minimumReleaseAge: 3 days` to avoid picking up releases before they've had time to surface issues

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other operator
NONE
```