### PR TITLE
feat(target): support seed targeting via pattern capturing group

### DIFF
--- a/docs/help/gardenctl_config_set-garden.md
+++ b/docs/help/gardenctl_config_set-garden.md
@@ -24,7 +24,7 @@ CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonp
 gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
 
 # configure my-garden with a context and patterns
-gardenctl config set-garden my-garden --context garden-context --pattern "^(?:landscape-dev/)?shoot--(?P<project>.+)--(?P<shoot>.+)$" --pattern "https://dashboard\.gardener\.cloud/namespace/(?P<namespace>[^/]+)/shoots/(?P<shoot>[^/]+)"
+gardenctl config set-garden my-garden --context garden-context --pattern "^(?:landscape-dev/)?shoot--(?P<project>.+)--(?P<shoot>.+)$" --pattern "https://dashboard\.gardener\.cloud/namespace/(?P<namespace>[^/]+)/shoots/(?P<shoot>[^/]+)" --pattern "https://dashboard\.gardener\.cloud/seeds/(?P<seed>[^/]+)"
 
 # configure prd-garden so shoot kubeconfigs default to read-only viewer access (seed access stays at admin)
 gardenctl config set-garden prd-garden --default-shoot-access-level viewer
@@ -41,7 +41,7 @@ gardenctl config set-garden prd-garden --default-shoot-access-level viewer
       --kubeconfig string                   path to kubeconfig file for this garden cluster
       --pattern stringArray                 define regex match patterns for this garden for custom input formats for targeting.
                                             Use named capturing groups to match target values.
-                                            Supported capturing groups: project, namespace, shoot.
+                                            Supported capturing groups: project, namespace, shoot, seed.
                                             Note that if you set this flag it will overwrite the pattern list in the config file.
                                             You may specify any number of extra patterns.
 ```

--- a/docs/usage/targeting.md
+++ b/docs/usage/targeting.md
@@ -2,7 +2,7 @@
 You can set a target to use it in subsequent commands.
 
 The target has a hierarchical structure that looks like this:
-```
+```text
 garden
 ├── project 
 │   └── shoot
@@ -14,7 +14,7 @@ You can show the current target with `gardenctl target view`.
 ## Arguments
 
 Set the target by setting the values in sequence.
-```
+```bash
 # target garden
 gardenctl target garden landscape-dev
 
@@ -25,13 +25,13 @@ gardenctl target project my-project
 gardenctl target shoot my-shoot
 
 # target control plane of my-shoot
-#gardenctl target control-plane
+gardenctl target control-plane
 ```
 
 ## Flags
 
 You can also use target flags to modify the target. Using flags, you can set the target with one command.
-```
+```bash
 # target shoot
 gardenctl target --garden landscape-dev --project my-project --shoot my-shoot
 
@@ -53,19 +53,19 @@ target clusters with custom patterns. This allows you define individual patterns
 domains.
 
 For example, the following pattern allows you to target clusters using a dashboard domain:
-```
+```text
 https://dashboard\.gardener\.cloud/namespace/(?P<namespace>[^/]+)/shoots/(?P<shoot>[^/]+)
 ```
 The following command would then target the shoot `my-cluster` in the project with namespace `garden-my-project` for the garden where this pattern is defined in the configuration:
-```
+```bash
 gardenctl target https://dashboard.gardener.cloud/namespace/garden-my-project/shoots/my-cluster
 ```
 
 A seed can be targeted the same way with a `(?P<seed>...)` capturing group:
-```
+```text
 https://dashboard\.gardener\.cloud/seeds/(?P<seed>[^/]+)
 ```
-```
+```bash
 gardenctl target https://dashboard.gardener.cloud/seeds/seed-02
 ```
 

--- a/docs/usage/targeting.md
+++ b/docs/usage/targeting.md
@@ -52,13 +52,21 @@ You can define patterns for each garden in the `gardenctl` configuration. Each p
 target clusters with custom patterns. This allows you define individual patterns, e.g. to target clusters via
 domains.
 
-For example,the following pattern allows you to target clusters using a dashboard domain:
+For example, the following pattern allows you to target clusters using a dashboard domain:
 ```
 https://dashboard\.gardener\.cloud/namespace/(?P<namespace>[^/]+)/shoots/(?P<shoot>[^/]+)
 ```
 The following command would then target the shoot `my-cluster` in the project with namespace `garden-my-project` for the garden where this pattern is defined in the configuration:
 ```
 gardenctl target https://dashboard.gardener.cloud/namespace/garden-my-project/shoots/my-cluster
+```
+
+A seed can be targeted the same way with a `(?P<seed>...)` capturing group:
+```
+https://dashboard\.gardener\.cloud/seeds/(?P<seed>[^/]+)
+```
+```
+gardenctl target https://dashboard.gardener.cloud/seeds/seed-02
 ```
 
 If a target is not complete, e.g. if the project is missing, it may be completed automatically. However, this is only

