### PR TITLE
add logout command

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -25,6 +25,7 @@ import (
 	cmdconfig "github.com/gardener/gardenctl-v2/pkg/cmd/config"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/kubeconfig"
 	cmdkubectl "github.com/gardener/gardenctl-v2/pkg/cmd/kubectlenv"
+	cmdlogout "github.com/gardener/gardenctl-v2/pkg/cmd/logout"
 	cmdprovider "github.com/gardener/gardenctl-v2/pkg/cmd/providerenv"
 	cmdrc "github.com/gardener/gardenctl-v2/pkg/cmd/rc"
 	"github.com/gardener/gardenctl-v2/pkg/cmd/resolve"
@@ -136,6 +137,7 @@ Find more information at: https://github.com/gardener/gardenctl-v2/blob/master/R
 	cmd.AddCommand(cmdrc.NewCmdRC(f, ioStreams))
 	cmd.AddCommand(kubeconfigCmd)
 	cmd.AddCommand(resolve.NewCmdResolve(f, ioStreams))
+	cmd.AddCommand(cmdlogout.NewCmdLogout(f, ioStreams))
 
 	return cmd
 }

--- a/pkg/cmd/logout/export_test.go
+++ b/pkg/cmd/logout/export_test.go
@@ -1,0 +1,19 @@
+/*
+SPDX-FileCopyrightText: Contributors to the Gardener project
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logout
+
+// ParseExecArgs exposes parseExecArgs for testing.
+var ParseExecArgs = parseExecArgs
+
+// ReadIssuerFromCacheFile exposes readIssuerFromCacheFile for testing.
+var ReadIssuerFromCacheFile = readIssuerFromCacheFile
+
+// IssuerFromJWT exposes issuerFromJWT for testing.
+var IssuerFromJWT = issuerFromJWT
+
+// RemoveCachedTokens exposes removeCachedTokens for testing.
+var RemoveCachedTokens = removeCachedTokens

--- a/pkg/cmd/logout/logout.go
+++ b/pkg/cmd/logout/logout.go
@@ -1,0 +1,301 @@
+/*
+SPDX-FileCopyrightText: Contributors to the Gardener project
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logout
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+	"github.com/gardener/gardenctl-v2/pkg/cmd/base"
+	"github.com/gardener/gardenctl-v2/pkg/config"
+)
+
+const defaultOIDCCacheDir = "~/.kube/cache/oidc-login"
+
+// NewCmdLogout returns a new logout command.
+func NewCmdLogout(f util.Factory, ioStreams util.IOStreams) *cobra.Command {
+	o := newOptions(ioStreams)
+
+	cmd := &cobra.Command{
+		Use:   "logout",
+		Short: "Clear cached OIDC login tokens for garden cluster(s)",
+		Long: `Clear cached OIDC login tokens for one or all configured garden clusters.
+
+This command reads the exec plugin configuration from each garden cluster's
+kubeconfig, determines the OIDC token cache directory (defaulting to
+~/.kube/cache/oidc-login/), and removes cached token files whose issuer
+matches the garden's OIDC provider.
+
+Use this when your OIDC token has expired or is no longer refreshing and you
+need to force a fresh login on the next kubectl/gardenctl invocation.`,
+		Example: `# Clear cached OIDC tokens for all configured garden clusters
+gardenctl logout
+
+# Clear cached OIDC tokens for a specific garden cluster
+gardenctl logout --garden my-garden`,
+		RunE: base.WrapRunE(o, f),
+	}
+
+	o.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+// options is a struct to support the logout command.
+type options struct {
+	base.Options
+
+	// GardenName optionally restricts logout to a single garden.
+	GardenName string
+
+	// cfg is loaded during Complete.
+	cfg *config.Config
+
+	// entries holds the resolved (gardenName, cacheDir, issuerURL) per garden.
+	entries []cacheEntry
+}
+
+type cacheEntry struct {
+	gardenName string
+	cacheDir   string
+	issuerURL  string // empty when no OIDC exec plugin was found
+}
+
+// tokenCacheFile is the on-disk structure written by kubelogin.
+type tokenCacheFile struct {
+	IDToken string `json:"id_token"`
+}
+
+// jwtPayload holds only the claims we care about.
+type jwtPayload struct {
+	Iss string `json:"iss"`
+}
+
+func newOptions(ioStreams util.IOStreams) *options {
+	return &options{
+		Options: base.Options{
+			IOStreams: ioStreams,
+		},
+	}
+}
+
+// AddFlags binds command flags to the options struct.
+func (o *options) AddFlags(flags *pflag.FlagSet) {
+	flags.StringVar(&o.GardenName, "garden", o.GardenName, "Name of the garden cluster to log out of. Defaults to all configured gardens.")
+}
+
+// Complete resolves configuration and OIDC exec plugin settings for each garden.
+func (o *options) Complete(f util.Factory, _ *cobra.Command, _ []string) error {
+	manager, err := f.Manager()
+	if err != nil {
+		return fmt.Errorf("failed to create manager: %w", err)
+	}
+
+	cfg := manager.Configuration()
+	o.cfg = cfg
+
+	gardens := cfg.Gardens
+	if o.GardenName != "" {
+		g, err := cfg.Garden(o.GardenName)
+		if err != nil {
+			return err
+		}
+
+		gardens = []config.Garden{*g}
+	}
+
+	for _, g := range gardens {
+		entry := cacheEntry{gardenName: g.Name}
+
+		rawCfg, err := g.LoadRawConfig()
+		if err != nil {
+			fmt.Fprintf(o.IOStreams.ErrOut, "Warning: could not load kubeconfig for garden %q: %v\n", g.Name, err)
+			o.entries = append(o.entries, entry)
+
+			continue
+		}
+
+		// Search all authInfos for an OIDC exec plugin.
+		for _, authInfo := range rawCfg.AuthInfos {
+			if authInfo.Exec == nil {
+				continue
+			}
+
+			cmd := authInfo.Exec.Command
+			if !strings.Contains(cmd, "kubelogin") && !strings.Contains(cmd, "oidc-login") {
+				continue
+			}
+
+			entry.cacheDir, entry.issuerURL = parseExecArgs(authInfo.Exec.Args)
+
+			break
+		}
+
+		o.entries = append(o.entries, entry)
+	}
+
+	return nil
+}
+
+// parseExecArgs extracts --token-cache-dir and --oidc-issuer-url from exec plugin args.
+// Returns the resolved cache directory and issuer URL.
+func parseExecArgs(args []string) (cacheDir, issuerURL string) {
+	for i, arg := range args {
+		switch {
+		case strings.HasPrefix(arg, "--token-cache-dir="):
+			cacheDir = strings.TrimPrefix(arg, "--token-cache-dir=")
+		case arg == "--token-cache-dir" && i+1 < len(args):
+			cacheDir = args[i+1]
+		case strings.HasPrefix(arg, "--oidc-issuer-url="):
+			issuerURL = strings.TrimPrefix(arg, "--oidc-issuer-url=")
+		case arg == "--oidc-issuer-url" && i+1 < len(args):
+			issuerURL = args[i+1]
+		}
+	}
+
+	if cacheDir == "" {
+		cacheDir = defaultOIDCCacheDir
+	}
+
+	expanded, err := homedir.Expand(cacheDir)
+	if err == nil {
+		cacheDir = expanded
+	}
+
+	return cacheDir, issuerURL
+}
+
+// Validate checks that options are consistent.
+func (o *options) Validate() error {
+	return nil
+}
+
+// Run deletes cached OIDC token files matching each garden's issuer URL.
+func (o *options) Run(_ util.Factory) error {
+	for _, entry := range o.entries {
+		if entry.issuerURL == "" {
+			fmt.Fprintf(o.IOStreams.ErrOut, "Warning: no OIDC exec plugin found in kubeconfig for garden %q, skipping\n", entry.gardenName)
+
+			continue
+		}
+
+		removed, err := removeCachedTokens(entry.cacheDir, entry.issuerURL)
+		if err != nil {
+			fmt.Fprintf(o.IOStreams.ErrOut, "Warning: error clearing tokens for garden %q: %v\n", entry.gardenName, err)
+
+			continue
+		}
+
+		if removed == 0 {
+			fmt.Fprintf(o.IOStreams.Out, "No cached tokens found for garden %q (issuer: %s)\n", entry.gardenName, entry.issuerURL)
+		} else {
+			fmt.Fprintf(o.IOStreams.Out, "Removed %d cached token file(s) for garden %q (issuer: %s)\n", removed, entry.gardenName, entry.issuerURL)
+		}
+	}
+
+	return nil
+}
+
+// removeCachedTokens deletes token cache files in dir whose id_token issuer matches issuerURL.
+// Returns the number of files removed.
+func removeCachedTokens(dir, issuerURL string) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+
+		return 0, fmt.Errorf("failed to read cache directory %q: %w", dir, err)
+	}
+
+	removed := 0
+
+	for _, e := range entries {
+		if e.IsDir() || strings.HasSuffix(e.Name(), ".lock") {
+			continue
+		}
+
+		path := filepath.Join(dir, e.Name())
+
+		iss, err := readIssuerFromCacheFile(path)
+		if err != nil {
+			// Not a token cache file we understand; skip silently.
+			continue
+		}
+
+		if iss != issuerURL {
+			continue
+		}
+
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return removed, fmt.Errorf("failed to remove %q: %w", path, err)
+		}
+
+		removed++
+	}
+
+	return removed, nil
+}
+
+// readIssuerFromCacheFile reads a kubelogin token cache file and returns the OIDC issuer URL.
+// The file contains {"id_token": "<jwt>", ...}; the issuer is in the JWT payload's "iss" claim.
+func readIssuerFromCacheFile(path string) (string, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- path is constructed from os.ReadDir output
+	if err != nil {
+		return "", err
+	}
+
+	var f tokenCacheFile
+	if err := json.Unmarshal(data, &f); err != nil || f.IDToken == "" {
+		return "", fmt.Errorf("not a token cache file")
+	}
+
+	return issuerFromJWT(f.IDToken)
+}
+
+// issuerFromJWT extracts the "iss" claim from a JWT's payload segment.
+func issuerFromJWT(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("invalid JWT format")
+	}
+
+	// JWT payload is base64url-encoded without padding.
+	payload := parts[1]
+	// Add padding if needed.
+	switch len(payload) % 4 {
+	case 2:
+		payload += "=="
+	case 3:
+		payload += "="
+	}
+
+	decoded, err := base64.URLEncoding.DecodeString(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode JWT payload: %w", err)
+	}
+
+	var claims jwtPayload
+	if err := json.Unmarshal(decoded, &claims); err != nil {
+		return "", fmt.Errorf("failed to unmarshal JWT payload: %w", err)
+	}
+
+	if claims.Iss == "" {
+		return "", fmt.Errorf("JWT payload has no iss claim")
+	}
+
+	return claims.Iss, nil
+}

--- a/pkg/cmd/logout/logout_suite_test.go
+++ b/pkg/cmd/logout/logout_suite_test.go
@@ -1,0 +1,19 @@
+/*
+SPDX-FileCopyrightText: Contributors to the Gardener project
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logout_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLogoutCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logout Command Test Suite")
+}

--- a/pkg/cmd/logout/logout_test.go
+++ b/pkg/cmd/logout/logout_test.go
@@ -27,10 +27,10 @@ import (
 )
 
 const (
-	testIssuer    = "https://oidc.example.com"
-	otherIssuer   = "https://other.example.com"
-	testGarden    = "my-garden"
-	testClientID  = "my-client"
+	testIssuer   = "https://oidc.example.com"
+	otherIssuer  = "https://other.example.com"
+	testGarden   = "my-garden"
+	testClientID = "my-client"
 )
 
 // makeJWT builds a minimal JWT whose payload contains the given iss claim.
@@ -38,6 +38,7 @@ func makeJWT(iss string) string {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
 	payload, _ := json.Marshal(map[string]string{"iss": iss, "sub": "user"})
 	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
+
 	return header + "." + encodedPayload + ".fakesig"
 }
 
@@ -49,6 +50,7 @@ func writeCacheFile(dir, name, iss string) string {
 	})
 	path := filepath.Join(dir, name)
 	Expect(os.WriteFile(path, data, 0o600)).To(Succeed())
+
 	return path
 }
 
@@ -64,6 +66,7 @@ func writeGardenKubeconfig(dir, issuerURL, cacheDir string) string {
 	cfg.Clusters["ctx"] = cluster
 
 	authInfo := clientcmdapi.NewAuthInfo()
+
 	args := []string{
 		"oidc-login",
 		"get-token",
@@ -73,6 +76,7 @@ func writeGardenKubeconfig(dir, issuerURL, cacheDir string) string {
 	if cacheDir != "" {
 		args = append(args, fmt.Sprintf("--token-cache-dir=%s", cacheDir))
 	}
+
 	authInfo.Exec = &clientcmdapi.ExecConfig{
 		Command:    "kubectl-oidc-login",
 		Args:       args,
@@ -87,6 +91,7 @@ func writeGardenKubeconfig(dir, issuerURL, cacheDir string) string {
 
 	path := filepath.Join(dir, "kubeconfig.yaml")
 	Expect(clientcmd.WriteToFile(*cfg, path)).To(Succeed())
+
 	return path
 }
 
@@ -154,6 +159,7 @@ var _ = Describe("RemoveCachedTokens", func() {
 
 	BeforeEach(func() {
 		var err error
+
 		cacheDir, err = os.MkdirTemp("", "oidc-cache-*")
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -191,6 +197,7 @@ var _ = Describe("RemoveCachedTokens", func() {
 
 	It("skips .lock files", func() {
 		writeCacheFile(cacheDir, "token-matching", testIssuer)
+
 		// write a matching .lock file — should not be removed
 		lockData, _ := json.Marshal(map[string]string{"id_token": makeJWT(testIssuer)})
 		Expect(os.WriteFile(filepath.Join(cacheDir, "token-matching.lock"), lockData, 0o600)).To(Succeed())
@@ -216,6 +223,7 @@ var _ = Describe("RemoveCachedTokens", func() {
 		for i := range 3 {
 			writeCacheFile(cacheDir, fmt.Sprintf("token-%d", i), testIssuer)
 		}
+
 		writeCacheFile(cacheDir, "token-other", otherIssuer)
 
 		removed, err := cmdlogout.RemoveCachedTokens(cacheDir, testIssuer)
@@ -247,6 +255,7 @@ var _ = Describe("Logout Command", func() {
 		streams, _, out, errOut = util.NewTestIOStreams()
 
 		var err error
+
 		tmpDir, err = os.MkdirTemp("", "gardenctl-logout-*")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -269,6 +278,7 @@ var _ = Describe("Logout Command", func() {
 				{Name: testGarden, Kubeconfig: kubeconfigPath},
 			},
 		}
+
 		factory.EXPECT().Manager().Return(manager, nil)
 		manager.EXPECT().Configuration().Return(cfg)
 
@@ -292,6 +302,7 @@ var _ = Describe("Logout Command", func() {
 				{Name: testGarden, Kubeconfig: kubeconfigPath},
 			},
 		}
+
 		factory.EXPECT().Manager().Return(manager, nil)
 		manager.EXPECT().Configuration().Return(cfg)
 
@@ -323,6 +334,7 @@ var _ = Describe("Logout Command", func() {
 				{Name: testGarden, Kubeconfig: kubeconfigPath},
 			},
 		}
+
 		factory.EXPECT().Manager().Return(manager, nil)
 		manager.EXPECT().Configuration().Return(cfg)
 
@@ -339,6 +351,7 @@ var _ = Describe("Logout Command", func() {
 				{Name: testGarden, Kubeconfig: filepath.Join(tmpDir, "kc.yaml")},
 			},
 		}
+
 		factory.EXPECT().Manager().Return(manager, nil)
 		manager.EXPECT().Configuration().Return(cfg)
 
@@ -357,6 +370,7 @@ var _ = Describe("Logout Command", func() {
 				{Name: "other-garden", Kubeconfig: kubeconfigPath},
 			},
 		}
+
 		factory.EXPECT().Manager().Return(manager, nil)
 		manager.EXPECT().Configuration().Return(cfg)
 

--- a/pkg/cmd/logout/logout_test.go
+++ b/pkg/cmd/logout/logout_test.go
@@ -1,0 +1,370 @@
+/*
+SPDX-FileCopyrightText: Contributors to the Gardener project
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package logout_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/gardener/gardenctl-v2/internal/util"
+	utilmocks "github.com/gardener/gardenctl-v2/internal/util/mocks"
+	cmdlogout "github.com/gardener/gardenctl-v2/pkg/cmd/logout"
+	"github.com/gardener/gardenctl-v2/pkg/config"
+	targetmocks "github.com/gardener/gardenctl-v2/pkg/target/mocks"
+)
+
+const (
+	testIssuer    = "https://oidc.example.com"
+	otherIssuer   = "https://other.example.com"
+	testGarden    = "my-garden"
+	testClientID  = "my-client"
+)
+
+// makeJWT builds a minimal JWT whose payload contains the given iss claim.
+func makeJWT(iss string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload, _ := json.Marshal(map[string]string{"iss": iss, "sub": "user"})
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
+	return header + "." + encodedPayload + ".fakesig"
+}
+
+// writeCacheFile writes a kubelogin-format token cache file to dir and returns the path.
+func writeCacheFile(dir, name, iss string) string {
+	data, _ := json.Marshal(map[string]string{
+		"id_token":      makeJWT(iss),
+		"refresh_token": "sometoken",
+	})
+	path := filepath.Join(dir, name)
+	Expect(os.WriteFile(path, data, 0o600)).To(Succeed())
+	return path
+}
+
+// writeGardenKubeconfig writes a minimal kubeconfig with an OIDC exec plugin to dir
+// and returns the path. The exec plugin includes --oidc-issuer-url and optionally
+// --token-cache-dir when cacheDir is non-empty.
+func writeGardenKubeconfig(dir, issuerURL, cacheDir string) string {
+	cfg := clientcmdapi.NewConfig()
+	cfg.CurrentContext = "ctx"
+
+	cluster := clientcmdapi.NewCluster()
+	cluster.Server = "https://api.example.com"
+	cfg.Clusters["ctx"] = cluster
+
+	authInfo := clientcmdapi.NewAuthInfo()
+	args := []string{
+		"oidc-login",
+		"get-token",
+		fmt.Sprintf("--oidc-issuer-url=%s", issuerURL),
+		fmt.Sprintf("--oidc-client-id=%s", testClientID),
+	}
+	if cacheDir != "" {
+		args = append(args, fmt.Sprintf("--token-cache-dir=%s", cacheDir))
+	}
+	authInfo.Exec = &clientcmdapi.ExecConfig{
+		Command:    "kubectl-oidc-login",
+		Args:       args,
+		APIVersion: "client.authentication.k8s.io/v1beta1",
+	}
+	cfg.AuthInfos["user"] = authInfo
+
+	ctx := clientcmdapi.NewContext()
+	ctx.Cluster = "ctx"
+	ctx.AuthInfo = "user"
+	cfg.Contexts["ctx"] = ctx
+
+	path := filepath.Join(dir, "kubeconfig.yaml")
+	Expect(clientcmd.WriteToFile(*cfg, path)).To(Succeed())
+	return path
+}
+
+var _ = Describe("ParseExecArgs", func() {
+	It("extracts --oidc-issuer-url and uses default cache dir when --token-cache-dir is absent", func() {
+		cacheDir, issuerURL := cmdlogout.ParseExecArgs([]string{
+			"oidc-login",
+			"get-token",
+			"--oidc-issuer-url=https://issuer.example.com",
+			"--oidc-client-id=my-client",
+		})
+		Expect(issuerURL).To(Equal("https://issuer.example.com"))
+		// default expands to ~/.kube/cache/oidc-login
+		Expect(cacheDir).To(HaveSuffix(filepath.Join(".kube", "cache", "oidc-login")))
+	})
+
+	It("extracts --token-cache-dir when present as =value", func() {
+		cacheDir, _ := cmdlogout.ParseExecArgs([]string{
+			"--token-cache-dir=/custom/cache",
+			"--oidc-issuer-url=https://issuer.example.com",
+		})
+		Expect(cacheDir).To(Equal("/custom/cache"))
+	})
+
+	It("extracts --token-cache-dir when present as separate value", func() {
+		cacheDir, _ := cmdlogout.ParseExecArgs([]string{
+			"--token-cache-dir", "/custom/cache2",
+			"--oidc-issuer-url=https://issuer.example.com",
+		})
+		Expect(cacheDir).To(Equal("/custom/cache2"))
+	})
+
+	It("extracts --oidc-issuer-url when present as separate value", func() {
+		_, issuerURL := cmdlogout.ParseExecArgs([]string{
+			"--oidc-issuer-url", "https://separate.example.com",
+		})
+		Expect(issuerURL).To(Equal("https://separate.example.com"))
+	})
+})
+
+var _ = Describe("IssuerFromJWT", func() {
+	It("extracts the iss claim from a valid JWT", func() {
+		jwt := makeJWT(testIssuer)
+		iss, err := cmdlogout.IssuerFromJWT(jwt)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(iss).To(Equal(testIssuer))
+	})
+
+	It("returns an error for an invalid JWT", func() {
+		_, err := cmdlogout.IssuerFromJWT("notajwt")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns an error for a JWT with no iss claim", func() {
+		header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256"}`))
+		payload := base64.RawURLEncoding.EncodeToString([]byte(`{"sub":"user"}`))
+		jwt := header + "." + payload + ".sig"
+		_, err := cmdlogout.IssuerFromJWT(jwt)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("RemoveCachedTokens", func() {
+	var cacheDir string
+
+	BeforeEach(func() {
+		var err error
+		cacheDir, err = os.MkdirTemp("", "oidc-cache-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(cacheDir)).To(Succeed())
+	})
+
+	It("removes only files matching the issuer URL", func() {
+		writeCacheFile(cacheDir, "token-matching", testIssuer)
+		writeCacheFile(cacheDir, "token-other", otherIssuer)
+
+		removed, err := cmdlogout.RemoveCachedTokens(cacheDir, testIssuer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(removed).To(Equal(1))
+
+		entries, _ := os.ReadDir(cacheDir)
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0].Name()).To(Equal("token-other"))
+	})
+
+	It("returns 0 when no files match", func() {
+		writeCacheFile(cacheDir, "token-other", otherIssuer)
+
+		removed, err := cmdlogout.RemoveCachedTokens(cacheDir, testIssuer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(removed).To(Equal(0))
+	})
+
+	It("returns 0 when the cache directory does not exist", func() {
+		removed, err := cmdlogout.RemoveCachedTokens("/nonexistent/path", testIssuer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(removed).To(Equal(0))
+	})
+
+	It("skips .lock files", func() {
+		writeCacheFile(cacheDir, "token-matching", testIssuer)
+		// write a matching .lock file — should not be removed
+		lockData, _ := json.Marshal(map[string]string{"id_token": makeJWT(testIssuer)})
+		Expect(os.WriteFile(filepath.Join(cacheDir, "token-matching.lock"), lockData, 0o600)).To(Succeed())
+
+		removed, err := cmdlogout.RemoveCachedTokens(cacheDir, testIssuer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(removed).To(Equal(1))
+
+		entries, _ := os.ReadDir(cacheDir)
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0].Name()).To(Equal("token-matching.lock"))
+	})
+
+	It("skips files that are not token cache files", func() {
+		Expect(os.WriteFile(filepath.Join(cacheDir, "not-a-token"), []byte("garbage"), 0o600)).To(Succeed())
+
+		removed, err := cmdlogout.RemoveCachedTokens(cacheDir, testIssuer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(removed).To(Equal(0))
+	})
+
+	It("removes multiple matching files", func() {
+		for i := range 3 {
+			writeCacheFile(cacheDir, fmt.Sprintf("token-%d", i), testIssuer)
+		}
+		writeCacheFile(cacheDir, "token-other", otherIssuer)
+
+		removed, err := cmdlogout.RemoveCachedTokens(cacheDir, testIssuer)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(removed).To(Equal(3))
+
+		entries, _ := os.ReadDir(cacheDir)
+		Expect(entries).To(HaveLen(1))
+	})
+})
+
+var _ = Describe("Logout Command", func() {
+	var (
+		ctrl     *gomock.Controller
+		factory  *utilmocks.MockFactory
+		manager  *targetmocks.MockManager
+		streams  util.IOStreams
+		out      *util.SafeBytesBuffer
+		errOut   *util.SafeBytesBuffer
+		tmpDir   string
+		cacheDir string
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		factory = utilmocks.NewMockFactory(ctrl)
+		manager = targetmocks.NewMockManager(ctrl)
+
+		streams, _, out, errOut = util.NewTestIOStreams()
+
+		var err error
+		tmpDir, err = os.MkdirTemp("", "gardenctl-logout-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		cacheDir = filepath.Join(tmpDir, "oidc-cache")
+		Expect(os.MkdirAll(cacheDir, 0o700)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		ctrl.Finish()
+	})
+
+	It("removes cached tokens for a garden with OIDC exec plugin", func() {
+		kubeconfigPath := writeGardenKubeconfig(tmpDir, testIssuer, cacheDir)
+		writeCacheFile(cacheDir, "token-1", testIssuer)
+		writeCacheFile(cacheDir, "token-other", otherIssuer)
+
+		cfg := &config.Config{
+			Gardens: []config.Garden{
+				{Name: testGarden, Kubeconfig: kubeconfigPath},
+			},
+		}
+		factory.EXPECT().Manager().Return(manager, nil)
+		manager.EXPECT().Configuration().Return(cfg)
+
+		cmd := cmdlogout.NewCmdLogout(factory, streams)
+		Expect(cmd.Execute()).To(Succeed())
+
+		Expect(out.String()).To(ContainSubstring("Removed 1 cached token file(s) for garden %q", testGarden))
+		Expect(out.String()).To(ContainSubstring(testIssuer))
+
+		// token-other should still exist
+		entries, _ := os.ReadDir(cacheDir)
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0].Name()).To(Equal("token-other"))
+	})
+
+	It("reports no tokens found when cache is empty", func() {
+		kubeconfigPath := writeGardenKubeconfig(tmpDir, testIssuer, cacheDir)
+
+		cfg := &config.Config{
+			Gardens: []config.Garden{
+				{Name: testGarden, Kubeconfig: kubeconfigPath},
+			},
+		}
+		factory.EXPECT().Manager().Return(manager, nil)
+		manager.EXPECT().Configuration().Return(cfg)
+
+		cmd := cmdlogout.NewCmdLogout(factory, streams)
+		Expect(cmd.Execute()).To(Succeed())
+
+		Expect(out.String()).To(ContainSubstring("No cached tokens found for garden %q", testGarden))
+	})
+
+	It("warns and skips a garden whose kubeconfig has no OIDC exec plugin", func() {
+		// Write a kubeconfig with no exec plugin.
+		kubeconfigPath := filepath.Join(tmpDir, "plain-kubeconfig.yaml")
+		plainCfg := clientcmdapi.NewConfig()
+		plainCfg.CurrentContext = "ctx"
+		cluster := clientcmdapi.NewCluster()
+		cluster.Server = "https://api.example.com"
+		plainCfg.Clusters["ctx"] = cluster
+		authInfo := clientcmdapi.NewAuthInfo()
+		authInfo.Token = "static-token"
+		plainCfg.AuthInfos["user"] = authInfo
+		ctx := clientcmdapi.NewContext()
+		ctx.Cluster = "ctx"
+		ctx.AuthInfo = "user"
+		plainCfg.Contexts["ctx"] = ctx
+		Expect(clientcmd.WriteToFile(*plainCfg, kubeconfigPath)).To(Succeed())
+
+		cfg := &config.Config{
+			Gardens: []config.Garden{
+				{Name: testGarden, Kubeconfig: kubeconfigPath},
+			},
+		}
+		factory.EXPECT().Manager().Return(manager, nil)
+		manager.EXPECT().Configuration().Return(cfg)
+
+		cmd := cmdlogout.NewCmdLogout(factory, streams)
+		Expect(cmd.Execute()).To(Succeed())
+
+		Expect(errOut.String()).To(ContainSubstring("no OIDC exec plugin found"))
+		Expect(errOut.String()).To(ContainSubstring(testGarden))
+	})
+
+	It("returns an error when --garden names an unknown garden", func() {
+		cfg := &config.Config{
+			Gardens: []config.Garden{
+				{Name: testGarden, Kubeconfig: filepath.Join(tmpDir, "kc.yaml")},
+			},
+		}
+		factory.EXPECT().Manager().Return(manager, nil)
+		manager.EXPECT().Configuration().Return(cfg)
+
+		cmd := cmdlogout.NewCmdLogout(factory, streams)
+		cmd.SetArgs([]string{"--garden", "nonexistent"})
+		Expect(cmd.Execute()).To(HaveOccurred())
+	})
+
+	It("restricts to the specified --garden only", func() {
+		kubeconfigPath := writeGardenKubeconfig(tmpDir, testIssuer, cacheDir)
+		writeCacheFile(cacheDir, "token-1", testIssuer)
+
+		cfg := &config.Config{
+			Gardens: []config.Garden{
+				{Name: testGarden, Kubeconfig: kubeconfigPath},
+				{Name: "other-garden", Kubeconfig: kubeconfigPath},
+			},
+		}
+		factory.EXPECT().Manager().Return(manager, nil)
+		manager.EXPECT().Configuration().Return(cfg)
+
+		cmd := cmdlogout.NewCmdLogout(factory, streams)
+		cmd.SetArgs([]string{"--garden", testGarden})
+		Expect(cmd.Execute()).To(Succeed())
+
+		Expect(out.String()).To(ContainSubstring(testGarden))
+		Expect(out.String()).NotTo(ContainSubstring("other-garden"))
+	})
+})


### PR DESCRIPTION
disclaimer: i don't have strong opinion on this feature, just encounter this problem (unable logout gardenctl after oidc permission changed) so with help from claude i proposed this PR, feel free ignore / close if maintainer consider it's not worth adding, thanks!

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

this PR add a `gardenctl logout` command which clears current oidc login info, also it allows clear specific target e.g. `gardenctl logout --garden my-garden`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

gardenctl logout 

New files:
- pkg/cmd/logout/logout.go — the command implementation
- pkg/cmd/logout/export_test.go — exports internal functions for testing
- pkg/cmd/logout/logout_suite_test.go — Ginkgo suite bootstrap
- pkg/cmd/logout/logout_test.go — 12 unit tests covering all core behaviors

Modified: pkg/cmd/cmd.go — registers the new command

How it works:
1. Loads each configured garden's kubeconfig and walks the authInfos looking for an exec plugin whose command contains kubelogin or oidc-login
2. Parses the exec args for --token-cache-dir (falls back to ~/.kube/cache/oidc-login/) and --oidc-issuer-url
3. Reads each file in the cache dir, decodes the JWT id_token payload, and deletes files whose iss claim matches the garden's issuer URL
4. Skips .lock files and non-token-cache files silently

Usage:
Clear cached OIDC tokens for all configured garden clusters
gardenctl logout

Clear cached OIDC tokens for a specific garden
gardenctl logout --garden my-garden

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
add a `gardenctl logout` command
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `logout` command to clear cached OIDC login tokens.
  - Supports logging out from all configured gardens or a specified garden.
  - Reports skipped gardens, errors, and cases where no cached tokens are found.
- **Tests**
  - Added coverage for argument parsing, token identification and removal, invalid configurations, and garden-specific logout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->