### PR TITLE
fix(ssh): validate node address before use as hostname

### DIFF
--- a/pkg/cmd/ssh/export_test.go
+++ b/pkg/cmd/ssh/export_test.go
@@ -63,6 +63,7 @@ var (
 	ValidateSSHPrivateKey = validateSSHPrivateKey
 	ValidateSSHPublicKey  = validateSSHPublicKey
 	ValidateHost          = validateHost
+	GetNodeHostname       = getNodeHostname
 )
 
 // CheckAccessRestrictions exposes the unexported checkAccessRestrictions method for tests.

--- a/pkg/cmd/ssh/options.go
+++ b/pkg/cmd/ssh/options.go
@@ -1415,6 +1415,10 @@ func getNodeHostname(node *corev1.Node) (string, error) {
 	// as the shoot nodes, we prefer the internal IP/hostname.
 	for _, k := range []corev1.NodeAddressType{corev1.NodeInternalIP, corev1.NodeInternalDNS, corev1.NodeExternalIP, corev1.NodeExternalDNS} {
 		if addr := addresses[k]; addr != "" {
+			if err := validateHost(addr); err != nil {
+				return "", fmt.Errorf("invalid node %s address: %w", k, err)
+			}
+
 			return addr, nil
 		}
 	}

--- a/pkg/cmd/ssh/ssh_test.go
+++ b/pkg/cmd/ssh/ssh_test.go
@@ -1376,6 +1376,48 @@ var _ = Describe("SSH Options", func() {
 		)
 	})
 
+	Describe("GetNodeHostname", func() {
+		DescribeTable("should return a valid preferred node address",
+			func(addresses []corev1.NodeAddress, expectedHostname string) {
+				node := &corev1.Node{Status: corev1.NodeStatus{Addresses: addresses}}
+
+				hostname, err := ssh.GetNodeHostname(node)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(hostname).To(Equal(expectedHostname))
+			},
+			Entry("internal IP", []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "192.0.2.1"},
+				{Type: corev1.NodeInternalDNS, Address: "node.example.invalid"},
+			}, "192.0.2.1"),
+			Entry("internal DNS", []corev1.NodeAddress{
+				{Type: corev1.NodeInternalDNS, Address: "node.example.invalid"},
+			}, "node.example.invalid"),
+			Entry("IPv6", []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "2001:db8::1"},
+			}, "2001:db8::1"),
+		)
+
+		DescribeTable("should reject an invalid preferred node address",
+			func(addresses []corev1.NodeAddress) {
+				node := &corev1.Node{Status: corev1.NodeStatus{Addresses: addresses}}
+
+				_, err := ssh.GetNodeHostname(node)
+
+				Expect(err).To(MatchError(ContainSubstring("invalid node")))
+			},
+			Entry("shell metacharacters in internal IP", []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "192.0.2.1;injected"},
+			}),
+			Entry("shell metacharacters in internal DNS", []corev1.NodeAddress{
+				{Type: corev1.NodeInternalDNS, Address: "node.example.invalid;injected"},
+			}),
+			Entry("unspecified IP", []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "0.0.0.0"},
+			}),
+		)
+	})
+
 	Context("SSH key validation", Ordered, func() {
 		var (
 			privateKey       *rsa.PrivateKey


### PR DESCRIPTION
**How to categorize this PR?**
/area security
/kind bug

**What this PR does / why we need it**:

Validates node addresses through the existing `validateHost` function before using them as SSH hostnames in `getNodeHostname`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```bugfix user
The `gardenctl ssh` command now validates node addresses before use.
```