--- a/pkg/cmd/config/set_garden.go
+++ b/pkg/cmd/config/set_garden.go
@@ -49,7 +49,7 @@ CLUSTER_IDENTITY=$(kubectl -n kube-system get configmap cluster-identity -ojsonp
 gardenctl config set-garden $CLUSTER_IDENTITY --kubeconfig $KUBECONFIG
 
 # configure my-garden with a context and patterns
-gardenctl config set-garden my-garden --context garden-context --pattern "^(?:landscape-dev/)?shoot--(?P<project>.+)--(?P<shoot>.+)$" --pattern "https://dashboard\.gardener\.cloud/namespace/(?P<namespace>[^/]+)/shoots/(?P<shoot>[^/]+)"
+gardenctl config set-garden my-garden --context garden-context --pattern "^(?:landscape-dev/)?shoot--(?P<project>.+)--(?P<shoot>.+)$" --pattern "https://dashboard\.gardener\.cloud/namespace/(?P<namespace>[^/]+)/shoots/(?P<shoot>[^/]+)" --pattern "https://dashboard\.gardener\.cloud/seeds/(?P<seed>[^/]+)"
 
 # configure prd-garden so shoot kubeconfigs default to read-only viewer access (seed access stays at admin)
 gardenctl config set-garden prd-garden --default-shoot-access-level viewer`,
@@ -81,7 +81,7 @@ type setGardenOptions struct {
 	ContextFlag flag.StringFlag
 	// Patterns is a list of regex patterns that can be defined to use custom input formats for targeting
 	// Use named capturing groups to match target values.
-	// Supported capturing groups: project, namespace, shoot
+	// Supported capturing groups: project, namespace, shoot, seed
 	// +optional
 	Patterns []string
 	// DefaultShootAccessLevelFlag sets kubeconfigAccessLevelDefaults.shoots in the
@@ -162,7 +162,7 @@ func (o *setGardenOptions) AddFlags(flags *pflag.FlagSet) {
 	flags.Var(&o.Alias, "alias", "unique alias of this garden that can be used instead of the name to target this garden")
 	flags.StringArrayVar(&o.Patterns, "pattern", nil, `define regex match patterns for this garden for custom input formats for targeting.
 Use named capturing groups to match target values.
-Supported capturing groups: project, namespace, shoot.
+Supported capturing groups: project, namespace, shoot, seed.
 Note that if you set this flag it will overwrite the pattern list in the config file.
 You may specify any number of extra patterns.`)
 	flags.Var(&o.DefaultShootAccessLevelFlag, FlagDefaultShootAccessLevel,
@@ -270,7 +270,7 @@ func validatePatterns(patterns []string) error {
 
 		names := re.SubexpNames()
 		for _, name := range names[1:] {
-			if name != "project" && name != "namespace" && name != "shoot" {
+			if !config.IsPatternKey(name) {
 				return fmt.Errorf("pattern[%d] contains an invalid subexpression %q", i, name)
 			}
 		}

--- a/pkg/cmd/config/set_garden_test.go
+++ b/pkg/cmd/config/set_garden_test.go
@@ -95,6 +95,7 @@ var _ = Describe("Config Subcommand SetGarden", func() {
 				Entry("when 1st pattern is empty", []string{""}, Succeed()),
 				Entry("when 1st pattern is empty and 2nd pattern is not empty", []string{"", "foo"}, MatchError("pattern[0] must not be empty")),
 				Entry("when all patterns are valid", []string{"^shoot--(?P<project>.+)--(?P<shoot>.+)$`"}, Succeed()),
+				Entry("when a pattern has a seed subexpression", []string{`^https://dashboard\.gardener\.cloud/seeds/(?P<seed>[^/]+)$`}, Succeed()),
 				Entry("when a pattern is not a valid regular expression", []string{"("}, MatchError(MatchRegexp(`^pattern\[0\] is not a valid regular expression`))),
 				Entry("when a pattern has an invalid subexpression name", []string{"^shoot--(?P<cluster>.+)$`"}, MatchError("pattern[0] contains an invalid subexpression \"cluster\"")),
 			)

--- a/pkg/cmd/target/target_test.go
+++ b/pkg/cmd/target/target_test.go
@@ -385,6 +385,24 @@ var _ = Describe("Target Command", func() {
 			Expect(currentTarget.ShootName()).To(Equal(shootName))
 		})
 
+		It("should be able to target a seed via a dashboard seed URL pattern", func() {
+			cfg.Gardens[0].Patterns = append(cfg.Gardens[0].Patterns,
+				`^https://dashboard\.gardener\.cloud/seeds/(?P<seed>[^/]+)$`,
+			)
+			cmd := cmdtarget.NewCmdTarget(factory, streams, new(config.KubeconfigAccessLevel))
+
+			url := fmt.Sprintf("https://dashboard.gardener.cloud/seeds/%s", seedName)
+			Expect(cmd.RunE(cmd, []string{url})).To(Succeed())
+			Expect(out.String()).To(ContainSubstring("Successfully targeted pattern %q\n", url))
+
+			currentTarget, err := targetProvider.Read()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(currentTarget.GardenName()).To(Equal(gardenName))
+			Expect(currentTarget.ProjectName()).To(BeEmpty())
+			Expect(currentTarget.SeedName()).To(Equal(seedName))
+			Expect(currentTarget.ShootName()).To(BeEmpty())
+		})
+
 		Context("when the shoot has access restrictions", func() {
 			BeforeEach(func() {
 				shoot.Spec.AccessRestrictions = []gardencorev1beta1.AccessRestrictionWithOptions{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -53,7 +53,7 @@ type Garden struct {
 	Context string `json:"context,omitempty"`
 	// Patterns is a list of regex patterns that can be defined to use custom input formats for targeting
 	// Use named capturing groups to match target values.
-	// Supported capturing groups: project, namespace, shoot
+	// Supported capturing groups: project, namespace, shoot, seed
 	// +optional
 	Patterns []string `json:"patterns,omitempty"`
 	// AccessRestrictions is a list of access restriction definitions
@@ -461,6 +461,8 @@ type PatternMatch struct {
 	Namespace string
 	// Shoot is the matched Shoot
 	Shoot string
+	// Seed is the matched Seed
+	Seed string
 }
 
 // PatternKey is a key that can be used to identify a value in a pattern.
@@ -473,7 +475,20 @@ const (
 	PatternKeyNamespace = PatternKey("namespace")
 	// PatternKeyShoot is used to identify a Shoot.
 	PatternKeyShoot = PatternKey("shoot")
+	// PatternKeySeed is used to identify a Seed.
+	PatternKeySeed = PatternKey("seed")
 )
+
+// IsPatternKey reports whether name is a supported named capturing group
+// for targeting patterns.
+func IsPatternKey(name string) bool {
+	switch PatternKey(name) {
+	case PatternKeyProject, PatternKeyNamespace, PatternKeyShoot, PatternKeySeed:
+		return true
+	default:
+		return false
+	}
+}
 
 // MatchPattern matches a string against patterns defined in gardenctl config.
 // If matched, the function creates and returns a PatternMatch from the provided target string.
@@ -547,6 +562,8 @@ func matchPattern(patterns []string, value string) (*PatternMatch, error) {
 				tm.Namespace = matches[i]
 			case PatternKeyShoot:
 				tm.Shoot = matches[i]
+			case PatternKeySeed:
+				tm.Seed = matches[i]
 			}
 		}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -74,6 +74,14 @@ var _ = Describe("Config", func() {
 		return value
 	}
 
+	It("should extract a seed from a dashboard seed URL pattern", func() {
+		cfg.Gardens[0].Patterns = []string{`^https://dashboard\.gardener\.cloud/seeds/(?P<seed>[^/]+)$`}
+
+		match, err := cfg.MatchPattern("", "https://dashboard.gardener.cloud/seeds/seed-02")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(match).To(Equal(&config.PatternMatch{Garden: clusterIdentity1, Seed: "seed-02"}))
+	})
+
 	DescribeTable("MatchPattern returns a match",
 		func(currentGardenName string, patternPrefix string, expectedGarden string) {
 			value := patternValue(patternPrefix)

--- a/pkg/target/manager.go
+++ b/pkg/target/manager.go
@@ -90,7 +90,7 @@ type Manager interface {
 	// UnsetTargetControlPlane unsets the control plane flag
 	UnsetTargetControlPlane(ctx context.Context) (Target, error)
 	// TargetMatchPattern replaces the whole target
-	// Garden, Project and Shoot values are determined by matching the provided value
+	// Garden, Project, Seed and Shoot values are determined by matching the provided value
 	// against patterns defined in gardenctl configuration. Some values may only match a subset
 	// of a pattern
 	TargetMatchPattern(ctx context.Context, tf TargetFlags, value string) (Target, error)
@@ -659,6 +659,7 @@ func (m *managerImpl) patternToFlags(ctx context.Context, tm *config.PatternMatc
 	return &targetFlagsImpl{
 		gardenName:   tm.Garden,
 		projectName:  projectName,
+		seedName:     tm.Seed,
 		shootName:    tm.Shoot,
 		controlPlane: NewBoolFlag(false),
 	}, nil

--- a/pkg/target/manager_test.go
+++ b/pkg/target/manager_test.go
@@ -438,6 +438,48 @@ var _ = Describe("Target Manager", func() {
 			assertTargetProvider(targetProvider, target.NewTarget(gardenName, "", "", ""))
 		})
 
+		It("should be able to target a seed by matching a dashboard seed URL pattern", func() {
+			cfg.Gardens[0].Patterns = append(cfg.Gardens[0].Patterns,
+				`^https://dashboard\.gardener\.cloud/seeds/(?P<seed>[^/]+)$`,
+			)
+
+			t := target.NewTarget("", "", "", "")
+			manager, targetProvider := createTestManager(t, cfg, clientProvider)
+
+			url := fmt.Sprintf("https://dashboard.gardener.cloud/seeds/%s", seed.Name)
+			_, err := manager.TargetMatchPattern(ctx, tf, url)
+			Expect(err).To(Succeed())
+			assertTargetProvider(targetProvider, target.NewTarget(gardenName, "", seed.Name, ""))
+		})
+
+		It("should not target anything if the seed from a pattern does not exist", func() {
+			cfg.Gardens[0].Patterns = append(cfg.Gardens[0].Patterns,
+				`^https://dashboard\.gardener\.cloud/seeds/(?P<seed>[^/]+)$`,
+			)
+
+			t := target.NewTarget(gardenName, "", "", "")
+			manager, targetProvider := createTestManager(t, cfg, clientProvider)
+
+			_, err := manager.TargetMatchPattern(ctx, tf, "https://dashboard.gardener.cloud/seeds/does-not-exist")
+			Expect(err).NotTo(Succeed())
+			assertTargetProvider(targetProvider, t)
+		})
+
+		It("should reject contradictions between --seed and a seed pattern", func() {
+			cfg.Gardens[0].Patterns = append(cfg.Gardens[0].Patterns,
+				`^https://dashboard\.gardener\.cloud/seeds/(?P<seed>[^/]+)$`,
+			)
+
+			t := target.NewTarget("", "", "", "")
+			manager, targetProvider := createTestManager(t, cfg, clientProvider)
+
+			tf := target.NewTargetFlags("", "", "other-seed", "", false)
+			url := fmt.Sprintf("https://dashboard.gardener.cloud/seeds/%s", seed.Name)
+			_, err := manager.TargetMatchPattern(ctx, tf, url)
+			Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("--seed=other-seed contradicts pattern (seed=%s)", seed.Name))))
+			assertTargetProvider(targetProvider, t)
+		})
+
 		It("should be able to target valid project by matching a pattern containing a namespace", func() {
 			t := target.NewTarget(gardenName, "", "", "")
 			manager, targetProvider := createTestManager(t, cfg, clientProvider)

--- a/pkg/target/target_provider.go
+++ b/pkg/target/target_provider.go
@@ -199,10 +199,10 @@ func combine(cliFlags TargetFlags, patternFlags TargetFlags, gardenNameForCompar
 		}
 	}
 
-	// Today's pattern keys are garden, project, namespace, shoot (see
-	// pkg/config/config.go PatternKey constants); seed and controlPlane can
-	// never be set by a pattern, so those checks are defensive and only fire
-	// if the pattern key set ever grows.
+	// Pattern keys are project, namespace, shoot, and seed (see pkg/config
+	// PatternKey). Garden identity comes from the garden that owns the matching
+	// pattern. controlPlane cannot be set by a pattern, so that check is
+	// defensive and only fires if the pattern key set ever grows.
 	addGardenConflict(cliFlags.GardenName(), patternFlags.GardenName())
 	addStringConflict("project", cliFlags.ProjectName(), patternFlags.ProjectName())
 	addStringConflict("seed", cliFlags.SeedName(), patternFlags.SeedName())


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area usability
/kind enhancement

**What this PR does / why we need it**:
Adds support for targeting seeds via a pattern capturing group in the garden config.

**Which issue(s) this PR fixes**:
Fixes #716

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Support seed targeting via a `seed` named capturing group in targeting patterns.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for targeting Gardener seeds through dashboard URL patterns.
  * Seed names can now be captured from URLs and included in the resulting target.
  * Added validation for seed targeting patterns and detection of invalid or conflicting seed selections.

* **Documentation**
  * Updated configuration and targeting guides with seed pattern examples and commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->